### PR TITLE
test: fix flaky unit tests

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -21,7 +21,7 @@ addopts = -v --tb=long
     --splunk-data-generator=tests/data
     --splunk-type=docker
     --sc4s-host=sc4s
-    -n 10
+    -n 1
     --keepalive
 filterwarnings =
     ignore::DeprecationWarning


### PR DESCRIPTION
`tests/data` tests are flaky due to `-n 10` in `pytest.ini`, they are trying to get contents from `globalConfig.json` which may be not in stable state.

Examples:

* https://github.com/splunk/addonfactory-ucc-generator/runs/2783628522
* https://github.com/splunk/addonfactory-ucc-generator/runs/2775867028