### PR TITLE
fix: broken import after modular alert code generation

### DIFF
--- a/splunk_add_on_ucc_framework/modular_alert_builder/build_core/alert_actions_py_gen.py
+++ b/splunk_add_on_ucc_framework/modular_alert_builder/build_core/alert_actions_py_gen.py
@@ -160,7 +160,6 @@ class AlertActionsPyGenerator(AlertActionsPyBase):
         template = Template(filename=template_path, lookup=tmp_lookup)
 
         # start to render new py file
-        rendered_content = None
         settings = None
         if self._global_settings:
             settings = self._global_settings["settings"]

--- a/splunk_add_on_ucc_framework/modular_alert_builder/build_core/arf_template/alert_action.py.template
+++ b/splunk_add_on_ucc_framework/modular_alert_builder/build_core/arf_template/alert_action.py.template
@@ -7,7 +7,7 @@ import os
 import sys
 
 from splunktaucclib.alert_actions_base import ModularAlertBase
-import ${helper_name}
+from ${lib_name} import ${helper_name}
 
 class AlertActionWorker${mod_alert.short_name}(ModularAlertBase):
 


### PR DESCRIPTION
`lib_name` variable was not used before in `splunk_add_on_ucc_framework/modular_alert_builder/build_core/arf_template/alert_action.py.template` template, but was provided from the Python side.

This caused an `ImportError` for newly generated add-on.

Thanks to @guilhemmarchand for spotting this one.