### PR TITLE
fix: remove non-valid Python code

### DIFF
--- a/splunk_add_on_ucc_framework/modular_alert_builder/build_core/alert_actions_merge.py
+++ b/splunk_add_on_ucc_framework/modular_alert_builder/build_core/alert_actions_merge.py
@@ -84,7 +84,7 @@ def merge_conf_file(src_file, dst_file, merge_mode="stanza_overwrite"):
             if stanza not in dst_dict:
                 parser.add_section(stanza)
             else:
-                parser.remove_section(stanza, false)
+                parser.remove_section(stanza)
                 parser.add_section(stanza)
 
             for k, v in list(key_values.items()):


### PR DESCRIPTION
`conf_parser.remove_stanza` does not accept second parameter.