### PR TITLE
SPL-196891: Updated regex for error message parsing

### DIFF
--- a/splunk_add_on_ucc_framework/UCC-UI-lib/package/appserver/static/js/util/promptMsgController.js
+++ b/splunk_add_on_ucc_framework/UCC-UI-lib/package/appserver/static/js/util/promptMsgController.js
@@ -67,7 +67,7 @@ export function parseErrorMsg(data) {
     var error_msg = '', rsp, regex, msg, matches;
     try {
         rsp = JSON.parse(data.responseText);
-        regex = /.+"REST Error \[[\d]+\]:\s+.+\s+--\s+([\s\S]*)"\.\s*See splunkd\.log for more details\./;
+        regex = /.+"REST Error \[[\d]+\]:\s+.+\s+--\s+([\s\S]*)"\.\s*See splunkd\.log(\/python.log)? for more details\./;
         msg = String(rsp.messages[0].text);
         matches = regex.exec(msg);
         if (matches && matches[1]) {


### PR DESCRIPTION
Jira Link:  https://jira.splunk.com/browse/SPL-196891   

- Updated regex for error message parsing to display proper message on UI.

There is an additional message format supported in Splunk version 8.1.2011 onwards:

`Unexpected error "<class 'splunktaucclib.rest_handler.error.RestError'>" from python handler: "REST Error [400]: Bad Request -- Account authentication failed. Please check your credentials and try again". See splunkd.log/python.log for more details.`

