### PR TITLE
feat: delete `apiVersion` from globalConfig.json and bump schemaVersion

### DIFF
--- a/.ucc-ui-version
+++ b/.ucc-ui-version
@@ -1,2 +1,2 @@
-#https://github.com/splunk/addonfactory-ucc-base-ui/releases/download/v1.8.4/splunk-ucc-ui.tgz
-VERSION=v1.8.4
+#https://github.com/splunk/addonfactory-ucc-base-ui/releases/download/v1.9.0/splunk-ucc-ui.tgz
+VERSION=v1.9.0

--- a/splunk_add_on_ucc_framework/__init__.py
+++ b/splunk_add_on_ucc_framework/__init__.py
@@ -169,6 +169,13 @@ def handle_biased_terms_update(schema_content: dict) -> dict:
     return schema_content
 
 
+def handle_dropping_api_version_update(schema_content: dict) -> dict:
+    if schema_content["meta"].get("apiVersion"):
+        del schema_content["meta"]["apiVersion"]
+    schema_content["meta"]["schemaVersion"] = "0.0.3"
+    return schema_content
+
+
 def handle_update(config_path):
     """
     handle changes in globalConfig.json
@@ -189,11 +196,9 @@ def handle_update(config_path):
         with open(config_path, "w") as config_file:
             json.dump(schema_content, config_file, ensure_ascii=False, indent=4)
 
-    # check for schemaVersion, if it's less than 0.0.2 then updating globalConfig.json
     if version_tuple(version) < version_tuple("0.0.2"):
         ta_tabs = schema_content.get("pages").get("configuration", {}).get("tabs", {})
 
-        # check for schema changes in configuration page of globalConfig.json
         for tab in ta_tabs:
             if tab["name"] == "account":
                 conf_entities = tab.get("entity")
@@ -253,6 +258,11 @@ def handle_update(config_path):
                     del service_options["onLoad"]
 
         schema_content["meta"]["schemaVersion"] = "0.0.2"
+        with open(config_path, "w") as config_file:
+            json.dump(schema_content, config_file, ensure_ascii=False, indent=4)
+
+    if version_tuple(version) < version_tuple("0.0.3"):
+        schema_content = handle_dropping_api_version_update(schema_content)
         with open(config_path, "w") as config_file:
             json.dump(schema_content, config_file, ensure_ascii=False, indent=4)
 

--- a/splunk_add_on_ucc_framework/uccrestbuilder/global_config.py
+++ b/splunk_add_on_ucc_framework/uccrestbuilder/global_config.py
@@ -231,7 +231,10 @@ class GlobalConfigBuilderSchema:
                     content = content + entity_element["options"]["oauth"]
                     # Append auth_type, access_token, refresh_token & instance_url fields
                     content = content + json.loads(
-                        '[{"field": "access_token","encrypted": true},{"field": "refresh_token","encrypted":true},{"field": "instance_url"},{"field": "auth_type"}]'
+                        '[{"field": "access_token","encrypted": true},'
+                        '{"field": "refresh_token","encrypted":true},'
+                        '{"field": "instance_url"},'
+                        '{"field": "auth_type"}]'
                     )
                 # If only oauth type authentication is required
                 elif "oauth" in entity_element["options"]["auth_type"]:
@@ -239,7 +242,9 @@ class GlobalConfigBuilderSchema:
                     content = content + entity_element["options"]["oauth"]
                     # Append access_token, refresh_token & instance_url fields
                     content = content + json.loads(
-                        '[{"field": "access_token","encrypted": true},{"field": "refresh_token","encrypted":true},{"field": "instance_url"}]'
+                        '[{"field": "access_token","encrypted": true},'
+                        '{"field": "refresh_token","encrypted":true},'
+                        '{"field": "instance_url"}]'
                     )
                 # We will remove the oauth type entity as we have replaced it with all the entity fields
                 content.remove(entity_element)
@@ -446,7 +451,7 @@ sys.path = new_paths
 
     def import_declare(self, rh_file):
         with open(rh_file) as f:
-            cont = [l for l in f]
+            cont = f.readlines()
         import_declare = self._import_declare_template.format(
             import_declare_name=self.import_declare_py_name()
         )

--- a/splunk_add_on_ucc_framework/uccrestbuilder/global_config.py
+++ b/splunk_add_on_ucc_framework/uccrestbuilder/global_config.py
@@ -69,10 +69,6 @@ class GlobalConfigBuilderSchema:
         return ""
 
     @property
-    def version(self):
-        return self._meta["apiVersion"]
-
-    @property
     def inputs(self):
         return self._inputs
 

--- a/tests/data/package_global_config_configuration/globalConfig.json
+++ b/tests/data/package_global_config_configuration/globalConfig.json
@@ -419,11 +419,10 @@
         }
     },
     "meta": {
-        "apiVersion": "3.2.0",
         "name": "Splunk_TA_UCCExample",
         "restRoot": "splunk_ta_uccexample",
-        "version": "5.6.2R6cc76bdf",
+        "version": "5.7.0Rc1c9ff9f",
         "displayName": "Splunk UCC test Add-on",
-        "schemaVersion": "0.0.2"
+        "schemaVersion": "0.0.3"
     }
 }

--- a/tests/data/package_global_config_inputs_configuration_alerts/globalConfig.json
+++ b/tests/data/package_global_config_inputs_configuration_alerts/globalConfig.json
@@ -1023,11 +1023,10 @@
         }
     ],
     "meta": {
-        "apiVersion": "3.2.0",
         "name": "Splunk_TA_UCCExample",
         "restRoot": "splunk_ta_uccexample",
-        "version": "5.6.2R6cc76bdf",
+        "version": "5.7.0Rc1c9ff9f",
         "displayName": "Splunk UCC test Add-on",
-        "schemaVersion": "0.0.2"
+        "schemaVersion": "0.0.3"
     }
 }

--- a/tests/unit/test_config_file_update.py
+++ b/tests/unit/test_config_file_update.py
@@ -17,7 +17,10 @@ import json
 import unittest
 
 import tests.unit.helpers as helpers
-from splunk_add_on_ucc_framework import handle_biased_terms_update
+from splunk_add_on_ucc_framework import (
+    handle_biased_terms_update,
+    handle_dropping_api_version_update,
+)
 
 
 class ConfigFileUpdateTest(unittest.TestCase):
@@ -49,3 +52,13 @@ class ConfigFileUpdateTest(unittest.TestCase):
         ][0]["entity"][1]["options"].keys()
         self.assertIn("allowList", configuration_entity_2_options_keys)
         self.assertNotIn("whiteList", configuration_entity_2_options_keys)
+
+    def test_handle_dropping_api_version_update(self):
+        config = helpers.get_testdata_file("config_with_biased_terms.json")
+        config = json.loads(config)
+        updated_config = handle_dropping_api_version_update(config)
+        expected_schema_version = "0.0.3"
+        self.assertEqual(
+            expected_schema_version, updated_config["meta"]["schemaVersion"]
+        )
+        self.assertNotIn("apiVersion", updated_config["meta"])


### PR DESCRIPTION
`apiVersion` from globalConfig is not used and is already marked as optional in UCC UI repository (https://github.com/splunk/addonfactory-ucc-base-ui/pull/57)