### PR TITLE
test: fix the issue with semgrep-agent

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,6 +71,7 @@ jobs:
     docker:
       - image: returntocorp/semgrep-agent:v1
         user: root
+    resource_class: large
     steps:
       - checkout
       - run:
@@ -79,7 +80,7 @@ jobs:
             pip3 install --upgrade semgrep
       - run:
           name: "Semgrep Scan"
-          no_output_timeout: 1h
+          no_output_timeout: 2h
           command: |
             export SEMGREP_REPO_NAME=splunk/${CIRCLE_PROJECT_REPONAME}
             python -m semgrep_agent --publish-deployment ${SEMGREP_DEPLOYMENT_ID} --publish-token ${SEMGREP_PUBLISH_TOKEN}

--- a/.semgrepignore
+++ b/.semgrepignore
@@ -28,4 +28,3 @@ tests/
 .reuse/
 .vscode/
 .idea/
-js/


### PR DESCRIPTION
* The issue with the semgrep agent is fixed by upgrading the resource class to large.
* For Semgrep scanning, have raised an issue at https://github.com/returntocorp/semgrep/issues/2784.

* Removed the `js` folder from the [.semgrepignore](https://github.com/splunk/addonfactory-ucc-generator/blob/main/.semgrepignore) file as the issue is covered in this PR