### PR TITLE
refactor: apply isort and delete unused imports after

### DIFF
--- a/splunk_add_on_ucc_framework/__init__.py
+++ b/splunk_add_on_ucc_framework/__init__.py
@@ -27,7 +27,6 @@ import shutil
 import stat
 import sys
 import time
-from os import system
 from pathlib import Path
 
 import jsonschema

--- a/splunk_add_on_ucc_framework/__init__.py
+++ b/splunk_add_on_ucc_framework/__init__.py
@@ -36,8 +36,10 @@ from jinja2 import Environment, FileSystemLoader
 
 from .start_alert_build import alert_build
 from .uccrestbuilder import build
-from .uccrestbuilder.global_config import (GlobalConfigBuilderSchema,
-                                           GlobalConfigPostProcessor)
+from .uccrestbuilder.global_config import (
+    GlobalConfigBuilderSchema,
+    GlobalConfigPostProcessor,
+)
 
 sourcedir = os.path.dirname(os.path.realpath(__file__))
 

--- a/splunk_add_on_ucc_framework/__init__.py
+++ b/splunk_add_on_ucc_framework/__init__.py
@@ -16,30 +16,29 @@
 
 __version__ = "5.0.0"
 
-import logging
-import os, time
-import re
-import glob
-from os import system
-import shutil
-import sys
 import argparse
+import configparser
+import glob
 import json
-from defusedxml import cElementTree as defused_et
-from pathlib import Path
+import logging
+import os
+import re
+import shutil
 import stat
-
-from .uccrestbuilder.global_config import (
-    GlobalConfigBuilderSchema,
-    GlobalConfigPostProcessor,
-)
-from .uccrestbuilder import build
-from .start_alert_build import alert_build
+import sys
+import time
+from os import system
+from pathlib import Path
 
 import jsonschema
+from defusedxml import cElementTree as defused_et
+from dunamai import Style, Version
 from jinja2 import Environment, FileSystemLoader
-from dunamai import Version, Style
-import configparser
+
+from .start_alert_build import alert_build
+from .uccrestbuilder import build
+from .uccrestbuilder.global_config import (GlobalConfigBuilderSchema,
+                                           GlobalConfigPostProcessor)
 
 sourcedir = os.path.dirname(os.path.realpath(__file__))
 

--- a/splunk_add_on_ucc_framework/alert_utils/alert_utils_common/conf_parser.py
+++ b/splunk_add_on_ucc_framework/alert_utils/alert_utils_common/conf_parser.py
@@ -26,9 +26,10 @@ please search: ######## tab_update ########
 """
 
 from future import standard_library
+
 standard_library.install_aliases()
-from builtins import str
 import configparser
+from builtins import str
 
 try:
     from collections import OrderedDict as _default_dict
@@ -46,7 +47,8 @@ class TABConfigParser(configparser.RawConfigParser):
         """
         Override the built-in _read() method to read comments
         """
-        from configparser import DEFAULTSECT, MissingSectionHeaderError, ParsingError
+        from configparser import (DEFAULTSECT, MissingSectionHeaderError,
+                                  ParsingError)
 
         cursect = None                        # None, or a dictionary
         optname = None

--- a/splunk_add_on_ucc_framework/alert_utils/alert_utils_common/conf_parser.py
+++ b/splunk_add_on_ucc_framework/alert_utils/alert_utils_common/conf_parser.py
@@ -47,8 +47,7 @@ class TABConfigParser(configparser.RawConfigParser):
         """
         Override the built-in _read() method to read comments
         """
-        from configparser import (DEFAULTSECT, MissingSectionHeaderError,
-                                  ParsingError)
+        from configparser import DEFAULTSECT, ParsingError
 
         cursect = None                        # None, or a dictionary
         optname = None

--- a/splunk_add_on_ucc_framework/alert_utils/alert_utils_common/logger.py
+++ b/splunk_add_on_ucc_framework/alert_utils/alert_utils_common/logger.py
@@ -15,13 +15,14 @@
 #
 
 
-import solnlib.log as log
-from . import builder_constant
+import copy
 import logging
 import threading
-import copy
 
+import solnlib.log as log
 from alert_utils.alert_utils_common.metric_collector import metric_util
+
+from . import builder_constant
 
 LOGS = {
     "validation": "ta_builder_validation",

--- a/splunk_add_on_ucc_framework/alert_utils/alert_utils_common/logger.py
+++ b/splunk_add_on_ucc_framework/alert_utils/alert_utils_common/logger.py
@@ -15,7 +15,6 @@
 #
 
 
-import copy
 import logging
 import threading
 

--- a/splunk_add_on_ucc_framework/alert_utils/alert_utils_common/metric_collector/event_writer.py
+++ b/splunk_add_on_ucc_framework/alert_utils/alert_utils_common/metric_collector/event_writer.py
@@ -16,12 +16,13 @@
 
 # encoding = utf-8
 
-from builtins import object
-import time
-import logging
 import json
+import logging
+import time
+from builtins import object
 
 from solnlib import log
+
 
 def message(app, current_time, event, tags):
     final_event = dict(event)

--- a/splunk_add_on_ucc_framework/alert_utils/alert_utils_common/metric_collector/memory_event_writer.py
+++ b/splunk_add_on_ucc_framework/alert_utils/alert_utils_common/metric_collector/memory_event_writer.py
@@ -15,9 +15,12 @@
 #
 
 from future import standard_library
+
 standard_library.install_aliases()
-from alert_utils.alert_utils_common.metric_collector.event_writer import *
 import queue
+
+from alert_utils.alert_utils_common.metric_collector.event_writer import *
+
 
 class MemoryEventWriter(MetricEventWriter):
     '''

--- a/splunk_add_on_ucc_framework/alert_utils/alert_utils_common/metric_collector/metric_aggregator.py
+++ b/splunk_add_on_ucc_framework/alert_utils/alert_utils_common/metric_collector/metric_aggregator.py
@@ -16,9 +16,8 @@
 
 # encode=utf-8
 
-from builtins import range
-from builtins import object
 import time
+from builtins import object, range
 
 
 class NumberMetricArregator(object):

--- a/splunk_add_on_ucc_framework/alert_utils/alert_utils_common/metric_collector/metric_aggregator.py
+++ b/splunk_add_on_ucc_framework/alert_utils/alert_utils_common/metric_collector/metric_aggregator.py
@@ -16,7 +16,6 @@
 
 # encode=utf-8
 
-import time
 from builtins import object, range
 
 

--- a/splunk_add_on_ucc_framework/alert_utils/alert_utils_common/metric_collector/metric_util.py
+++ b/splunk_add_on_ucc_framework/alert_utils/alert_utils_common/metric_collector/metric_util.py
@@ -17,13 +17,14 @@
 
 # encoding = utf-8
 
-from past.builtins import str
-from builtins import str
-from six import string_types as str
 import functools
+import time
+from builtins import str
+
+from past.builtins import str
+from six import string_types as str
 
 from . import monitor
-import time
 
 __all__ = ['initialize_metric_collector', 'function_run_time']
 

--- a/splunk_add_on_ucc_framework/alert_utils/alert_utils_common/metric_collector/monitor.py
+++ b/splunk_add_on_ucc_framework/alert_utils/alert_utils_common/metric_collector/monitor.py
@@ -15,18 +15,16 @@
 #
 
 
+import threading
 # encoding = utf-8
 from builtins import object
-from . import event_writer
-from . import memory_event_writer
+
+from future.utils import with_metaclass
+from solnlib import log, pattern
+
+from . import event_writer, memory_event_writer
 from .metric_exception import MetricException
 from .number_metric_collector import NumberMetricCollector
-
-from solnlib import pattern
-from solnlib import log
-
-import threading
-from future.utils import with_metaclass
 
 __all__ = ['Monitor']
 

--- a/splunk_add_on_ucc_framework/alert_utils/alert_utils_common/metric_collector/number_metric_collector.py
+++ b/splunk_add_on_ucc_framework/alert_utils/alert_utils_common/metric_collector/number_metric_collector.py
@@ -16,15 +16,17 @@
 
 
 from future import standard_library
+
 standard_library.install_aliases()
-from builtins import object
-import threading
 import queue
+import threading
 import time
+from builtins import object
 
 from solnlib import log
-from .metric_exception import MetricException
+
 from . import metric_aggregator
+from .metric_exception import MetricException
 
 __all__ = ['NumberMetricCollector']
 

--- a/splunk_add_on_ucc_framework/modular_alert_builder/build_core/__init__.py
+++ b/splunk_add_on_ucc_framework/modular_alert_builder/build_core/__init__.py
@@ -15,14 +15,14 @@
 #
 
 
+import os
 import re
 import shutil
-import os
+import traceback
+
 from .alert_actions_conf_gen import generate_alert_actions_conf
 from .alert_actions_html_gen import generate_alert_actions_html_files
 from .alert_actions_py_gen import generate_alert_actions_py_files
-import traceback
-
 
 cache_path = {}
 

--- a/splunk_add_on_ucc_framework/modular_alert_builder/build_core/__init__.py
+++ b/splunk_add_on_ucc_framework/modular_alert_builder/build_core/__init__.py
@@ -18,7 +18,6 @@
 import os
 import re
 import shutil
-import traceback
 
 from .alert_actions_conf_gen import generate_alert_actions_conf
 from .alert_actions_html_gen import generate_alert_actions_html_files

--- a/splunk_add_on_ucc_framework/modular_alert_builder/build_core/alert_actions_base.py
+++ b/splunk_add_on_ucc_framework/modular_alert_builder/build_core/alert_actions_base.py
@@ -16,10 +16,10 @@
 
 
 
-from builtins import str
 import csv
 import gzip
 import sys
+from builtins import str
 
 try:
     from splunk.clilib.bundle_paths import make_splunkhome_path
@@ -27,8 +27,9 @@ except ImportError:
     from splunk.appserver.mrsparkle.lib.util import make_splunkhome_path
 sys.path.append(make_splunkhome_path(["etc", "apps", "Splunk_SA_CIM", "lib"]))
 
-from .cim_actions import ModularAction
 from solnlib.log import Logs
+
+from .cim_actions import ModularAction
 
 
 class ModularAlertBase(ModularAction):

--- a/splunk_add_on_ucc_framework/modular_alert_builder/build_core/alert_actions_conf_gen.py
+++ b/splunk_add_on_ucc_framework/modular_alert_builder/build_core/alert_actions_conf_gen.py
@@ -20,7 +20,6 @@ from builtins import object
 from json import loads as jloads
 from os import linesep
 from os import path as op
-from shutil import copy
 
 from mako import exceptions
 from mako.template import Template

--- a/splunk_add_on_ucc_framework/modular_alert_builder/build_core/alert_actions_conf_gen.py
+++ b/splunk_add_on_ucc_framework/modular_alert_builder/build_core/alert_actions_conf_gen.py
@@ -15,20 +15,22 @@
 #
 
 
-from builtins import object
-from os import path as op
 import os
-from . import arf_consts as ac
-from . import alert_actions_exceptions as aae
-from shutil import copy
-from os import linesep
-from mako.template import Template
-from mako import exceptions
-from munch import Munch
-from .alert_actions_template import AlertActionsTemplateMgr
+from builtins import object
 from json import loads as jloads
+from os import linesep
+from os import path as op
+from shutil import copy
+
+from mako import exceptions
+from mako.template import Template
+from munch import Munch
+
+from . import alert_actions_exceptions as aae
+from . import arf_consts as ac
 from .alert_actions_helper import write_file
 from .alert_actions_merge import remove_alert_from_conf_file
+from .alert_actions_template import AlertActionsTemplateMgr
 
 
 class AlertActionsConfBase(object):

--- a/splunk_add_on_ucc_framework/modular_alert_builder/build_core/alert_actions_helper.py
+++ b/splunk_add_on_ucc_framework/modular_alert_builder/build_core/alert_actions_helper.py
@@ -19,8 +19,9 @@ import os.path as op
 import sys
 from os import makedirs, remove
 
-from splunk_add_on_ucc_framework.alert_utils.alert_utils_common.conf_parser import \
-    TABConfigParser
+from splunk_add_on_ucc_framework.alert_utils.alert_utils_common.conf_parser import (
+    TABConfigParser,
+)
 
 from .alert_actions_merge import merge_conf_file
 

--- a/splunk_add_on_ucc_framework/modular_alert_builder/build_core/alert_actions_helper.py
+++ b/splunk_add_on_ucc_framework/modular_alert_builder/build_core/alert_actions_helper.py
@@ -17,7 +17,7 @@
 
 import os.path as op
 import sys
-from os import makedirs, remove, rename
+from os import makedirs, remove
 
 from splunk_add_on_ucc_framework.alert_utils.alert_utils_common.conf_parser import \
     TABConfigParser

--- a/splunk_add_on_ucc_framework/modular_alert_builder/build_core/alert_actions_helper.py
+++ b/splunk_add_on_ucc_framework/modular_alert_builder/build_core/alert_actions_helper.py
@@ -15,12 +15,14 @@
 #
 
 
-import sys
 import os.path as op
-from os import rename, remove, makedirs
-from .alert_actions_merge import merge_conf_file
+import sys
+from os import makedirs, remove, rename
 
-from splunk_add_on_ucc_framework.alert_utils.alert_utils_common.conf_parser import TABConfigParser
+from splunk_add_on_ucc_framework.alert_utils.alert_utils_common.conf_parser import \
+    TABConfigParser
+
+from .alert_actions_merge import merge_conf_file
 
 
 def write_file(file_name, file_path, content, logger, merge="stanza_overwrite"):

--- a/splunk_add_on_ucc_framework/modular_alert_builder/build_core/alert_actions_html_gen.py
+++ b/splunk_add_on_ucc_framework/modular_alert_builder/build_core/alert_actions_html_gen.py
@@ -15,20 +15,22 @@
 #
 
 
-from builtins import object
-from . import arf_consts as ac
 import os
 import sys
-from os import path as op
+from builtins import object
 from os import linesep
-from . import alert_actions_exceptions as aae
-from munch import Munch
-from mako.template import Template
-from mako.lookup import TemplateLookup
-from defusedxml import lxml as defused_lxml
+from os import path as op
 from re import search
-from .alert_actions_template import AlertActionsTemplateMgr
+
+from defusedxml import lxml as defused_lxml
+from mako.lookup import TemplateLookup
+from mako.template import Template
+from munch import Munch
+
+from . import alert_actions_exceptions as aae
+from . import arf_consts as ac
 from .alert_actions_helper import write_file
+from .alert_actions_template import AlertActionsTemplateMgr
 
 
 class AlertHtmlBase(object):

--- a/splunk_add_on_ucc_framework/modular_alert_builder/build_core/alert_actions_merge.py
+++ b/splunk_add_on_ucc_framework/modular_alert_builder/build_core/alert_actions_merge.py
@@ -20,8 +20,9 @@ import os.path as op
 from os.path import basename as bn
 from shutil import copy
 
-from splunk_add_on_ucc_framework.alert_utils.alert_utils_common.conf_parser import \
-    TABConfigParser
+from splunk_add_on_ucc_framework.alert_utils.alert_utils_common.conf_parser import (
+    TABConfigParser,
+)
 
 from . import alert_actions_exceptions as aae
 from . import arf_consts as ac

--- a/splunk_add_on_ucc_framework/modular_alert_builder/build_core/alert_actions_merge.py
+++ b/splunk_add_on_ucc_framework/modular_alert_builder/build_core/alert_actions_merge.py
@@ -17,13 +17,15 @@
 
 import os
 import os.path as op
-from os.path import dirname as dn
 from os.path import basename as bn
+from os.path import dirname as dn
 from shutil import copy
+
+from splunk_add_on_ucc_framework.alert_utils.alert_utils_common.conf_parser import \
+    TABConfigParser
+
 from . import alert_actions_exceptions as aae
 from . import arf_consts as ac
-
-from splunk_add_on_ucc_framework.alert_utils.alert_utils_common.conf_parser import TABConfigParser
 
 merge_deny_list = ['default.meta', 'README.txt']
 merge_mode_config = {

--- a/splunk_add_on_ucc_framework/modular_alert_builder/build_core/alert_actions_merge.py
+++ b/splunk_add_on_ucc_framework/modular_alert_builder/build_core/alert_actions_merge.py
@@ -18,7 +18,6 @@
 import os
 import os.path as op
 from os.path import basename as bn
-from os.path import dirname as dn
 from shutil import copy
 
 from splunk_add_on_ucc_framework.alert_utils.alert_utils_common.conf_parser import \

--- a/splunk_add_on_ucc_framework/modular_alert_builder/build_core/alert_actions_py_gen.py
+++ b/splunk_add_on_ucc_framework/modular_alert_builder/build_core/alert_actions_py_gen.py
@@ -18,7 +18,6 @@
 import re
 from builtins import object
 from os import path as op
-from os import remove
 
 from mako.lookup import TemplateLookup
 from mako.template import Template

--- a/splunk_add_on_ucc_framework/modular_alert_builder/build_core/alert_actions_py_gen.py
+++ b/splunk_add_on_ucc_framework/modular_alert_builder/build_core/alert_actions_py_gen.py
@@ -15,17 +15,19 @@
 #
 
 
+import re
 from builtins import object
-from . import arf_consts as ac
 from os import path as op
 from os import remove
-from munch import Munch
-from mako.template import Template
+
 from mako.lookup import TemplateLookup
+from mako.template import Template
+from munch import Munch
+
 from . import alert_actions_exceptions as aae
-from .alert_actions_template import AlertActionsTemplateMgr
+from . import arf_consts as ac
 from .alert_actions_helper import write_file
-import re
+from .alert_actions_template import AlertActionsTemplateMgr
 
 
 class AlertActionsPyBase(object):

--- a/splunk_add_on_ucc_framework/modular_alert_builder/build_core/alert_actions_template.py
+++ b/splunk_add_on_ucc_framework/modular_alert_builder/build_core/alert_actions_template.py
@@ -14,8 +14,8 @@
 # limitations under the License.
 #
 
-from builtins import object
 import os.path as op
+from builtins import object
 
 
 class AlertActionsTemplateMgr(object):

--- a/splunk_add_on_ucc_framework/modular_alert_builder/build_core/cim_actions.py
+++ b/splunk_add_on_ucc_framework/modular_alert_builder/build_core/cim_actions.py
@@ -14,13 +14,15 @@
 # limitations under the License.
 #
 
-from builtins import object
 import json
 import logging
 import logging.handlers
 import re
+from builtins import object
+
 import splunk.rest as rest
 from splunk.util import normalizeBoolean
+
 
 class InvalidResultID(Exception):
     pass

--- a/splunk_add_on_ucc_framework/normalize.py
+++ b/splunk_add_on_ucc_framework/normalize.py
@@ -14,11 +14,11 @@
 # limitations under the License.
 #
 
-from builtins import zip
-import json
-import sys
 import copy
 import itertools
+import json
+import sys
+from builtins import zip
 
 mapping_keys = {
     "activeResponse": "active_response",

--- a/splunk_add_on_ucc_framework/normalize.py
+++ b/splunk_add_on_ucc_framework/normalize.py
@@ -15,8 +15,6 @@
 #
 
 import copy
-import itertools
-import json
 import sys
 from builtins import zip
 

--- a/splunk_add_on_ucc_framework/start_alert_build.py
+++ b/splunk_add_on_ucc_framework/start_alert_build.py
@@ -15,11 +15,12 @@
 #
 
 
-from . import normalize
 import logging
 import os
-from .modular_alert_builder.build_core import generate_alerts
 import traceback
+
+from . import normalize
+from .modular_alert_builder.build_core import generate_alerts
 
 
 class LoggerAdapter(logging.LoggerAdapter):

--- a/splunk_add_on_ucc_framework/uccrestbuilder/__init__.py
+++ b/splunk_add_on_ucc_framework/uccrestbuilder/__init__.py
@@ -21,12 +21,10 @@ REST Builder.
 
 
 import collections
+
 from splunktaucclib.rest_handler.schema import RestSchema
 
-from .builder import (
-    RestBuilder,
-    RestBuilderError,
-)
+from .builder import RestBuilder, RestBuilderError
 
 __all__ = [
     "RestBuilder",

--- a/splunk_add_on_ucc_framework/uccrestbuilder/builder.py
+++ b/splunk_add_on_ucc_framework/uccrestbuilder/builder.py
@@ -16,9 +16,10 @@
 
 
 
-from builtins import object
 import os
 import os.path as op
+from builtins import object
+
 from .rest_conf import RestmapConf, WebConf
 
 __all__ = [

--- a/splunk_add_on_ucc_framework/uccrestbuilder/endpoint/base.py
+++ b/splunk_add_on_ucc_framework/uccrestbuilder/endpoint/base.py
@@ -16,13 +16,14 @@
 
 
 
-from past.builtins import str
-from splunktaucclib.rest_handler.schema import RestSchema
-from io import StringIO
 from builtins import object
-from six import string_types as str
+from io import StringIO
+
 import six
 from future import standard_library
+from past.builtins import str
+from six import string_types as str
+from splunktaucclib.rest_handler.schema import RestSchema
 
 standard_library.install_aliases()
 

--- a/splunk_add_on_ucc_framework/uccrestbuilder/endpoint/field.py
+++ b/splunk_add_on_ucc_framework/uccrestbuilder/endpoint/field.py
@@ -17,7 +17,8 @@
 
 
 from builtins import object
-from .base import quote_string, indent
+
+from .base import indent, quote_string
 
 
 class RestFieldBuilder(object):

--- a/splunk_add_on_ucc_framework/uccrestbuilder/endpoint/oauth_model.py
+++ b/splunk_add_on_ucc_framework/uccrestbuilder/endpoint/oauth_model.py
@@ -18,7 +18,6 @@
 
 from .base import RestEndpointBuilder
 
-
 """
 This class is used to generate the endpoint for getting access token from auth code and 
 extends RestEndpointBuilder class

--- a/splunk_add_on_ucc_framework/uccrestbuilder/endpoint/single_model.py
+++ b/splunk_add_on_ucc_framework/uccrestbuilder/endpoint/single_model.py
@@ -16,7 +16,7 @@
 
 
 
-from .base import RestEntityBuilder, RestEndpointBuilder
+from .base import RestEndpointBuilder, RestEntityBuilder
 
 
 class SingleModelEntityBuilder(RestEntityBuilder):

--- a/splunk_add_on_ucc_framework/uccrestbuilder/global_config.py
+++ b/splunk_add_on_ucc_framework/uccrestbuilder/global_config.py
@@ -24,7 +24,6 @@ import json
 import os
 import os.path as op
 import shutil
-import stat
 from builtins import map, object
 
 from solnlib.utils import is_true

--- a/splunk_add_on_ucc_framework/uccrestbuilder/global_config.py
+++ b/splunk_add_on_ucc_framework/uccrestbuilder/global_config.py
@@ -20,36 +20,27 @@ Global config schema.
 
 
 
-from builtins import map
-from builtins import object
+import json
 import os
 import os.path as op
-import stat
 import shutil
+import stat
+from builtins import map, object
+
 from solnlib.utils import is_true
 from splunktaucclib.global_config import GlobalConfigSchema
-from splunktaucclib.rest_handler.endpoint.field import (
-    RestField,
-)
-import json
+from splunktaucclib.rest_handler.endpoint.field import RestField
 
+from .endpoint.base import indent, quote_regex
+from .endpoint.datainput import (DataInputEndpointBuilder,
+                                 DataInputEntityBuilder)
 from .endpoint.field import RestFieldBuilder
-from .endpoint.single_model import (
-    SingleModelEntityBuilder,
-    SingleModelEndpointBuilder,
-)
-from .endpoint.multiple_model import (
-    MultipleModelEntityBuilder,
-    MultipleModelEndpointBuilder,
-)
-from .endpoint.datainput import (
-    DataInputEndpointBuilder,
-    DataInputEntityBuilder,
-)
-
+from .endpoint.multiple_model import (MultipleModelEndpointBuilder,
+                                      MultipleModelEntityBuilder)
 # model to get accesstoken for oauth
 from .endpoint.oauth_model import OAuthModelEndpointBuilder
-from .endpoint.base import indent, quote_regex
+from .endpoint.single_model import (SingleModelEndpointBuilder,
+                                    SingleModelEntityBuilder)
 
 
 class GlobalConfigBuilderSchema(GlobalConfigSchema):

--- a/splunk_add_on_ucc_framework/uccrestbuilder/global_config.py
+++ b/splunk_add_on_ucc_framework/uccrestbuilder/global_config.py
@@ -31,15 +31,21 @@ from splunktaucclib.global_config import GlobalConfigSchema
 from splunktaucclib.rest_handler.endpoint.field import RestField
 
 from .endpoint.base import indent, quote_regex
-from .endpoint.datainput import (DataInputEndpointBuilder,
-                                 DataInputEntityBuilder)
+from .endpoint.datainput import (
+    DataInputEndpointBuilder,
+    DataInputEntityBuilder,
+)
 from .endpoint.field import RestFieldBuilder
-from .endpoint.multiple_model import (MultipleModelEndpointBuilder,
-                                      MultipleModelEntityBuilder)
+from .endpoint.multiple_model import (
+    MultipleModelEndpointBuilder,
+    MultipleModelEntityBuilder,
+)
 # model to get accesstoken for oauth
 from .endpoint.oauth_model import OAuthModelEndpointBuilder
-from .endpoint.single_model import (SingleModelEndpointBuilder,
-                                    SingleModelEntityBuilder)
+from .endpoint.single_model import (
+    SingleModelEndpointBuilder,
+    SingleModelEntityBuilder,
+)
 
 
 class GlobalConfigBuilderSchema(GlobalConfigSchema):

--- a/splunk_add_on_ucc_framework/uccrestbuilder/rest_conf.py
+++ b/splunk_add_on_ucc_framework/uccrestbuilder/rest_conf.py
@@ -18,6 +18,8 @@
 
 
 from builtins import object
+
+
 class RestmapConf(object):
 
     _admin_template = """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,6 @@ import pytest
 
 pytest_plugins = "pytester"
 import json
-import urllib.parse
 
 from solnlib.splunk_rest_client import SplunkRestClient
 from splunklib import binding

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,12 +15,16 @@
 #
 
 import os
+
 import pytest
+
 pytest_plugins = "pytester"
-import urllib.parse
 import json
+import urllib.parse
+
 from solnlib.splunk_rest_client import SplunkRestClient
 from splunklib import binding
+
 
 def pytest_configure(config):
     config.addinivalue_line("markers", "external: Test search time only")

--- a/tests/data/test_ucc_generate.py
+++ b/tests/data/test_ucc_generate.py
@@ -1,5 +1,5 @@
-from os import path
 import unittest
+from os import path
 
 import splunk_add_on_ucc_framework as ucc
 


### PR DESCRIPTION
First commit is just `isort .`, second commit is deleting unused imports and third commit is making CI actually green by fixing CI's isort.