### PR TITLE
fix: update ucc ui version to 1.7.7

### DIFF
--- a/.ucc-ui-version
+++ b/.ucc-ui-version
@@ -1,2 +1,2 @@
-#https://github.com/splunk/addonfactory-ucc-base-ui/releases/download/v1.7.6/splunk-ucc-ui.tgz
-VERSION=v1.7.6
+#https://github.com/splunk/addonfactory-ucc-base-ui/releases/download/v1.7.7/splunk-ucc-ui.tgz
+VERSION=v1.7.7


### PR DESCRIPTION
[ADDON-38581](https://jira.splunk.com/browse/ADDON-38581): fallback to latest form state if resthandler skips some table fields from response