### PR TITLE
fix: update UCC UI version to 1.8.1

### DIFF
--- a/.ucc-ui-version
+++ b/.ucc-ui-version
@@ -1,2 +1,2 @@
-#https://github.com/splunk/addonfactory-ucc-base-ui/releases/download/v1.8.0/splunk-ucc-ui.tgz
-VERSION=v1.8.0
+#https://github.com/splunk/addonfactory-ucc-base-ui/releases/download/v1.8.1/splunk-ucc-ui.tgz
+VERSION=v1.8.1


### PR DESCRIPTION
Bug Fixes:

* default to `basic` oauth_type if `undefined` to handle upgrade scenario for some add-ons ([c7373eb](https://github.com/splunk/addonfactory-ucc-base-ui/commit/c7373eb02b62c656c6052ae4a7f8de2fc54055f2)) [[ADDON-39022](https://jira.splunk.com/browse/ADDON-39022)]
* skip `null` value fields from displaying in table expansion row ([b69f7aa](https://github.com/splunk/addonfactory-ucc-base-ui/commit/b69f7aa2aa7a8c1a3cc8903560872a650785843e)) [[ADDON-39037](https://jira.splunk.com/browse/ADDON-39037)]