### PR TITLE
ADDON-29634 : Added support for Addon without inputs

### DIFF
--- a/splunk_add_on_ucc_framework/__init__.py
+++ b/splunk_add_on_ucc_framework/__init__.py
@@ -447,14 +447,18 @@ def handle_no_inputs(ta_name):
     # Remove "inputs" view from default.xml
     _removeinput(default_xml_file)
 
-    inputs_xml_file = os.path.join(
+    file_remove_list = []
+    file_remove_list.append(os.path.join(
         outputdir, ta_name, "default", "data", "ui", "views","inputs.xml"
-    )
+    ))
+    file_remove_list.append(os.path.join(outputdir,ta_name,"appserver","static","css","inputs.css"))
+    file_remove_list.append(os.path.join(outputdir,ta_name,"appserver","static","css","createInput.css"))
     # Remove unnecessary files
-    try:
-        os.remove(inputs_xml_file)
-    except OSError:
-        pass
+    for fl in file_remove_list:
+        try:
+            os.remove(fl)
+        except OSError:
+            pass
 
 def main():
     parser = argparse.ArgumentParser(description="Build the add-on")


### PR DESCRIPTION
Added Support for Add-ons without inputs.

- "inputs" view would be removed from `default.xml`.

- `inputs.xml` , `inputs.css` and `createInput.css` files would be removed.

- inputs related python files would not be added.

[jira link](https://jira.splunk.com/browse/ADDON-29634)