### PR TITLE
fix: overwrite of generated files by default ones

### DIFF
--- a/splunk_add_on_ucc_framework/__init__.py
+++ b/splunk_add_on_ucc_framework/__init__.py
@@ -721,6 +721,9 @@ def _generate(source, config, ta_version, outputdir=None):
         sys.exit(1)
     ta_name = manifest.get_addon_name()
 
+    logger.info("Copy package directory ")
+    recursive_overwrite(source, os.path.join(outputdir, ta_name))
+
     if os.path.exists(config):
         try:
             with open(config) as f_config:
@@ -802,8 +805,6 @@ def _generate(source, config, ta_version, outputdir=None):
         ta_name, os.path.abspath(os.path.join(source, PARENT_DIR, ".uccignore"))
     )
     remove_listed_files(ignore_list)
-    logger.info("Copy package directory ")
-    recursive_overwrite(source, os.path.join(outputdir, ta_name))
 
     # Update app.manifest
     with open(os.path.join(outputdir, ta_name, "VERSION"), "w") as version_file:

--- a/tests/data/package/default/inputs.conf
+++ b/tests/data/package/default/inputs.conf
@@ -1,0 +1,2 @@
+[example_input_one]
+python.version = python3

--- a/tests/expected_output/Splunk_TA_UCCExample/default/eventtypes.conf
+++ b/tests/expected_output/Splunk_TA_UCCExample/default/eventtypes.conf
@@ -2,3 +2,7 @@
 # Just something
 [UCC_NOT_GENERATED]
 search = index=_internal sourcetype=splunkd
+
+[test_alert_modaction_result]
+search = sourcetype="test:incident"
+

--- a/tests/expected_output/Splunk_TA_UCCExample/default/tags.conf
+++ b/tests/expected_output/Splunk_TA_UCCExample/default/tags.conf
@@ -2,3 +2,6 @@
 [eventtype=UCC_NOT_GENERATED]
 notalert = enabled
 
+[eventtype=test_alert_modaction_result]
+modaction_result = enabled
+


### PR DESCRIPTION
Before this PR - if you have 2 inputs in globalConfig.json and one
of them already exists in inputs.conf, ucc-gen will not create second
input in the end, because generated inputs.conf would be overwritten
by copying the package folder.

As a sideeffect of this fix - modular alerts configuration files are
now properly generated.