### PR TITLE
fix: dump dunamai to 1.5.5 version

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -365,7 +365,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pyt
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "48f9baac751c5b69910166f33a40729bacc817a7db579b589b52aa389140f4b6"
+content-hash = "f15c8c9e1526b3e417aa8fd0e52b583270f11a189497e67d65e555a3129535bb"
 
 [metadata.files]
 appdirs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,9 +56,9 @@ python = "^3.7"
 jinja2 = ">=2,<4"
 lxml = "^4.3"
 wheel = "*"
-dunamai = "*"
 defusedxml = "^0.7.1"
 jsonschema = "^3.2.0"
+dunamai = "1.5.5"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2"


### PR DESCRIPTION
Having "*" in pyproject.toml for dunamai leads to installation
of the latest version after running `poetry build`. Lock file is
ignored in this case.

And in case of new dunamai release the new version will be installed
which can break everything.

Related issue: https://github.com/python-poetry/poetry/issues/1307