### PR TITLE
fix: validate that a configuration tab with table has field "name"

### DIFF
--- a/splunk_add_on_ucc_framework/global_config_validator.py
+++ b/splunk_add_on_ucc_framework/global_config_validator.py
@@ -1,0 +1,75 @@
+#
+# Copyright 2021 Splunk Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import json
+import os
+import jsonschema
+
+
+class GlobalConfigValidatorException(Exception):
+    pass
+
+
+class GlobalConfigValidator:
+    """
+    GlobalConfigValidator implements different validation for globalConfig.json.
+    Simple validation should go to JSON schema in
+    https://github.com/splunk/addonfactory-ucc-base-ui repository.
+    Custom validation should be implemented here.
+    """
+
+    def __init__(self, source_dir: str, config: dict):
+        self._source_dir = source_dir
+        self._config = config
+
+    def _validate_config_against_schema(self) -> None:
+        """
+        Validates config against JSON schema.
+        Raises jsonschema.ValidationError if config is not valid.
+        """
+        schema_path = os.path.join(self._source_dir, "schema", "schema.json")
+        with open(schema_path) as f_schema:
+            schema_raw = f_schema.read()
+            schema = json.loads(schema_raw)
+        try:
+            return jsonschema.validate(instance=self._config, schema=schema)
+        except jsonschema.ValidationError as e:
+            raise GlobalConfigValidatorException(e.message)
+
+    def _validate_configuration_tab_table_has_name_field(self) -> None:
+        """
+        Validates that if a configuration tab should be rendered as a table,
+        then it needs to have an entity which has field "name".
+        """
+        pages = self._config["pages"]
+        configuration = pages["configuration"]
+        tabs = configuration["tabs"]
+        for tab in tabs:
+            if "table" in tab:
+                entities = tab["entity"]
+                has_name_field = False
+                for entity in entities:
+                    if entity["field"] == "name":
+                        has_name_field = True
+                        break
+                if not has_name_field:
+                    raise GlobalConfigValidatorException(
+                        f"Tab '{tab['name']}' should have entity with field 'name'"
+                    )
+
+    def validate(self) -> None:
+        self._validate_config_against_schema()
+        self._validate_configuration_tab_table_has_name_field()

--- a/splunk_add_on_ucc_framework/global_config_validator.py
+++ b/splunk_add_on_ucc_framework/global_config_validator.py
@@ -16,6 +16,7 @@
 
 import json
 import os
+
 import jsonschema
 
 

--- a/tests/unit/test_config_validation.py
+++ b/tests/unit/test_config_validation.py
@@ -14,21 +14,42 @@
 # limitations under the License.
 #
 import json
+import os
 import unittest
 
-import jsonschema
 import tests.unit.helpers as helpers
-from splunk_add_on_ucc_framework import validate_config_against_schema
+from splunk_add_on_ucc_framework.global_config_validator import (
+    GlobalConfigValidator,
+    GlobalConfigValidatorException,
+)
+
+
+def _path_to_source_dir() -> str:
+    return os.path.join(
+        os.getcwd(),
+        "splunk_add_on_ucc_framework",
+    )
 
 
 class ConfigValidationTest(unittest.TestCase):
     def test_config_validation_when_valid_config_then_no_exception(self):
         config = helpers.get_testdata_file("valid_config.json")
         config = json.loads(config)
-        validate_config_against_schema(config)
+        validator = GlobalConfigValidator(_path_to_source_dir(), config)
+        validator.validate()
 
     def test_config_validation_when_invalid_config_then_exception(self):
         config = helpers.get_testdata_file("invalid_config_no_configuration_tabs.json")
         config = json.loads(config)
-        with self.assertRaises(jsonschema.ValidationError):
-            validate_config_against_schema(config)
+        validator = GlobalConfigValidator(_path_to_source_dir(), config)
+        with self.assertRaises(GlobalConfigValidatorException):
+            validator.validate()
+
+    def test_config_validation_when_configuration_tab_table_has_no_name_field(self):
+        config = helpers.get_testdata_file(
+            "invalid_config_no_name_field_in_configuration_tab_table.json"
+        )
+        config = json.loads(config)
+        validator = GlobalConfigValidator(_path_to_source_dir(), config)
+        with self.assertRaises(GlobalConfigValidatorException):
+            validator.validate()

--- a/tests/unit/testdata/invalid_config_no_name_field_in_configuration_tab_table.json
+++ b/tests/unit/testdata/invalid_config_no_name_field_in_configuration_tab_table.json
@@ -1,0 +1,436 @@
+{
+    "pages": {
+        "configuration": {
+            "tabs": [
+                {
+                    "name": "account",
+                    "table": {
+                        "actions": [
+                            "edit",
+                            "delete",
+                            "clone"
+                        ],
+                        "header": [
+                            {
+                                "label": "Name",
+                                "field": "name"
+                            },
+                            {
+                                "label": "Auth Type",
+                                "field": "auth_type"
+                            }
+                        ]
+                    },
+                    "entity": [
+                        {
+                            "type": "text",
+                            "label": "Name",
+                            "validators": [
+                                {
+                                    "type": "string",
+                                    "errorMsg": "Length of ID should be between 1 and 50",
+                                    "minLength": 1,
+                                    "maxLength": 50
+                                },
+                                {
+                                    "type": "regex",
+                                    "errorMsg": "Name must begin with a letter and consist exclusively of alphanumeric characters and underscores.",
+                                    "pattern": "^[a-zA-Z]\\w*$"
+                                }
+                            ],
+                            "options": {
+                                "placeholder": "Required"
+                            },
+                            "field": "not_a_name",
+                            "help": "Enter a unique name for this account.",
+                            "required": true
+                        },
+                        {
+                            "type": "singleSelect",
+                            "label": "Example Environment",
+                            "options": {
+                                "disableSearch": true,
+                                "autoCompleteFields": [
+                                    {
+                                        "value": "login.example.com",
+                                        "label": "Value1"
+                                    },
+                                    {
+                                        "value": "test.example.com",
+                                        "label": "Value2"
+                                    },
+                                    {
+                                        "value": "other",
+                                        "label": "Other"
+                                    }
+                                ],
+                                "display": true
+                            },
+                            "help": "",
+                            "field": "custom_endpoint",
+                            "defaultValue": "login.example.com",
+                            "required": true
+                        },
+                        {
+                            "type": "text",
+                            "label": "Endpoint URL",
+                            "help": "Enter the endpoint URL.",
+                            "field": "endpoint",
+                            "options": {
+                                "display": false
+                            }
+                        },
+                        {
+                            "type": "checkbox",
+                            "label": "Example Checkbox",
+                            "field": "account_checkbox",
+                            "help": "This is an example checkbox for the account entity"
+                        },
+                        {
+                            "type": "radio",
+                            "label": "Example Radio",
+                            "field": "account_radio",
+                            "defaultValue": "yes",
+                            "help": "This is an example radio button for the account entity",
+                            "required": true,
+                            "options": {
+                                "items": [
+                                    {
+                                        "value": "yes",
+                                        "label": "Yes"
+                                    },
+                                    {
+                                        "value": "no",
+                                        "label": "No"
+                                    }
+                                ],
+                                "display": true
+                            }
+                        },
+                        {
+                            "type": "multipleSelect",
+                            "label": "Example Multiple Select",
+                            "field": "account_multiple_select",
+                            "help": "This is an example multipleSelect for account entity",
+                            "required": true,
+                            "options": {
+                                "items": [
+                                    {
+                                        "value": "one",
+                                        "label": "Option One"
+                                    },
+                                    {
+                                        "value": "two",
+                                        "label": "Option Two"
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "type": "text",
+                            "label": "State",
+                            "help": "This is a boolean field for developers to decide whether state parameter will be passed in the OAuth flow. Value: true|false",
+                            "field": "oauth_state_enabled",
+                            "options": {
+                                "display": false
+                            }
+                        },
+                        {
+                            "type": "oauth",
+                            "field": "oauth",
+                            "label": "Not used",
+                            "options": {
+                                "auth_type": [
+                                    "basic",
+                                    "oauth"
+                                ],
+                                "basic": [
+                                    {
+                                        "oauth_field": "username",
+                                        "label": "Username",
+                                        "help": "Enter the username for this account.",
+                                        "field": "username"
+                                    },
+                                    {
+                                        "oauth_field": "password",
+                                        "label": "Password",
+                                        "encrypted": true,
+                                        "help": "Enter the password for this account.",
+                                        "field": "password"
+                                    },
+                                    {
+                                        "oauth_field": "security_token",
+                                        "label": "Security Token",
+                                        "encrypted": true,
+                                        "help": "Enter the security token.",
+                                        "field": "token"
+                                    }
+                                ],
+                                "oauth": [
+                                    {
+                                        "oauth_field": "client_id",
+                                        "label": "Client Id",
+                                        "field": "client_id",
+                                        "help": "Enter the Client Id for this account."
+                                    },
+                                    {
+                                        "oauth_field": "client_secret",
+                                        "label": "Client Secret",
+                                        "field": "client_secret",
+                                        "encrypted": true,
+                                        "help": "Enter the Client Secret key for this account."
+                                    },
+                                    {
+                                        "oauth_field": "redirect_url",
+                                        "label": "Redirect url",
+                                        "field": "redirect_url",
+                                        "help": "Copy and paste this URL into your app."
+                                    }
+                                ],
+                                "auth_code_endpoint": "/services/oauth2/authorize",
+                                "access_token_endpoint": "/services/oauth2/token",
+                                "oauth_timeout": 30
+                            }
+                        },
+                        {
+                            "field": "example_help_link",
+                            "label": "",
+                            "type": "helpLink",
+                            "options": {
+                                "text": "Help Link",
+                                "link": "https://docs.splunk.com/Documentation"
+                            }
+                        }
+                    ],
+                    "title": "Account"
+                },
+                {
+                    "name": "proxy",
+                    "entity": [
+                        {
+                            "type": "checkbox",
+                            "label": "Enable",
+                            "field": "proxy_enabled"
+                        },
+                        {
+                            "type": "singleSelect",
+                            "label": "Proxy Type",
+                            "options": {
+                                "disableSearch": true,
+                                "autoCompleteFields": [
+                                    {
+                                        "value": "http",
+                                        "label": "http"
+                                    },
+                                    {
+                                        "value": "socks4",
+                                        "label": "socks4"
+                                    },
+                                    {
+                                        "value": "socks5",
+                                        "label": "socks5"
+                                    }
+                                ]
+                            },
+                            "defaultValue": "http",
+                            "field": "proxy_type"
+                        },
+                        {
+                            "type": "text",
+                            "label": "Host",
+                            "validators": [
+                                {
+                                    "type": "string",
+                                    "errorMsg": "Max host length is 4096",
+                                    "minLength": 0,
+                                    "maxLength": 4096
+                                }
+                            ],
+                            "field": "proxy_url"
+                        },
+                        {
+                            "type": "text",
+                            "label": "Port",
+                            "validators": [
+                                {
+                                    "type": "number",
+                                    "range": [
+                                        1,
+                                        65535
+                                    ]
+                                }
+                            ],
+                            "field": "proxy_port"
+                        },
+                        {
+                            "type": "text",
+                            "label": "Username",
+                            "validators": [
+                                {
+                                    "type": "string",
+                                    "errorMsg": "Max length of username is 50",
+                                    "minLength": 0,
+                                    "maxLength": 50
+                                }
+                            ],
+                            "field": "proxy_username"
+                        },
+                        {
+                            "type": "text",
+                            "label": "Password",
+                            "validators": [
+                                {
+                                    "type": "string",
+                                    "errorMsg": "Max length of password is 8192",
+                                    "minLength": 0,
+                                    "maxLength": 8192
+                                }
+                            ],
+                            "encrypted": true,
+                            "field": "proxy_password"
+                        },
+                        {
+                            "type": "checkbox",
+                            "label": "Reverse DNS resolution",
+                            "field": "proxy_rdns"
+                        }
+                    ],
+                    "options": {
+                        "saveValidator": "function(formData) { if(!formData.proxy_enabled || formData.proxy_enabled === '0') {return true; } if(!formData.proxy_url) { return 'Proxy Host can not be empty'; } if(!formData.proxy_port) { return 'Proxy Port can not be empty'; } return true; }"
+                    },
+                    "title": "Proxy"
+                },
+                {
+                    "name": "logging",
+                    "entity": [
+                        {
+                            "type": "singleSelect",
+                            "label": "Log level",
+                            "options": {
+                                "disableSearch": true,
+                                "autoCompleteFields": [
+                                    {
+                                        "value": "DEBUG",
+                                        "label": "DEBUG"
+                                    },
+                                    {
+                                        "value": "INFO",
+                                        "label": "INFO"
+                                    },
+                                    {
+                                        "value": "WARNING",
+                                        "label": "WARNING"
+                                    },
+                                    {
+                                        "value": "ERROR",
+                                        "label": "ERROR"
+                                    },
+                                    {
+                                        "value": "CRITICAL",
+                                        "label": "CRITICAL"
+                                    }
+                                ]
+                            },
+                            "defaultValue": "INFO",
+                            "field": "loglevel"
+                        }
+                    ],
+                    "title": "Logging"
+                },
+                {
+                    "name": "custom_abc",
+                    "title": "Customized tab",
+                    "entity": [
+                        {
+                            "field": "testString",
+                            "label": "Test String",
+                            "type": "text",
+                            "validators": [
+                                {
+                                    "type": "string",
+                                    "maxLength": 10,
+                                    "minLength": 5
+                                }
+                            ]
+                        },
+                        {
+                            "field": "testNumber",
+                            "label": "Test number",
+                            "type": "text",
+                            "validators": [
+                                {
+                                    "type": "number",
+                                    "range": [
+                                        1,
+                                        10
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "field": "testRegex",
+                            "label": "Test regex",
+                            "type": "text",
+                            "validators": [
+                                {
+                                    "type": "regex",
+                                    "pattern": "^\\w+$",
+                                    "errorMsg": "Characters of Name should match regex ^\\w+$ ."
+                                }
+                            ]
+                        },
+                        {
+                            "field": "testEmail",
+                            "label": "Test Email",
+                            "type": "text",
+                            "validators": [
+                                {
+                                    "type": "email"
+                                }
+                            ]
+                        },
+                        {
+                            "field": "testIpv4",
+                            "label": "Test ipv4",
+                            "type": "text",
+                            "validators": [
+                                {
+                                    "type": "ipv4"
+                                }
+                            ]
+                        },
+                        {
+                            "field": "testDate",
+                            "label": "Test date",
+                            "type": "text",
+                            "validators": [
+                                {
+                                    "type": "date"
+                                }
+                            ]
+                        },
+                        {
+                            "field": "testUrl",
+                            "label": "Test url",
+                            "type": "text",
+                            "validators": [
+                                {
+                                    "type": "url"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ],
+            "title": "Configuration",
+            "description": "Set up your add-on"
+        }
+    },
+    "meta": {
+        "apiVersion": "3.2.0",
+        "name": "Splunk_TA_UCCExample",
+        "restRoot": "splunk_ta_uccexample",
+        "version": "1.0.0",
+        "displayName": "Splunk UCC test Add-on"
+    }
+}


### PR DESCRIPTION
Before this fix - `ucc-gen` generated add-on which did not work in Splunk.

Thanks to @guilhemmarchand for spotting this one.