### PR TITLE
fix: quick fix for ta-version argument

### DIFF
--- a/splunk_add_on_ucc_framework/__init__.py
+++ b/splunk_add_on_ucc_framework/__init__.py
@@ -689,6 +689,7 @@ def main():
         ta_version = version_splunk
     else:
         ta_version = args.ta_version.strip()
+        version_str = ta_version
 
     if not os.path.exists(args.source):
         raise NotADirectoryError("{} not Found.".format(os.path.abspath(args.source)))


### PR DESCRIPTION
Checked locally, works fine with and without `ta-version`.
When specifying a `ta-version` argument, for example: `ucc-gen --ta-version=3.0.0`, it will create a `VERSION` file with the following content:
```
3.0.0
3.0.0
```