### PR TITLE
Adding legacy resolver param for pip

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ jobs:
       - run:
           name: Install Tools
           command: |
-            pip install /tmp/workspace/dist/*
+            pip install /tmp/workspace/dist/* --use-deprecated=legacy-resolver
   publish:
     docker:
       - image: circleci/python:3.7-node

--- a/splunk_add_on_ucc_framework/__init__.py
+++ b/splunk_add_on_ucc_framework/__init__.py
@@ -232,7 +232,7 @@ def install_libs(path, ucc_lib_target):
             install_cmd = (
                 installer +" -m pip install -r \""
                 + requirements
-                + "\" --no-compile --prefer-binary --ignore-installed --target \""
+                + "\" --no-compile --prefer-binary --ignore-installed --use-deprecated=legacy-resolver --target \""
                 + ucc_target
                 + "\""
             )

--- a/splunk_add_on_ucc_framework/__init__.py
+++ b/splunk_add_on_ucc_framework/__init__.py
@@ -236,6 +236,7 @@ def install_libs(path, ucc_lib_target):
                 + ucc_target
                 + "\""
             )
+            os.system(installer +" -m pip install pip --upgrade")
             os.system(install_cmd)
             remove_files(ucc_target)
     logging.info(f"  Checking for requirements in {path}")


### PR DESCRIPTION
- In the latest pip version the build was not generated for MSCS due to `ERROR: ResolutionImpossible:` for some modules s therefore adding legacy resolver param in the installation command.