### PR TITLE
fix: update ucc ui version to 1.8.2

### DIFF
--- a/.ucc-ui-version
+++ b/.ucc-ui-version
@@ -1,2 +1,2 @@
-#https://github.com/splunk/addonfactory-ucc-base-ui/releases/download/v1.8.1/splunk-ucc-ui.tgz
-VERSION=v1.8.1
+#https://github.com/splunk/addonfactory-ucc-base-ui/releases/download/v1.8.2/splunk-ucc-ui.tgz
+VERSION=v1.8.2


### PR DESCRIPTION
### Bug Fixes

* pass `count` query param in rest to overcome default thirty records limit ([8591f1c](https://github.com/splunk/addonfactory-ucc-base-ui/commit/8591f1c453929b6394f153770ea2f4d18c1a0feb)) [[ADDON-39044](https://jira.splunk.com/browse/ADDON-39044)]