### PR TITLE
feat(Append TA directory to os.path): Append TA directory name to os.path rather than namespace

### DIFF
--- a/splunk_add_on_ucc_framework/uccrestbuilder/global_config.py
+++ b/splunk_add_on_ucc_framework/uccrestbuilder/global_config.py
@@ -377,7 +377,7 @@ sys.path = new_paths
             self.builder.output.bin,
             self.import_declare_py_name() + ".py",
         )
-        content = self._import_declare_content.format(ta_name=self.schema.namespace,)
+        content = self._import_declare_content.format(ta_name=self.schema.product,)
         with open(import_declare_file, "w") as f:
             f.write(content)
 


### PR DESCRIPTION
Updated global_config.py to append TA's directory (schema.product) rather than schema.namespace to os.path.  This will support cases where the directory name (schema.product) is different than the schema.namespace.  This is only used in the generation of import_declare_test.py.