### PR TITLE
chore: remove Python 2 related code

### DIFF
--- a/splunk_add_on_ucc_framework/alert_utils/alert_utils_common/logger.py
+++ b/splunk_add_on_ucc_framework/alert_utils/alert_utils_common/logger.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import absolute_import
+
 import solnlib.log as log
 from . import builder_constant
 import logging

--- a/splunk_add_on_ucc_framework/alert_utils/alert_utils_common/metric_collector/metric_util.py
+++ b/splunk_add_on_ucc_framework/alert_utils/alert_utils_common/metric_collector/metric_util.py
@@ -2,12 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import absolute_import
+
 # encoding = utf-8
 
-from past.builtins import basestring
+from past.builtins import str
 from builtins import str
-from six import string_types as basestring
+from six import string_types as str
 import functools
 
 from . import monitor
@@ -63,7 +63,7 @@ def mask_credentials(data):
         for d in data:
             new_data.append(mask_credentials(d))
         return new_data
-    elif isinstance(data, (str, basestring)):
+    elif isinstance(data, str):
         d = data.lower()
         sensitive_word = False
         for w in CREDENTIAL_KEYS:

--- a/splunk_add_on_ucc_framework/alert_utils/alert_utils_common/metric_collector/monitor.py
+++ b/splunk_add_on_ucc_framework/alert_utils/alert_utils_common/metric_collector/monitor.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import absolute_import
+
 # encoding = utf-8
 from builtins import object
 from . import event_writer

--- a/splunk_add_on_ucc_framework/alert_utils/alert_utils_common/metric_collector/number_metric_collector.py
+++ b/splunk_add_on_ucc_framework/alert_utils/alert_utils_common/metric_collector/number_metric_collector.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import absolute_import
+
 from future import standard_library
 standard_library.install_aliases()
 from builtins import object

--- a/splunk_add_on_ucc_framework/modular_alert_builder/build_core/__init__.py
+++ b/splunk_add_on_ucc_framework/modular_alert_builder/build_core/__init__.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import absolute_import
+
 import re
 import shutil
 import os

--- a/splunk_add_on_ucc_framework/modular_alert_builder/build_core/alert_actions_base.py
+++ b/splunk_add_on_ucc_framework/modular_alert_builder/build_core/alert_actions_base.py
@@ -2,8 +2,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import print_function
-from __future__ import absolute_import
+
+
 from builtins import str
 import csv
 import gzip

--- a/splunk_add_on_ucc_framework/modular_alert_builder/build_core/alert_actions_conf_gen.py
+++ b/splunk_add_on_ucc_framework/modular_alert_builder/build_core/alert_actions_conf_gen.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import absolute_import
+
 from builtins import object
 from os import path as op
 import os
@@ -112,7 +112,7 @@ class AlertActionsConfGeneration(AlertActionsConfBase):
         try:
             final_string = template.render(mod_alerts=alert_obj)
         except:
-            print (exceptions.html_error_template().render())
+            print(exceptions.html_error_template().render())
             raise
         text = linesep.join([s.strip() for s in final_string.splitlines()])
         write_file(self._alert_conf_name,

--- a/splunk_add_on_ucc_framework/modular_alert_builder/build_core/alert_actions_helper.py
+++ b/splunk_add_on_ucc_framework/modular_alert_builder/build_core/alert_actions_helper.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import absolute_import
+
 import sys
 import os.path as op
 from os import rename, remove, makedirs

--- a/splunk_add_on_ucc_framework/modular_alert_builder/build_core/alert_actions_html_gen.py
+++ b/splunk_add_on_ucc_framework/modular_alert_builder/build_core/alert_actions_html_gen.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import absolute_import
+
 from builtins import object
 from . import arf_consts as ac
 import os

--- a/splunk_add_on_ucc_framework/modular_alert_builder/build_core/alert_actions_merge.py
+++ b/splunk_add_on_ucc_framework/modular_alert_builder/build_core/alert_actions_merge.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import absolute_import
+
 import os
 import os.path as op
 from os.path import dirname as dn

--- a/splunk_add_on_ucc_framework/modular_alert_builder/build_core/alert_actions_py_gen.py
+++ b/splunk_add_on_ucc_framework/modular_alert_builder/build_core/alert_actions_py_gen.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import absolute_import
+
 from builtins import object
 from . import arf_consts as ac
 from os import path as op

--- a/splunk_add_on_ucc_framework/start_alert_build.py
+++ b/splunk_add_on_ucc_framework/start_alert_build.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import absolute_import
+
 from . import normalize
 import logging
 import os

--- a/splunk_add_on_ucc_framework/uccrestbuilder/__init__.py
+++ b/splunk_add_on_ucc_framework/uccrestbuilder/__init__.py
@@ -6,7 +6,7 @@
 REST Builder.
 """
 
-from __future__ import absolute_import
+
 
 import collections
 from splunktaucclib.rest_handler.schema import RestSchema

--- a/splunk_add_on_ucc_framework/uccrestbuilder/builder.py
+++ b/splunk_add_on_ucc_framework/uccrestbuilder/builder.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import absolute_import
+
 
 from builtins import object
 import os

--- a/splunk_add_on_ucc_framework/uccrestbuilder/endpoint/base.py
+++ b/splunk_add_on_ucc_framework/uccrestbuilder/endpoint/base.py
@@ -2,13 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import absolute_import
 
-from past.builtins import basestring
+
+from past.builtins import str
 from splunktaucclib.rest_handler.schema import RestSchema
 from io import StringIO
 from builtins import object
-from six import string_types as basestring
+from six import string_types as str
 import six
 from future import standard_library
 
@@ -148,7 +148,7 @@ def quote_string(value):
     :param value:
     :return:
     """
-    if isinstance(value, basestring):
+    if isinstance(value, str):
         return "'%s'" % value
     else:
         return value
@@ -160,7 +160,7 @@ def quote_regex(value):
     :param value:
     :return:
     """
-    if isinstance(value, basestring):
+    if isinstance(value, str):
         return '"""%s"""' % value
     else:
         return value

--- a/splunk_add_on_ucc_framework/uccrestbuilder/endpoint/datainput.py
+++ b/splunk_add_on_ucc_framework/uccrestbuilder/endpoint/datainput.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import absolute_import
+
 
 from .single_model import RestEndpointBuilder, RestEntityBuilder
 

--- a/splunk_add_on_ucc_framework/uccrestbuilder/endpoint/field.py
+++ b/splunk_add_on_ucc_framework/uccrestbuilder/endpoint/field.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import absolute_import
+
 
 from builtins import object
 from .base import quote_string, indent

--- a/splunk_add_on_ucc_framework/uccrestbuilder/endpoint/multiple_model.py
+++ b/splunk_add_on_ucc_framework/uccrestbuilder/endpoint/multiple_model.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import absolute_import
+
 
 from .base import indent
 from .single_model import RestEndpointBuilder, RestEntityBuilder

--- a/splunk_add_on_ucc_framework/uccrestbuilder/endpoint/oauth_model.py
+++ b/splunk_add_on_ucc_framework/uccrestbuilder/endpoint/oauth_model.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import absolute_import
+
 
 from .base import RestEndpointBuilder
 

--- a/splunk_add_on_ucc_framework/uccrestbuilder/endpoint/single_model.py
+++ b/splunk_add_on_ucc_framework/uccrestbuilder/endpoint/single_model.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import absolute_import
+
 
 from .base import RestEntityBuilder, RestEndpointBuilder
 

--- a/splunk_add_on_ucc_framework/uccrestbuilder/global_config.py
+++ b/splunk_add_on_ucc_framework/uccrestbuilder/global_config.py
@@ -6,7 +6,7 @@
 Global config schema.
 """
 
-from __future__ import absolute_import
+
 
 from builtins import map
 from builtins import object

--- a/splunk_add_on_ucc_framework/uccrestbuilder/rest_conf.py
+++ b/splunk_add_on_ucc_framework/uccrestbuilder/rest_conf.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import absolute_import
+
 
 
 from builtins import object


### PR DESCRIPTION
This PR was mainly generated by 2to3 tool.

One manual change in splunk_add_on_ucc_framework/modular_alert_builder/build_core/alert_actions_conf_gen.py to remove duplicate brackets.