### PR TITLE
chore: delete unused file

### DIFF
--- a/splunk_add_on_ucc_framework/templates/README.md
+++ b/splunk_add_on_ucc_framework/templates/README.md
@@ -1,0 +1,3 @@
+# input_with_helper.template
+
+`input_with_helper.template` is used by AOB generated add-ons.


### PR DESCRIPTION
If you run `grep -rn 'input_with_helper' .` - it returns nothing.