### PR TITLE
ci: use install-poetry.py instead of get-poetry.py

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -62,7 +62,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install Poetry
-        run: curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3 -
+        run: curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | python3 -
       - name: Get UI Base
         run: |
           ./get-ucc-ui.sh
@@ -183,7 +183,7 @@ jobs:
         with:
           python-version: "3.7"
       - name: Install Poetry
-        run: curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3 -
+        run: curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/install-poetry.py | python3 -
       - name: Get UI Base
         run: |
           ./get-ucc-ui.sh


### PR DESCRIPTION
More details: https://python-poetry.org/blog/announcing-poetry-1.2.0a1/