### PR TITLE
fix: update ucc ui version to 1.9.1

### DIFF
--- a/.ucc-ui-version
+++ b/.ucc-ui-version
@@ -1,2 +1,2 @@
-#https://github.com/splunk/addonfactory-ucc-base-ui/releases/download/v1.9.0/splunk-ucc-ui.tgz
-VERSION=v1.9.0
+#https://github.com/splunk/addonfactory-ucc-base-ui/releases/download/v1.9.1/splunk-ucc-ui.tgz
+VERSION=v1.9.1


### PR DESCRIPTION
### Bug Fixes

* resolve missed `type` param for custom input row feature ([#84](https://github.com/splunk/addonfactory-ucc-base-ui/issues/84)) ([6bc9e13](https://github.com/splunk/addonfactory-ucc-base-ui/commit/6bc9e138568a305521f236ada96e16b33438b033))