### PR TITLE
feat: support app.manifest file with comments

### DIFF
--- a/splunk_add_on_ucc_framework/__init__.py
+++ b/splunk_add_on_ucc_framework/__init__.py
@@ -34,6 +34,12 @@ from defusedxml import cElementTree as defused_et
 from dunamai import Style, Version
 from jinja2 import Environment, FileSystemLoader
 
+from .app_manifest import (
+    APP_MANIFEST_FILE_NAME,
+    APP_MANIFEST_WEBSITE,
+    AppManifest,
+    AppManifestFormatException,
+)
 from .start_alert_build import alert_build
 from .uccrestbuilder import build
 from .uccrestbuilder.global_config import (
@@ -690,10 +696,21 @@ def _generate(source, config, ta_version, outputdir=None):
 
     clean_before_build(outputdir)
 
-    with open(os.path.abspath(os.path.join(source, "app.manifest")),
-              "r") as manifest_file:
-        manifest = json.load(manifest_file)
-        ta_name = manifest['info']['id']['name']
+    app_manifest_path = os.path.abspath(
+        os.path.join(source, APP_MANIFEST_FILE_NAME),
+    )
+    with open(app_manifest_path) as manifest_file:
+        app_manifest_content = manifest_file.read()
+    manifest = AppManifest()
+    try:
+        manifest.read(app_manifest_content)
+    except app_manifest.AppManifestFormatException:
+        logger.error(
+            f"Manifest file @ {app_manifest_path} has invalid format.\n"
+            f"Please refer to {APP_MANIFEST_WEBSITE}.\n"
+            f"Lines with comments are supported if they start with \"#\".\n")
+        sys.exit(1)
+    ta_name = manifest.get_addon_name()
 
     if os.path.exists(config):
         try:
@@ -783,15 +800,12 @@ def _generate(source, config, ta_version, outputdir=None):
         version_file.write("\n")
         version_file.write(ta_version)
 
-    manifest = None
-    with open(os.path.abspath(os.path.join(outputdir, ta_name, "app.manifest")),
-              "r") as manifest_file:
-        manifest = json.load(manifest_file)
-        manifest['info']['id']['version'] = ta_version
-
-    with open(os.path.abspath(os.path.join(outputdir, ta_name, "app.manifest")),
-              "w") as manifest_file:
-        manifest_file.write(json.dumps(manifest, indent=4, sort_keys=True))
+    manifest.update_addon_version(ta_version)
+    output_manifest_path = os.path.abspath(
+        os.path.join(outputdir, ta_name, APP_MANIFEST_FILE_NAME)
+    )
+    with open(output_manifest_path, "w") as manifest_file:
+        manifest_file.write(str(manifest))
 
     comment_map = save_comments(outputdir, ta_name)
     app_config = configparser.ConfigParser()
@@ -809,14 +823,14 @@ def _generate(source, config, ta_version, outputdir=None):
         app_config.add_section('ui')
 
     app_config['launcher']['version'] = ta_version
-    app_config['launcher']['description'] = manifest['info']['description']
+    app_config['launcher']['description'] = manifest.get_description()
 
     app_config['id']['version'] = ta_version
 
     app_config['install']['build'] = str(int(time.time()))
-    app_config['package']['id'] = manifest['info']['id']['name']
+    app_config['package']['id'] = ta_name
 
-    app_config['ui']['label'] = manifest['info']['title']
+    app_config['ui']['label'] = manifest.get_title()
 
     with open(os.path.join(outputdir, ta_name, 'default', "app.conf"),
               'w') as configfile:

--- a/splunk_add_on_ucc_framework/app_manifest.py
+++ b/splunk_add_on_ucc_framework/app_manifest.py
@@ -1,0 +1,74 @@
+#
+# Copyright 2021 Splunk Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import json
+import warnings
+
+APP_MANIFEST_FILE_NAME = "app.manifest"
+APP_MANIFEST_WEBSITE = "https://dev.splunk.com/enterprise/reference/packagingtoolkit/pkgtoolkitappmanifest/"
+
+DEPRECATION_MESSAGE = f"""
+Comments are not allowed in app.manifest file.
+Please refer to {APP_MANIFEST_WEBSITE}
+"""
+
+
+class AppManifestFormatException(Exception):
+    pass
+
+
+class AppManifest:
+    def __init__(self):
+        self._manifest = None
+        self._comments = []
+
+    def get_addon_name(self) -> str:
+        return self._manifest["info"]["id"]["name"]
+
+    def get_title(self) -> str:
+        return self._manifest["info"]["title"]
+
+    def get_description(self) -> str:
+        return self._manifest["info"]["description"]
+
+    def read(self, content: str) -> None:
+        try:
+            self._manifest = json.loads(content)
+        except json.JSONDecodeError:
+            # Manifest file has comments.
+            manifest_lines = []
+            for line in content.split("\n"):
+                if line.lstrip().startswith("#"):
+                    self._comments.append(line)
+                else:
+                    manifest_lines.append(line)
+            if self._comments:
+                warnings.warn(DEPRECATION_MESSAGE, FutureWarning)
+            manifest = "".join(manifest_lines)
+            try:
+                self._manifest = json.loads(manifest)
+            except json.JSONDecodeError:
+                raise AppManifestFormatException
+
+    def update_addon_version(self, version: str) -> None:
+        self._manifest["info"]["id"]["version"] = version
+
+    def __str__(self) -> str:
+        content = json.dumps(self._manifest, indent=4, sort_keys=True)
+        if self._comments:
+            for comment in self._comments:
+                content += f"\n{comment}"
+        return content

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -17,10 +17,9 @@ import json
 import os
 
 
-def get_config(config_name: str) -> dict:
-    config_path = os.path.join(
-        os.path.dirname(os.path.realpath(__file__)), "testdata", config_name
+def get_testdata_file(file_name: str) -> str:
+    file_path = os.path.join(
+        os.path.dirname(os.path.realpath(__file__)), "testdata", file_name
     )
-    with open(config_path, "r") as f_config:
-        valid_config_raw = f_config.read()
-        return json.loads(valid_config_raw)
+    with open(file_path) as fp:
+        return fp.read()

--- a/tests/unit/test_app_manifest.py
+++ b/tests/unit/test_app_manifest.py
@@ -1,0 +1,79 @@
+#
+# Copyright 2021 Splunk Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import unittest
+
+from splunk_add_on_ucc_framework import app_manifest
+from tests.unit.helpers import get_testdata_file
+
+
+def get_manifest(file_name: str) -> app_manifest.AppManifest:
+    content = get_testdata_file(file_name)
+    manifest = app_manifest.AppManifest()
+    manifest.read(content)
+    return manifest
+
+
+class AppManifestTest(unittest.TestCase):
+    def test_read(self):
+        manifest = get_manifest("app.manifest")
+        self.assertTrue(isinstance(manifest._manifest, dict))
+        self.assertFalse(manifest._comments)
+
+    def test_read_with_comments(self):
+        manifest = get_manifest("app.manifest_with_comments")
+        self.assertTrue(isinstance(manifest._manifest, dict))
+        expected_comments = [
+            "# This is a comment.",
+            "# We will keep it after modifying this file.",
+        ]
+        self.assertListEqual(expected_comments, manifest._comments)
+
+    def test_read_with_unsupported_comments_throws_exception(self):
+        with self.assertRaises(app_manifest.AppManifestFormatException):
+            get_manifest("app.manifest_with_unsupported_comments")
+
+    def test_get_addon_name(self):
+        manifest = get_manifest("app.manifest")
+        expected_addon_name = "Splunk_TA_UCCExample"
+        self.assertEqual(expected_addon_name, manifest.get_addon_name())
+
+    def test_get_title(self):
+        manifest = get_manifest("app.manifest")
+        expected_title = "Splunk Add-on for UCC Example"
+        self.assertEqual(expected_title, manifest.get_title())
+
+    def test_get_description(self):
+        manifest = get_manifest("app.manifest")
+        expected_description = "Description of Splunk Add-on for UCC Example"
+        self.assertEqual(expected_description, manifest.get_description())
+
+    def test_update_addon_version(self):
+        manifest = get_manifest("app.manifest")
+        expected_addon_version = "v1.1.1"
+        manifest.update_addon_version(expected_addon_version)
+        self.assertEqual(
+            expected_addon_version, manifest._manifest["info"]["id"]["version"]
+        )
+
+    def test_str(self):
+        manifest = get_manifest("app.manifest")
+        expected_content = get_testdata_file("app.manifest_written")
+        self.assertEqual(expected_content, str(manifest))
+
+    def test_str_with_comments(self):
+        manifest = get_manifest("app.manifest_with_comments")
+        expected_content = get_testdata_file("app.manifest_with_comments_written")
+        self.assertEqual(expected_content, str(manifest))

--- a/tests/unit/test_config_file_update.py
+++ b/tests/unit/test_config_file_update.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import json
 import unittest
 
 import tests.unit.helpers as helpers
@@ -21,7 +22,8 @@ from splunk_add_on_ucc_framework import handle_biased_terms_update
 
 class ConfigFileUpdateTest(unittest.TestCase):
     def test_handle_biased_terms_update(self):
-        config = helpers.get_config("config_with_biased_terms.json")
+        config = helpers.get_testdata_file("config_with_biased_terms.json")
+        config = json.loads(config)
         updated_config = handle_biased_terms_update(config)
         expected_schema_version = "0.0.1"
         self.assertEqual(

--- a/tests/unit/test_config_validation.py
+++ b/tests/unit/test_config_validation.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 #
 import json
-import os.path
 import unittest
 
 import jsonschema
@@ -22,21 +21,14 @@ import tests.unit.helpers as helpers
 from splunk_add_on_ucc_framework import validate_config_against_schema
 
 
-def _get_config(config_name: str) -> dict:
-    config_path = os.path.join(
-        os.path.dirname(os.path.realpath(__file__)), "testdata", config_name
-    )
-    with open(config_path, "r") as f_config:
-        valid_config_raw = f_config.read()
-        return json.loads(valid_config_raw)
-
-
 class ConfigValidationTest(unittest.TestCase):
     def test_config_validation_when_valid_config_then_no_exception(self):
-        config = helpers.get_config("valid_config.json")
+        config = helpers.get_testdata_file("valid_config.json")
+        config = json.loads(config)
         validate_config_against_schema(config)
 
     def test_config_validation_when_invalid_config_then_exception(self):
-        config = helpers.get_config("invalid_config_no_configuration_tabs.json")
+        config = helpers.get_testdata_file("invalid_config_no_configuration_tabs.json")
+        config = json.loads(config)
         with self.assertRaises(jsonschema.ValidationError):
             validate_config_against_schema(config)

--- a/tests/unit/testdata/app.manifest
+++ b/tests/unit/testdata/app.manifest
@@ -1,0 +1,51 @@
+{
+  "schemaVersion": "2.0.0",
+  "info": {
+    "title": "Splunk Add-on for UCC Example",
+    "id": {
+      "group": null,
+      "name": "Splunk_TA_UCCExample",
+      "version": "7.0.1"
+    },
+    "author": [
+      {
+        "name": "Splunk",
+        "email": null,
+        "company": null
+      }
+    ],
+    "releaseDate": null,
+    "description": "Description of Splunk Add-on for UCC Example",
+    "classification": {
+      "intendedAudience": null,
+      "categories": [],
+      "developmentStatus": null
+    },
+    "commonInformationModels": null,
+    "license": {
+      "name": null,
+      "text": "LICENSES/Apache-2.0.txt",
+      "uri": null
+    },
+    "privacyPolicy": {
+      "name": null,
+      "text": null,
+      "uri": null
+    },
+    "releaseNotes": {
+      "name": null,
+      "text": "./README.txt",
+      "uri": null
+    }
+  },
+  "dependencies": null,
+  "tasks": null,
+  "inputGroups": null,
+  "incompatibleApps": null,
+  "platformRequirements": null,
+  "supportedDeployments": [
+    "_standalone",
+    "_distributed"
+  ],
+  "targetWorkloads": null
+}

--- a/tests/unit/testdata/app.manifest_with_comments
+++ b/tests/unit/testdata/app.manifest_with_comments
@@ -1,0 +1,53 @@
+{
+  "schemaVersion": "2.0.0",
+  "info": {
+    "title": "Splunk Add-on for UCC Example",
+    "id": {
+      "group": null,
+      "name": "Splunk_TA_UCCExample",
+      "version": "7.0.1"
+    },
+    "author": [
+      {
+        "name": "Splunk",
+        "email": null,
+        "company": null
+      }
+    ],
+    "releaseDate": null,
+    "description": "Splunk Add-on for UCC Example",
+    "classification": {
+      "intendedAudience": null,
+      "categories": [],
+      "developmentStatus": null
+    },
+    "commonInformationModels": null,
+    "license": {
+      "name": null,
+      "text": "LICENSES/Apache-2.0.txt",
+      "uri": null
+    },
+    "privacyPolicy": {
+      "name": null,
+      "text": null,
+      "uri": null
+    },
+    "releaseNotes": {
+      "name": null,
+      "text": "./README.txt",
+      "uri": null
+    }
+  },
+  "dependencies": null,
+  "tasks": null,
+  "inputGroups": null,
+  "incompatibleApps": null,
+  "platformRequirements": null,
+  "supportedDeployments": [
+    "_standalone",
+    "_distributed"
+  ],
+  "targetWorkloads": null
+}
+# This is a comment.
+# We will keep it after modifying this file.

--- a/tests/unit/testdata/app.manifest_with_comments_written
+++ b/tests/unit/testdata/app.manifest_with_comments_written
@@ -1,0 +1,53 @@
+{
+    "dependencies": null,
+    "incompatibleApps": null,
+    "info": {
+        "author": [
+            {
+                "company": null,
+                "email": null,
+                "name": "Splunk"
+            }
+        ],
+        "classification": {
+            "categories": [],
+            "developmentStatus": null,
+            "intendedAudience": null
+        },
+        "commonInformationModels": null,
+        "description": "Splunk Add-on for UCC Example",
+        "id": {
+            "group": null,
+            "name": "Splunk_TA_UCCExample",
+            "version": "7.0.1"
+        },
+        "license": {
+            "name": null,
+            "text": "LICENSES/Apache-2.0.txt",
+            "uri": null
+        },
+        "privacyPolicy": {
+            "name": null,
+            "text": null,
+            "uri": null
+        },
+        "releaseDate": null,
+        "releaseNotes": {
+            "name": null,
+            "text": "./README.txt",
+            "uri": null
+        },
+        "title": "Splunk Add-on for UCC Example"
+    },
+    "inputGroups": null,
+    "platformRequirements": null,
+    "schemaVersion": "2.0.0",
+    "supportedDeployments": [
+        "_standalone",
+        "_distributed"
+    ],
+    "targetWorkloads": null,
+    "tasks": null
+}
+# This is a comment.
+# We will keep it after modifying this file.

--- a/tests/unit/testdata/app.manifest_with_unsupported_comments
+++ b/tests/unit/testdata/app.manifest_with_unsupported_comments
@@ -1,0 +1,54 @@
+{
+  "schemaVersion": "2.0.0",
+  "info": {
+    "title": "Splunk Add-on for UCC Example",
+    "id": {
+      "group": null,
+      "name": "Splunk_TA_UCCExample",
+      "version": "7.0.1"
+    },
+    "author": [
+      {
+        "name": "Splunk",
+        "email": null,
+        "company": null
+      }
+    ],
+    "releaseDate": null,
+    "description": "Description of Splunk Add-on for UCC Example",
+    "classification": {
+      "intendedAudience": null,
+      "categories": [],
+      "developmentStatus": null
+    },
+    "commonInformationModels": null,
+    "license": {
+      "name": null,
+      "text": "LICENSES/Apache-2.0.txt",
+      "uri": null
+    },
+    "privacyPolicy": {
+      "name": null,
+      "text": null,
+      "uri": null
+    },
+    "releaseNotes": {
+      "name": null,
+      "text": "./README.txt",
+      "uri": null
+    }
+  },
+  "dependencies": null,
+  "tasks": null,
+  "inputGroups": null,
+  "incompatibleApps": null,
+  "platformRequirements": null,
+  "supportedDeployments": [
+    "_standalone",
+    "_distributed"
+  ],
+  "targetWorkloads": null
+}
+# This is supported comment.
+// This is unsupported comment.
+This is just a line.

--- a/tests/unit/testdata/app.manifest_written
+++ b/tests/unit/testdata/app.manifest_written
@@ -1,0 +1,51 @@
+{
+    "dependencies": null,
+    "incompatibleApps": null,
+    "info": {
+        "author": [
+            {
+                "company": null,
+                "email": null,
+                "name": "Splunk"
+            }
+        ],
+        "classification": {
+            "categories": [],
+            "developmentStatus": null,
+            "intendedAudience": null
+        },
+        "commonInformationModels": null,
+        "description": "Description of Splunk Add-on for UCC Example",
+        "id": {
+            "group": null,
+            "name": "Splunk_TA_UCCExample",
+            "version": "7.0.1"
+        },
+        "license": {
+            "name": null,
+            "text": "LICENSES/Apache-2.0.txt",
+            "uri": null
+        },
+        "privacyPolicy": {
+            "name": null,
+            "text": null,
+            "uri": null
+        },
+        "releaseDate": null,
+        "releaseNotes": {
+            "name": null,
+            "text": "./README.txt",
+            "uri": null
+        },
+        "title": "Splunk Add-on for UCC Example"
+    },
+    "inputGroups": null,
+    "platformRequirements": null,
+    "schemaVersion": "2.0.0",
+    "supportedDeployments": [
+        "_standalone",
+        "_distributed"
+    ],
+    "targetWorkloads": null,
+    "tasks": null
+}


### PR DESCRIPTION
Lines that start with "#" are supported. Some of the app.manifest files have comments.

Appinspect tool does not fail if app.manifest contains comments. Exact lines of code from appinspect: https://github.com/splunk/appinspect/blob/fabd1387cf41e087edd86fb7f28e2f9e69a1467c/splunk_appinspect/checks/check_support_and_installation_standards.py#L169-L180