### PR TITLE
ci: add pre-commit step

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -131,6 +131,14 @@ jobs:
         with:
           app_path: tests/slimmed
           included_tags: ${{ matrix.tags }}
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.7"
+      - uses: pre-commit/action@v2.0.3
   lint:
     runs-on: ubuntu-latest
     name: Lint Code Base

--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -139,24 +139,6 @@ jobs:
         with:
           python-version: "3.7"
       - uses: pre-commit/action@v2.0.3
-  lint:
-    runs-on: ubuntu-latest
-    name: Lint Code Base
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          # Full git history is needed to get a proper list of changed files within `super-linter`
-          fetch-depth: 0
-      - name: Lint Code Base
-        uses: docker://ghcr.io/github/super-linter:slim-v4
-        env:
-          DEFAULT_BRANCH: main
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-          VALIDATE_ALL_CODEBASE: false
-          LINTER_RULES_PATH: /
-          PYTHON_ISORT_CONFIG_FILE: pyproject.toml
-          FILTER_REGEX_EXCLUDE: .*tests/expected_output.*
   semgrep:
     runs-on: ubuntu-latest
     name: security-sast-semgrep


### PR DESCRIPTION
This PR adds `pre-commit` step to CI and removes Github's `super-linter` step.

Reasons:
1. `pre-commit` is faster (at least 2 times, even with slim `super-linter` Docker image)
2. No need to keep 2 configurations (for `pre-commit` and for `super-linter`)
3. `pre-commit` is easier to run locally
4. This repository mostly has Python files and `pre-commit` should be sufficient.