### PR TITLE
refactor: cElementTree is deprecated

### DIFF
--- a/splunk_add_on_ucc_framework/__init__.py
+++ b/splunk_add_on_ucc_framework/__init__.py
@@ -26,7 +26,7 @@ import stat
 import sys
 from pathlib import Path
 
-from defusedxml import cElementTree as defused_et
+from defusedxml import ElementTree as defused_et
 from dunamai import Style, Version
 from jinja2 import Environment, FileSystemLoader
 


### PR DESCRIPTION
defusedxml.cElementTree is deprecated
```
splunk_add_on_ucc_framework/__init__.py:29
  /Users/arys/src/addonfactory-ucc-generator/splunk_add_on_ucc_framework/__init__.py:29: DeprecationWarning: defusedxml.cElementTree is deprecated, import from defusedxml.ElementTree instead.
    from defusedxml import cElementTree as defused_et
```