### PR TITLE
fix: checking pyproject.toml file before releasing

### DIFF
--- a/.github/workflows/sr-prepare.sh
+++ b/.github/workflows/sr-prepare.sh
@@ -2,5 +2,6 @@
 
 set -eE
 set -v
+# shellcheck disable=SC1091,SC2086
 source $HOME/.poetry/env
 poetry build

--- a/.github/workflows/sr-prepare.sh
+++ b/.github/workflows/sr-prepare.sh
@@ -3,5 +3,4 @@
 set -eE
 set -v
 source $HOME/.poetry/env
-poetry version $1
 poetry build

--- a/.releaserc
+++ b/.releaserc
@@ -57,9 +57,9 @@
               "results": [
                 {
                   "file": "pyproject.toml",
-                  "hasChanged": true,
+                  "hasChanged": false,
                   "numMatches": 1,
-                  "numReplacements": 1
+                  "numReplacements": 0
                 }
               ],
               "countMatches": true

--- a/.releaserc
+++ b/.releaserc
@@ -23,22 +23,13 @@
   plugins:
     [
       "@semantic-release/commit-analyzer",
-      "@semantic-release/release-notes-generator",
-      [
-        "@semantic-release/exec",
-        {
-          "prepareCmd": "./.github/workflows/sr-prepare.sh ${nextRelease.version}",
-          "publishCmd": "./.github/workflows/sr-release.sh",
-          "shell": "bash"
-        },
-      ],
       [
         "@google/semantic-release-replace-plugin",
         {
           "replacements": [
             {
               "files": ["splunk_add_on_ucc_framework/__init__.py"],
-              "from": "__version__ = \".*\"",
+              "from": "__version__ ?=.*",
               "to": "__version__ = \"${nextRelease.version}\"",
               "results": [
                 {
@@ -52,20 +43,29 @@
             },
             {
               "files": ["pyproject.toml"],
-              "from": "version = \".*\"",
+              "from": "version ?=.*",
               "to": "version = \"${nextRelease.version}\"",
               "results": [
                 {
                   "file": "pyproject.toml",
-                  "hasChanged": false,
+                  "hasChanged": True,
                   "numMatches": 1,
-                  "numReplacements": 0
+                  "numReplacements": 1
                 }
               ],
               "countMatches": true
             }
           ]
         }
+      ],
+      "@semantic-release/release-notes-generator",
+      [
+        "@semantic-release/exec",
+        {
+          "prepareCmd": "./.github/workflows/sr-prepare.sh ${nextRelease.version}",
+          "publishCmd": "./.github/workflows/sr-release.sh",
+          "shell": "bash"
+        },
       ],
       [
         "@semantic-release/git",

--- a/.releaserc
+++ b/.releaserc
@@ -48,7 +48,7 @@
               "results": [
                 {
                   "file": "pyproject.toml",
-                  "hasChanged": True,
+                  "hasChanged": true,
                   "numMatches": 1,
                   "numReplacements": 1
                 }

--- a/splunk_add_on_ucc_framework/uccrestbuilder/__init__.py
+++ b/splunk_add_on_ucc_framework/uccrestbuilder/__init__.py
@@ -30,9 +30,6 @@ __all__ = [
     "build",
 ]
 
-__version__ = "0.0.0"
-
-
 RestHandlerClass = collections.namedtuple(
     "RestHandlerClass",
     ("module", "name"),


### PR DESCRIPTION
pyproject.toml file has been changed after running sr-prepare.sh file
and already contains updated version in it. So, no need to change the
version in .releaserc. We need only to check it.

Closes #315.