### PR TITLE
fix: remove generation of `expose:_splunkd_data` stanza in web.conf

### DIFF
--- a/splunk_add_on_ucc_framework/uccrestbuilder/rest_conf.py
+++ b/splunk_add_on_ucc_framework/uccrestbuilder/rest_conf.py
@@ -71,12 +71,6 @@ pattern = {name}/*
 methods = POST, GET, DELETE
 """
 
-    _internal_template = """
-[expose:{name}]
-pattern = {endpoint}
-methods = GET
-"""
-
     @classmethod
     def build(cls, endpoints):
         stanzas = []
@@ -93,8 +87,4 @@ methods = GET
                     name=endpoint.name,
                 )
             )
-        # add splunkd data endpoint
-        stanzas.append(
-            cls._internal_template.format(name="_splunkd_data", endpoint="data/*")
-        )
         return "".join(stanzas)

--- a/tests/expected_output_global_config_configuration/Splunk_TA_UCCExample/default/web.conf
+++ b/tests/expected_output_global_config_configuration/Splunk_TA_UCCExample/default/web.conf
@@ -22,7 +22,3 @@ methods = POST, GET
 [expose:splunk_ta_uccexample_settings_specified]
 pattern = splunk_ta_uccexample_settings/*
 methods = POST, GET, DELETE
-
-[expose:_splunkd_data]
-pattern = data/*
-methods = GET

--- a/tests/expected_output_global_config_inputs_configuration_alerts/Splunk_TA_UCCExample/default/web.conf
+++ b/tests/expected_output_global_config_inputs_configuration_alerts/Splunk_TA_UCCExample/default/web.conf
@@ -38,7 +38,3 @@ methods = POST, GET
 [expose:splunk_ta_uccexample_example_input_two_specified]
 pattern = splunk_ta_uccexample_example_input_two/*
 methods = POST, GET, DELETE
-
-[expose:_splunkd_data]
-pattern = data/*
-methods = GET


### PR DESCRIPTION
This commit removes generation of
```
[expose:_splunkd_data]
pattern = data/*
methods = GET
```
for `web.conf`.

Closes #303.