### PR TITLE
fix: Dont remove  jsonschema metadata files

### DIFF
--- a/splunk_add_on_ucc_framework/__init__.py
+++ b/splunk_add_on_ucc_framework/__init__.py
@@ -365,9 +365,17 @@ def remove_files(path):
         path (str): Path to remove *.egg-info and *.dist-info files.
     """
 
-    rmdirs = glob.glob(os.path.join(path, "*.egg-info")) + glob.glob(
-        os.path.join(path, "*.dist-info")
-    )
+    delete_list = ["*.egg-info", "*.dist-info"]
+    # the jsonschema is not working when metadata files are not present hence not removing jsonschema dist-info/egg-info directory
+    do_not_delete_list = ["jsonschema-*"]
+
+    rmdirs = set()
+    for item in delete_list:
+        rmdirs.update(set(glob.glob(os.path.join(path, item))))
+    
+    for item in do_not_delete_list:
+        rmdirs.difference_update(set(glob.glob(os.path.join(path, item))))
+
     for rmdir in rmdirs:
         shutil.rmtree(rmdir)
 

--- a/splunk_add_on_ucc_framework/__init__.py
+++ b/splunk_add_on_ucc_framework/__init__.py
@@ -309,7 +309,6 @@ def install_libs(path, ucc_lib_target):
             )
             os.system(installer + " -m pip install pip --upgrade")
             os.system(install_cmd)
-            remove_files(ucc_target)
 
     logging.info(f"  Checking for requirements in {path}")
     if os.path.exists(os.path.join(path, "lib", "requirements.txt")):
@@ -355,29 +354,6 @@ def install_libs(path, ucc_lib_target):
             logging.info(f"  fixing {o} execute bit")
             current_permissions = stat.S_IMODE(os.lstat(o).st_mode)
             os.chmod(o, current_permissions & NO_EXEC)
-
-
-def remove_files(path):
-    """
-    Remove *.egg-info and *.dist-info files in given path.
-
-    Args:
-        path (str): Path to remove *.egg-info and *.dist-info files.
-    """
-
-    delete_list = ["*.egg-info", "*.dist-info"]
-    # the jsonschema is not working when metadata files are not present hence not removing jsonschema dist-info/egg-info directory
-    do_not_delete_list = ["jsonschema-*"]
-
-    rmdirs = set()
-    for item in delete_list:
-        rmdirs.update(set(glob.glob(os.path.join(path, item))))
-    
-    for item in do_not_delete_list:
-        rmdirs.difference_update(set(glob.glob(os.path.join(path, item))))
-
-    for rmdir in rmdirs:
-        shutil.rmtree(rmdir)
 
 
 def generate_rest(ta_name, scheme, import_declare_name, outputdir):


### PR DESCRIPTION
The jsonschema is not working if we delete the metadata files.
```
  File "import_declare_test.py", line 12, in <module>
    from jsonschema import validate
  File "/opt/splunk2/etc/apps/Splunk_TA_salesforce/lib/jsonschema/__init__.py", line 34, in <module>
    __version__ = metadata.version("jsonschema")
  File "/opt/splunk2/etc/apps/Splunk_TA_salesforce/lib/importlib_metadata/__init__.py", line 957, in version
    return distribution(distribution_name).version
  File "/opt/splunk2/etc/apps/Splunk_TA_salesforce/lib/importlib_metadata/__init__.py", line 930, in distribution
    return Distribution.from_name(distribution_name)
  File "/opt/splunk2/etc/apps/Splunk_TA_salesforce/lib/importlib_metadata/__init__.py", line 524, in from_name
    raise PackageNotFoundError(name)
importlib_metadata.PackageNotFoundError: No package metadata was found for jsonschema
```

The latest jsonschema library requires metadata files in order to work correctly. (Ref: https://jira.splunk.com/browse/ADDON-23349)

Changes:
* Don't remove jsonschema metadata files




