### PR TITLE
test: add CI support for unit tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,6 +25,7 @@ jobs:
           command: |
             source $HOME/.poetry/env
             poetry install
+            poetry run pytest
             poetry run poetry-dynamic-versioning
             poetry build
       - save_cache:


### PR DESCRIPTION
Supports unit testing in CI.

For now, one line local run of unit tests is not supported as it requires Splunk UCC UI to be downloaded.

You can run unit tests using CircleCI local executor, more details here: https://circleci.com/docs/2.0/local-cli/
