### PR TITLE
test: move all tests to pytest

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -38,7 +38,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "coverage"
-version = "6.3.1"
+version = "6.3.2"
 description = "Code coverage measurement for Python"
 category = "dev"
 optional = false
@@ -163,17 +163,6 @@ python-versions = ">=3.6"
 pyparsing = ">=2.0.2,<3"
 
 [[package]]
-name = "parameterized"
-version = "0.8.1"
-description = "Parameterized testing with any Python test framework"
-category = "dev"
-optional = false
-python-versions = "*"
-
-[package.extras]
-dev = ["jinja2"]
-
-[[package]]
 name = "pluggy"
 version = "1.0.0"
 description = "plugin and hook calling mechanisms for python"
@@ -280,7 +269,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "a5071ddcaad7157156cefe03f19c623d60f099f02ecb73f5e68026a0e86d6beb"
+content-hash = "97ba925c48ae4eb4d9a34db2b65f06297b49136aaa67f24a15867958432eed3f"
 
 [metadata.files]
 addonfactory-splunk-conf-parser-lib = [
@@ -300,47 +289,47 @@ colorama = [
     {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
 ]
 coverage = [
-    {file = "coverage-6.3.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:eeffd96882d8c06d31b65dddcf51db7c612547babc1c4c5db6a011abe9798525"},
-    {file = "coverage-6.3.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:621f6ea7260ea2ffdaec64fe5cb521669984f567b66f62f81445221d4754df4c"},
-    {file = "coverage-6.3.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:84f2436d6742c01136dd940ee158bfc7cf5ced3da7e4c949662b8703b5cd8145"},
-    {file = "coverage-6.3.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:de73fca6fb403dd72d4da517cfc49fcf791f74eee697d3219f6be29adf5af6ce"},
-    {file = "coverage-6.3.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:78fbb2be068a13a5d99dce9e1e7d168db880870f7bc73f876152130575bd6167"},
-    {file = "coverage-6.3.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:f5a4551dfd09c3bd12fca8144d47fe7745275adf3229b7223c2f9e29a975ebda"},
-    {file = "coverage-6.3.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:7bff3a98f63b47464480de1b5bdd80c8fade0ba2832c9381253c9b74c4153c27"},
-    {file = "coverage-6.3.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:a06c358f4aed05fa1099c39decc8022261bb07dfadc127c08cfbd1391b09689e"},
-    {file = "coverage-6.3.1-cp310-cp310-win32.whl", hash = "sha256:9fff3ff052922cb99f9e52f63f985d4f7a54f6b94287463bc66b7cdf3eb41217"},
-    {file = "coverage-6.3.1-cp310-cp310-win_amd64.whl", hash = "sha256:276b13cc085474e482566c477c25ed66a097b44c6e77132f3304ac0b039f83eb"},
-    {file = "coverage-6.3.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:56c4a409381ddd7bbff134e9756077860d4e8a583d310a6f38a2315b9ce301d0"},
-    {file = "coverage-6.3.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9eb494070aa060ceba6e4bbf44c1bc5fa97bfb883a0d9b0c9049415f9e944793"},
-    {file = "coverage-6.3.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5e15d424b8153756b7c903bde6d4610be0c3daca3986173c18dd5c1a1625e4cd"},
-    {file = "coverage-6.3.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:61d47a897c1e91f33f177c21de897267b38fbb45f2cd8e22a710bcef1df09ac1"},
-    {file = "coverage-6.3.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:25e73d4c81efa8ea3785274a2f7f3bfbbeccb6fcba2a0bdd3be9223371c37554"},
-    {file = "coverage-6.3.1-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:fac0bcc5b7e8169bffa87f0dcc24435446d329cbc2b5486d155c2e0f3b493ae1"},
-    {file = "coverage-6.3.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:72128176fea72012063200b7b395ed8a57849282b207321124d7ff14e26988e8"},
-    {file = "coverage-6.3.1-cp37-cp37m-win32.whl", hash = "sha256:1bc6d709939ff262fd1432f03f080c5042dc6508b6e0d3d20e61dd045456a1a0"},
-    {file = "coverage-6.3.1-cp37-cp37m-win_amd64.whl", hash = "sha256:618eeba986cea7f621d8607ee378ecc8c2504b98b3fdc4952b30fe3578304687"},
-    {file = "coverage-6.3.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:d5ed164af5c9078596cfc40b078c3b337911190d3faeac830c3f1274f26b8320"},
-    {file = "coverage-6.3.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:352c68e233409c31048a3725c446a9e48bbff36e39db92774d4f2380d630d8f8"},
-    {file = "coverage-6.3.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:448d7bde7ceb6c69e08474c2ddbc5b4cd13c9e4aa4a717467f716b5fc938a734"},
-    {file = "coverage-6.3.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9fde6b90889522c220dd56a670102ceef24955d994ff7af2cb786b4ba8fe11e4"},
-    {file = "coverage-6.3.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e647a0be741edbb529a72644e999acb09f2ad60465f80757da183528941ff975"},
-    {file = "coverage-6.3.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:6a5cdc3adb4f8bb8d8f5e64c2e9e282bc12980ef055ec6da59db562ee9bdfefa"},
-    {file = "coverage-6.3.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:2dd70a167843b4b4b2630c0c56f1b586fe965b4f8ac5da05b6690344fd065c6b"},
-    {file = "coverage-6.3.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:9ad0a117b8dc2061ce9461ea4c1b4799e55edceb236522c5b8f958ce9ed8fa9a"},
-    {file = "coverage-6.3.1-cp38-cp38-win32.whl", hash = "sha256:e92c7a5f7d62edff50f60a045dc9542bf939758c95b2fcd686175dd10ce0ed10"},
-    {file = "coverage-6.3.1-cp38-cp38-win_amd64.whl", hash = "sha256:482fb42eea6164894ff82abbcf33d526362de5d1a7ed25af7ecbdddd28fc124f"},
-    {file = "coverage-6.3.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:c5b81fb37db76ebea79aa963b76d96ff854e7662921ce742293463635a87a78d"},
-    {file = "coverage-6.3.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:a4f923b9ab265136e57cc14794a15b9dcea07a9c578609cd5dbbfff28a0d15e6"},
-    {file = "coverage-6.3.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:56d296cbc8254a7dffdd7bcc2eb70be5a233aae7c01856d2d936f5ac4e8ac1f1"},
-    {file = "coverage-6.3.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1245ab82e8554fa88c4b2ab1e098ae051faac5af829efdcf2ce6b34dccd5567c"},
-    {file = "coverage-6.3.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3f2b05757c92ad96b33dbf8e8ec8d4ccb9af6ae3c9e9bd141c7cc44d20c6bcba"},
-    {file = "coverage-6.3.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:9e3dd806f34de38d4c01416344e98eab2437ac450b3ae39c62a0ede2f8b5e4ed"},
-    {file = "coverage-6.3.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:d651fde74a4d3122e5562705824507e2f5b2d3d57557f1916c4b27635f8fbe3f"},
-    {file = "coverage-6.3.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:704f89b87c4f4737da2860695a18c852b78ec7279b24eedacab10b29067d3a38"},
-    {file = "coverage-6.3.1-cp39-cp39-win32.whl", hash = "sha256:2aed4761809640f02e44e16b8b32c1a5dee5e80ea30a0ff0912158bde9c501f2"},
-    {file = "coverage-6.3.1-cp39-cp39-win_amd64.whl", hash = "sha256:9976fb0a5709988778ac9bc44f3d50fccd989987876dfd7716dee28beed0a9fa"},
-    {file = "coverage-6.3.1-pp36.pp37.pp38-none-any.whl", hash = "sha256:463e52616ea687fd323888e86bf25e864a3cc6335a043fad6bbb037dbf49bbe2"},
-    {file = "coverage-6.3.1.tar.gz", hash = "sha256:6c3f6158b02ac403868eea390930ae64e9a9a2a5bbfafefbb920d29258d9f2f8"},
+    {file = "coverage-6.3.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:9b27d894748475fa858f9597c0ee1d4829f44683f3813633aaf94b19cb5453cf"},
+    {file = "coverage-6.3.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:37d1141ad6b2466a7b53a22e08fe76994c2d35a5b6b469590424a9953155afac"},
+    {file = "coverage-6.3.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f9987b0354b06d4df0f4d3e0ec1ae76d7ce7cbca9a2f98c25041eb79eec766f1"},
+    {file = "coverage-6.3.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:26e2deacd414fc2f97dd9f7676ee3eaecd299ca751412d89f40bc01557a6b1b4"},
+    {file = "coverage-6.3.2-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4dd8bafa458b5c7d061540f1ee9f18025a68e2d8471b3e858a9dad47c8d41903"},
+    {file = "coverage-6.3.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:46191097ebc381fbf89bdce207a6c107ac4ec0890d8d20f3360345ff5976155c"},
+    {file = "coverage-6.3.2-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:6f89d05e028d274ce4fa1a86887b071ae1755082ef94a6740238cd7a8178804f"},
+    {file = "coverage-6.3.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:58303469e9a272b4abdb9e302a780072c0633cdcc0165db7eec0f9e32f901e05"},
+    {file = "coverage-6.3.2-cp310-cp310-win32.whl", hash = "sha256:2fea046bfb455510e05be95e879f0e768d45c10c11509e20e06d8fcaa31d9e39"},
+    {file = "coverage-6.3.2-cp310-cp310-win_amd64.whl", hash = "sha256:a2a8b8bcc399edb4347a5ca8b9b87e7524c0967b335fbb08a83c8421489ddee1"},
+    {file = "coverage-6.3.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:f1555ea6d6da108e1999b2463ea1003fe03f29213e459145e70edbaf3e004aaa"},
+    {file = "coverage-6.3.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e5f4e1edcf57ce94e5475fe09e5afa3e3145081318e5fd1a43a6b4539a97e518"},
+    {file = "coverage-6.3.2-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7a15dc0a14008f1da3d1ebd44bdda3e357dbabdf5a0b5034d38fcde0b5c234b7"},
+    {file = "coverage-6.3.2-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:21b7745788866028adeb1e0eca3bf1101109e2dc58456cb49d2d9b99a8c516e6"},
+    {file = "coverage-6.3.2-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:8ce257cac556cb03be4a248d92ed36904a59a4a5ff55a994e92214cde15c5bad"},
+    {file = "coverage-6.3.2-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:b0be84e5a6209858a1d3e8d1806c46214e867ce1b0fd32e4ea03f4bd8b2e3359"},
+    {file = "coverage-6.3.2-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:acf53bc2cf7282ab9b8ba346746afe703474004d9e566ad164c91a7a59f188a4"},
+    {file = "coverage-6.3.2-cp37-cp37m-win32.whl", hash = "sha256:8bdde1177f2311ee552f47ae6e5aa7750c0e3291ca6b75f71f7ffe1f1dab3dca"},
+    {file = "coverage-6.3.2-cp37-cp37m-win_amd64.whl", hash = "sha256:b31651d018b23ec463e95cf10070d0b2c548aa950a03d0b559eaa11c7e5a6fa3"},
+    {file = "coverage-6.3.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:07e6db90cd9686c767dcc593dff16c8c09f9814f5e9c51034066cad3373b914d"},
+    {file = "coverage-6.3.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:2c6dbb42f3ad25760010c45191e9757e7dce981cbfb90e42feef301d71540059"},
+    {file = "coverage-6.3.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c76aeef1b95aff3905fb2ae2d96e319caca5b76fa41d3470b19d4e4a3a313512"},
+    {file = "coverage-6.3.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8cf5cfcb1521dc3255d845d9dca3ff204b3229401994ef8d1984b32746bb45ca"},
+    {file = "coverage-6.3.2-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8fbbdc8d55990eac1b0919ca69eb5a988a802b854488c34b8f37f3e2025fa90d"},
+    {file = "coverage-6.3.2-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:ec6bc7fe73a938933d4178c9b23c4e0568e43e220aef9472c4f6044bfc6dd0f0"},
+    {file = "coverage-6.3.2-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:9baff2a45ae1f17c8078452e9e5962e518eab705e50a0aa8083733ea7d45f3a6"},
+    {file = "coverage-6.3.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:fd9e830e9d8d89b20ab1e5af09b32d33e1a08ef4c4e14411e559556fd788e6b2"},
+    {file = "coverage-6.3.2-cp38-cp38-win32.whl", hash = "sha256:f7331dbf301b7289013175087636bbaf5b2405e57259dd2c42fdcc9fcc47325e"},
+    {file = "coverage-6.3.2-cp38-cp38-win_amd64.whl", hash = "sha256:68353fe7cdf91f109fc7d474461b46e7f1f14e533e911a2a2cbb8b0fc8613cf1"},
+    {file = "coverage-6.3.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:b78e5afb39941572209f71866aa0b206c12f0109835aa0d601e41552f9b3e620"},
+    {file = "coverage-6.3.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:4e21876082ed887baed0146fe222f861b5815455ada3b33b890f4105d806128d"},
+    {file = "coverage-6.3.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:34626a7eee2a3da12af0507780bb51eb52dca0e1751fd1471d0810539cefb536"},
+    {file = "coverage-6.3.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1ebf730d2381158ecf3dfd4453fbca0613e16eaa547b4170e2450c9707665ce7"},
+    {file = "coverage-6.3.2-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:dd6fe30bd519694b356cbfcaca9bd5c1737cddd20778c6a581ae20dc8c04def2"},
+    {file = "coverage-6.3.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:96f8a1cb43ca1422f36492bebe63312d396491a9165ed3b9231e778d43a7fca4"},
+    {file = "coverage-6.3.2-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:dd035edafefee4d573140a76fdc785dc38829fe5a455c4bb12bac8c20cfc3d69"},
+    {file = "coverage-6.3.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:5ca5aeb4344b30d0bec47481536b8ba1181d50dbe783b0e4ad03c95dc1296684"},
+    {file = "coverage-6.3.2-cp39-cp39-win32.whl", hash = "sha256:f5fa5803f47e095d7ad8443d28b01d48c0359484fec1b9d8606d0e3282084bc4"},
+    {file = "coverage-6.3.2-cp39-cp39-win_amd64.whl", hash = "sha256:9548f10d8be799551eb3a9c74bbf2b4934ddb330e08a73320123c07f95cc2d92"},
+    {file = "coverage-6.3.2-pp36.pp37.pp38-none-any.whl", hash = "sha256:18d520c6860515a771708937d2f78f63cc47ab3b80cb78e86573b0a760161faf"},
+    {file = "coverage-6.3.2.tar.gz", hash = "sha256:03e2a7826086b91ef345ff18742ee9fc47a6839ccd517061ef8fa1976e652ce9"},
 ]
 defusedxml = [
     {file = "defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61"},
@@ -371,28 +360,12 @@ jsonschema = [
     {file = "jsonschema-4.3.3.tar.gz", hash = "sha256:f210d4ce095ed1e8af635d15c8ee79b586f656ab54399ba87b8ab87e5bff0ade"},
 ]
 markupsafe = [
-    {file = "MarkupSafe-2.0.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d8446c54dc28c01e5a2dbac5a25f071f6653e6e40f3a8818e8b45d790fe6ef53"},
-    {file = "MarkupSafe-2.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:36bc903cbb393720fad60fc28c10de6acf10dc6cc883f3e24ee4012371399a38"},
-    {file = "MarkupSafe-2.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2d7d807855b419fc2ed3e631034685db6079889a1f01d5d9dac950f764da3dad"},
-    {file = "MarkupSafe-2.0.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:add36cb2dbb8b736611303cd3bfcee00afd96471b09cda130da3581cbdc56a6d"},
-    {file = "MarkupSafe-2.0.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:168cd0a3642de83558a5153c8bd34f175a9a6e7f6dc6384b9655d2697312a646"},
-    {file = "MarkupSafe-2.0.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:4dc8f9fb58f7364b63fd9f85013b780ef83c11857ae79f2feda41e270468dd9b"},
-    {file = "MarkupSafe-2.0.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:20dca64a3ef2d6e4d5d615a3fd418ad3bde77a47ec8a23d984a12b5b4c74491a"},
-    {file = "MarkupSafe-2.0.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:cdfba22ea2f0029c9261a4bd07e830a8da012291fbe44dc794e488b6c9bb353a"},
-    {file = "MarkupSafe-2.0.1-cp310-cp310-win32.whl", hash = "sha256:99df47edb6bda1249d3e80fdabb1dab8c08ef3975f69aed437cb69d0a5de1e28"},
-    {file = "MarkupSafe-2.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:e0f138900af21926a02425cf736db95be9f4af72ba1bb21453432a07f6082134"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f9081981fe268bd86831e5c75f7de206ef275defcb82bc70740ae6dc507aee51"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:0955295dd5eec6cb6cc2fe1698f4c6d84af2e92de33fbcac4111913cd100a6ff"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:0446679737af14f45767963a1a9ef7620189912317d095f2d9ffa183a4d25d2b"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:f826e31d18b516f653fe296d967d700fddad5901ae07c622bb3705955e1faa94"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:fa130dd50c57d53368c9d59395cb5526eda596d3ffe36666cd81a44d56e48872"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:905fec760bd2fa1388bb5b489ee8ee5f7291d692638ea5f67982d968366bef9f"},
-    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bf5d821ffabf0ef3533c39c518f3357b171a1651c1ff6827325e4489b0e46c3c"},
-    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:0d4b31cc67ab36e3392bbf3862cfbadac3db12bdd8b02a2731f509ed5b829724"},
-    {file = "MarkupSafe-2.0.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:baa1a4e8f868845af802979fcdbf0bb11f94f1cb7ced4c4b8a351bb60d108145"},
-    {file = "MarkupSafe-2.0.1-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:deb993cacb280823246a026e3b2d81c493c53de6acfd5e6bfe31ab3402bb37dd"},
-    {file = "MarkupSafe-2.0.1-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:63f3268ba69ace99cab4e3e3b5840b03340efed0948ab8f78d2fd87ee5442a4f"},
-    {file = "MarkupSafe-2.0.1-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:8d206346619592c6200148b01a2142798c989edcb9c896f9ac9722a99d4e77e6"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-win32.whl", hash = "sha256:6c4ca60fa24e85fe25b912b01e62cb969d69a23a5d5867682dd3e80b5b02581d"},
     {file = "MarkupSafe-2.0.1-cp36-cp36m-win_amd64.whl", hash = "sha256:b2f4bf27480f5e5e8ce285a8c8fd176c0b03e93dcc6646477d4630e83440c6a9"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:0717a7390a68be14b8c793ba258e075c6f4ca819f15edfc2a3a027c823718567"},
@@ -401,27 +374,14 @@ markupsafe = [
     {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:d7f9850398e85aba693bb640262d3611788b1f29a79f0c93c565694658f4071f"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:6a7fae0dd14cf60ad5ff42baa2e95727c3d81ded453457771d02b7d2b3f9c0c2"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:b7f2d075102dc8c794cbde1947378051c4e5180d52d276987b8d28a3bd58c17d"},
-    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e9936f0b261d4df76ad22f8fee3ae83b60d7c3e871292cd42f40b81b70afae85"},
-    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:2a7d351cbd8cfeb19ca00de495e224dea7e7d919659c2841bbb7f420ad03e2d6"},
-    {file = "MarkupSafe-2.0.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:60bf42e36abfaf9aff1f50f52644b336d4f0a3fd6d8a60ca0d054ac9f713a864"},
-    {file = "MarkupSafe-2.0.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:d6c7ebd4e944c85e2c3421e612a7057a2f48d478d79e61800d81468a8d842207"},
-    {file = "MarkupSafe-2.0.1-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:f0567c4dc99f264f49fe27da5f735f414c4e7e7dd850cfd8e69f0862d7c74ea9"},
-    {file = "MarkupSafe-2.0.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:89c687013cb1cd489a0f0ac24febe8c7a666e6e221b783e53ac50ebf68e45d86"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-win32.whl", hash = "sha256:a30e67a65b53ea0a5e62fe23682cfe22712e01f453b95233b25502f7c61cb415"},
     {file = "MarkupSafe-2.0.1-cp37-cp37m-win_amd64.whl", hash = "sha256:611d1ad9a4288cf3e3c16014564df047fe08410e628f89805e475368bd304914"},
-    {file = "MarkupSafe-2.0.1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:5bb28c636d87e840583ee3adeb78172efc47c8b26127267f54a9c0ec251d41a9"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:be98f628055368795d818ebf93da628541e10b75b41c559fdf36d104c5787066"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:1d609f577dc6e1aa17d746f8bd3c31aa4d258f4070d61b2aa5c4166c1539de35"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:7d91275b0245b1da4d4cfa07e0faedd5b0812efc15b702576d103293e252af1b"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:01a9b8ea66f1658938f65b93a85ebe8bc016e6769611be228d797c9d998dd298"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:47ab1e7b91c098ab893b828deafa1203de86d0bc6ab587b160f78fe6c4011f75"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:97383d78eb34da7e1fa37dd273c20ad4320929af65d156e35a5e2d89566d9dfb"},
-    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6fcf051089389abe060c9cd7caa212c707e58153afa2c649f00346ce6d260f1b"},
-    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:5855f8438a7d1d458206a2466bf82b0f104a3724bf96a1c781ab731e4201731a"},
-    {file = "MarkupSafe-2.0.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:3dd007d54ee88b46be476e293f48c85048603f5f516008bee124ddd891398ed6"},
-    {file = "MarkupSafe-2.0.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:aca6377c0cb8a8253e493c6b451565ac77e98c2951c45f913e0b52facdcff83f"},
-    {file = "MarkupSafe-2.0.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:04635854b943835a6ea959e948d19dcd311762c5c0c6e1f0e16ee57022669194"},
-    {file = "MarkupSafe-2.0.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:6300b8454aa6930a24b9618fbb54b5a68135092bc666f7b06901f897fa5c2fee"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-win32.whl", hash = "sha256:023cb26ec21ece8dc3907c0e8320058b2e0cb3c55cf9564da612bc325bed5e64"},
     {file = "MarkupSafe-2.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:984d76483eb32f1bcb536dc27e4ad56bba4baa70be32fa87152832cdd9db0833"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:2ef54abee730b502252bcdf31b10dacb0a416229b72c18b19e24a4509f273d26"},
@@ -431,12 +391,6 @@ markupsafe = [
     {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:4efca8f86c54b22348a5467704e3fec767b2db12fc39c6d963168ab1d3fc9135"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:ab3ef638ace319fa26553db0624c4699e31a28bb2a835c5faca8f8acf6a5a902"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:f8ba0e8349a38d3001fae7eadded3f6606f0da5d748ee53cc1dab1d6527b9509"},
-    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c47adbc92fc1bb2b3274c4b3a43ae0e4573d9fbff4f54cd484555edbf030baf1"},
-    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:37205cac2a79194e3750b0af2a5720d95f786a55ce7df90c3af697bfa100eaac"},
-    {file = "MarkupSafe-2.0.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:1f2ade76b9903f39aa442b4aadd2177decb66525062db244b35d71d0ee8599b6"},
-    {file = "MarkupSafe-2.0.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:4296f2b1ce8c86a6aea78613c34bb1a672ea0e3de9c6ba08a960efe0b0a09047"},
-    {file = "MarkupSafe-2.0.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:9f02365d4e99430a12647f09b6cc8bab61a6564363f313126f775eb4f6ef798e"},
-    {file = "MarkupSafe-2.0.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:5b6d930f030f8ed98e3e6c98ffa0652bdb82601e7a016ec2ab5d7ff23baa78d1"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-win32.whl", hash = "sha256:10f82115e21dc0dfec9ab5c0223652f7197feb168c940f3ef61563fc2d6beb74"},
     {file = "MarkupSafe-2.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:693ce3f9e70a6cf7d2fb9e6c9d8b204b6b39897a2c4a1aa65728d5ac97dcc1d8"},
     {file = "MarkupSafe-2.0.1.tar.gz", hash = "sha256:594c67807fb16238b30c44bdf74f36c02cdf22d1c8cda91ef8a0ed8dabf5620a"},
@@ -444,10 +398,6 @@ markupsafe = [
 packaging = [
     {file = "packaging-21.2-py3-none-any.whl", hash = "sha256:14317396d1e8cdb122989b916fa2c7e9ca8e2be9e8060a6eff75b6b7b4d8a7e0"},
     {file = "packaging-21.2.tar.gz", hash = "sha256:096d689d78ca690e4cd8a89568ba06d07ca097e3306a4381635073ca91479966"},
-]
-parameterized = [
-    {file = "parameterized-0.8.1-py2.py3-none-any.whl", hash = "sha256:9cbb0b69a03e8695d68b3399a8a5825200976536fe1cb79db60ed6a4c8c9efe9"},
-    {file = "parameterized-0.8.1.tar.gz", hash = "sha256:41bbff37d6186430f77f900d777e5bb6a24928a1c46fb1de692f8b52b8833b5c"},
 ]
 pluggy = [
     {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,6 @@ addonfactory-splunk-conf-parser-lib = "^0.3.3"
 [tool.poetry.dev-dependencies]
 pytest = "^7.0"
 pytest-cov = "^3.0.0"
-parameterized = "^0.8.1"
 
 [tool.poetry.scripts]
 ucc-gen="splunk_add_on_ucc_framework:main"

--- a/tests/unit/test_alert_actions_conf_gen.py
+++ b/tests/unit/test_alert_actions_conf_gen.py
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import tempfile
-import unittest
 from unittest import mock
 
 from splunk_add_on_ucc_framework.modular_alert_builder.build_core import (
@@ -23,109 +21,101 @@ from splunk_add_on_ucc_framework.modular_alert_builder.build_core import (
 from tests.unit.helpers import get_testdata_file
 
 
-class AlertActionsConfGenTest(unittest.TestCase):
-    def test_generate_alert_action(self):
-        with tempfile.TemporaryDirectory() as temp_dir:
-            generated = alert_actions_conf_gen.generate_alert_actions_conf(
-                input_setting={
-                    "product_id": "Splunk_TA_UCCExample",
-                    "short_name": "splunk_ta_uccexample",
-                    "modular_alerts": [
+def test_generate_alert_action(tmp_path):
+    generated = alert_actions_conf_gen.generate_alert_actions_conf(
+        input_setting={
+            "product_id": "Splunk_TA_UCCExample",
+            "short_name": "splunk_ta_uccexample",
+            "modular_alerts": [
+                {
+                    "label": "Test Alert",
+                    "description": "Description for test Alert Action",
+                    "short_name": "test_alert",
+                    "active_response": {
+                        "task": ["Create", "Update"],
+                        "subject": ["endpoint"],
+                        "category": [
+                            "Information Conveyance",
+                            "Information Portrayal",
+                        ],
+                        "technology": [
+                            {
+                                "version": ["1.0.0"],
+                                "product": "Test Incident Update",
+                                "vendor": "Splunk",
+                            }
+                        ],
+                        "sourcetype": "test:incident",
+                        "supports_adhoc": True,
+                        "drilldown_uri": 'search?q=search%20index%3D"_internal"&earliest=0&latest=',
+                    },
+                    "parameters": [
                         {
-                            "label": "Test Alert",
-                            "description": "Description for test Alert Action",
-                            "short_name": "test_alert",
-                            "active_response": {
-                                "task": ["Create", "Update"],
-                                "subject": ["endpoint"],
-                                "category": [
-                                    "Information Conveyance",
-                                    "Information Portrayal",
-                                ],
-                                "technology": [
-                                    {
-                                        "version": ["1.0.0"],
-                                        "product": "Test Incident Update",
-                                        "vendor": "Splunk",
-                                    }
-                                ],
-                                "sourcetype": "test:incident",
-                                "supports_adhoc": True,
-                                "drilldown_uri": 'search?q=search%20index%3D"_internal"&earliest=0&latest=',
+                            "label": "Name",
+                            "required": True,
+                            "format_type": "text",
+                            "name": "name",
+                            "default_value": "xyz",
+                            "help_string": "Please enter your name",
+                        },
+                        {
+                            "label": "All Incidents",
+                            "required": False,
+                            "format_type": "checkbox",
+                            "name": "all_incidents",
+                            "default_value": 0,
+                            "help_string": "Tick if you want to update all incidents/problems",
+                        },
+                        {
+                            "label": "Table List",
+                            "required": False,
+                            "format_type": "dropdownlist",
+                            "name": "table_list",
+                            "help_string": "Please select the table",
+                            "default_value": "problem",
+                            "possible_values": {
+                                "incident": "Incident",
+                                "problem": "Problem",
                             },
-                            "parameters": [
-                                {
-                                    "label": "Name",
-                                    "required": True,
-                                    "format_type": "text",
-                                    "name": "name",
-                                    "default_value": "xyz",
-                                    "help_string": "Please enter your name",
-                                },
-                                {
-                                    "label": "All Incidents",
-                                    "required": False,
-                                    "format_type": "checkbox",
-                                    "name": "all_incidents",
-                                    "default_value": 0,
-                                    "help_string": "Tick if you want to update all incidents/problems",
-                                },
-                                {
-                                    "label": "Table List",
-                                    "required": False,
-                                    "format_type": "dropdownlist",
-                                    "name": "table_list",
-                                    "help_string": "Please select the table",
-                                    "default_value": "problem",
-                                    "possible_values": {
-                                        "incident": "Incident",
-                                        "problem": "Problem",
-                                    },
-                                },
-                                {
-                                    "label": "Action:",
-                                    "required": True,
-                                    "format_type": "radio",
-                                    "name": "action",
-                                    "help_string": "Select the action you want to perform",
-                                    "default_value": "two",
-                                    "possible_values": {
-                                        "update": "Update",
-                                        "delete": "Delete",
-                                    },
-                                },
-                                {
-                                    "label": "Select Account",
-                                    "required": True,
-                                    "format_type": "dropdownlist_splunk_search",
-                                    "name": "account",
-                                    "help_string": "Select the account from the dropdown",
-                                    "ctrl_props": {
-                                        "value-field": "title",
-                                        "label-field": "title",
-                                        "search": "| rest /servicesNS/nobody/TA-SNOW/admin/TA_SNOW_account | dedup title",  # noqa: E501
-                                    },
-                                },
-                            ],
-                        }
+                        },
+                        {
+                            "label": "Action:",
+                            "required": True,
+                            "format_type": "radio",
+                            "name": "action",
+                            "help_string": "Select the action you want to perform",
+                            "default_value": "two",
+                            "possible_values": {
+                                "update": "Update",
+                                "delete": "Delete",
+                            },
+                        },
+                        {
+                            "label": "Select Account",
+                            "required": True,
+                            "format_type": "dropdownlist_splunk_search",
+                            "name": "account",
+                            "help_string": "Select the account from the dropdown",
+                            "ctrl_props": {
+                                "value-field": "title",
+                                "label-field": "title",
+                                "search": "| rest /servicesNS/nobody/TA-SNOW/admin/TA_SNOW_account | dedup title",  # noqa: E501
+                            },
+                        },
                     ],
-                },
-                logger=mock.MagicMock(),
-                package_path=temp_dir,
-            )
-            expected_alert_actions_conf = get_testdata_file(
-                "alert_actions.conf.generated"
-            )
-            self.assertEqual(
-                expected_alert_actions_conf, generated["alert_actions.conf"]
-            )
-            expected_alert_actions_conf_spec = get_testdata_file(
-                "alert_actions.conf.spec.generated"
-            )
-            self.assertEqual(
-                expected_alert_actions_conf_spec, generated["alert_actions.conf.spec"]
-            )
-            expected_eventtypes_conf = get_testdata_file("eventtypes.conf.generated")
-            self.assertEqual(expected_eventtypes_conf, generated["eventtypes.conf"])
-            expected_tags_conf = get_testdata_file("tags.conf.generated")
-            self.assertEqual(expected_tags_conf, generated["tags.conf"])
+                }
+            ],
+        },
+        logger=mock.MagicMock(),
+        package_path=tmp_path,
+    )
+    expected_alert_actions_conf = get_testdata_file("alert_actions.conf.generated")
+    assert expected_alert_actions_conf == generated["alert_actions.conf"]
+    expected_alert_actions_conf_spec = get_testdata_file(
+        "alert_actions.conf.spec.generated"
+    )
+    assert expected_alert_actions_conf_spec == generated["alert_actions.conf.spec"]
+    expected_eventtypes_conf = get_testdata_file("eventtypes.conf.generated")
+    assert expected_eventtypes_conf == generated["eventtypes.conf"]
+    expected_tags_conf = get_testdata_file("tags.conf.generated")
+    assert expected_tags_conf == generated["tags.conf"]

--- a/tests/unit/test_alert_actions_html_gen.py
+++ b/tests/unit/test_alert_actions_html_gen.py
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import tempfile
-import unittest
 from unittest import mock
 
 from splunk_add_on_ucc_framework.modular_alert_builder.build_core import (
@@ -23,102 +21,100 @@ from splunk_add_on_ucc_framework.modular_alert_builder.build_core import (
 from tests.unit.helpers import get_testdata_file
 
 
-class AlertActionsHtmlGenTest(unittest.TestCase):
-    def test_generate_alert_action(self):
-        with tempfile.TemporaryDirectory() as temp_dir:
-            generated = alert_actions_html_gen.generate_alert_actions_html_files(
-                input_setting={
-                    "product_id": "Splunk_TA_UCCExample",
-                    "short_name": "splunk_ta_uccexample",
-                    "modular_alerts": [
+def test_generate_alert_action(tmp_path):
+    generated = alert_actions_html_gen.generate_alert_actions_html_files(
+        input_setting={
+            "product_id": "Splunk_TA_UCCExample",
+            "short_name": "splunk_ta_uccexample",
+            "modular_alerts": [
+                {
+                    "label": "Test Alert",
+                    "description": "Description for test Alert Action",
+                    "short_name": "test_alert",
+                    "active_response": {
+                        "task": ["Create", "Update"],
+                        "subject": ["endpoint"],
+                        "category": [
+                            "Information Conveyance",
+                            "Information Portrayal",
+                        ],
+                        "technology": [
+                            {
+                                "version": ["1.0.0"],
+                                "product": "Test Incident Update",
+                                "vendor": "Splunk",
+                            }
+                        ],
+                        "sourcetype": "test:incident",
+                        "supports_adhoc": True,
+                        "drilldown_uri": 'search?q=search%20index%3D"_internal"&earliest=0&latest=',
+                    },
+                    "parameters": [
                         {
-                            "label": "Test Alert",
-                            "description": "Description for test Alert Action",
-                            "short_name": "test_alert",
-                            "active_response": {
-                                "task": ["Create", "Update"],
-                                "subject": ["endpoint"],
-                                "category": [
-                                    "Information Conveyance",
-                                    "Information Portrayal",
-                                ],
-                                "technology": [
-                                    {
-                                        "version": ["1.0.0"],
-                                        "product": "Test Incident Update",
-                                        "vendor": "Splunk",
-                                    }
-                                ],
-                                "sourcetype": "test:incident",
-                                "supports_adhoc": True,
-                                "drilldown_uri": 'search?q=search%20index%3D"_internal"&earliest=0&latest=',
+                            "label": "Name",
+                            "required": True,
+                            "format_type": "text",
+                            "name": "name",
+                            "default_value": "xyz",
+                            "help_string": "Please enter your name",
+                        },
+                        {
+                            "label": "All Incidents",
+                            "required": False,
+                            "format_type": "checkbox",
+                            "name": "all_incidents",
+                            "default_value": 0,
+                            "help_string": "Tick if you want to update all incidents/problems",
+                        },
+                        {
+                            "label": "Table List",
+                            "required": False,
+                            "format_type": "dropdownlist",
+                            "name": "table_list",
+                            "help_string": "Please select the table",
+                            "default_value": "problem",
+                            "possible_values": {
+                                "incident": "Incident",
+                                "problem": "Problem",
                             },
-                            "parameters": [
-                                {
-                                    "label": "Name",
-                                    "required": True,
-                                    "format_type": "text",
-                                    "name": "name",
-                                    "default_value": "xyz",
-                                    "help_string": "Please enter your name",
-                                },
-                                {
-                                    "label": "All Incidents",
-                                    "required": False,
-                                    "format_type": "checkbox",
-                                    "name": "all_incidents",
-                                    "default_value": 0,
-                                    "help_string": "Tick if you want to update all incidents/problems",
-                                },
-                                {
-                                    "label": "Table List",
-                                    "required": False,
-                                    "format_type": "dropdownlist",
-                                    "name": "table_list",
-                                    "help_string": "Please select the table",
-                                    "default_value": "problem",
-                                    "possible_values": {
-                                        "incident": "Incident",
-                                        "problem": "Problem",
-                                    },
-                                },
-                                {
-                                    "label": "Scripted Endpoint",
-                                    "required": False,
-                                    "format_type": "text",
-                                    "name": "scripted_endpoint",
-                                    "help_string": "Scripted REST endpoint to create incident at. Format: /api/<API namespace>/<API ID>/<Relative path>. Default: /api/now/incident",  # noqa: E501
-                                },
-                                {
-                                    "label": "Action:",
-                                    "required": True,
-                                    "format_type": "radio",
-                                    "name": "action",
-                                    "help_string": "Select the action you want to perform",
-                                    "default_value": "two",
-                                    "possible_values": {
-                                        "update": "Update",
-                                        "delete": "Delete",
-                                    },
-                                },
-                                {
-                                    "label": "Select Account",
-                                    "required": True,
-                                    "format_type": "dropdownlist_splunk_search",
-                                    "name": "account",
-                                    "help_string": "Select the account from the dropdown",
-                                    "ctrl_props": {
-                                        "value-field": "title",
-                                        "label-field": "title",
-                                        "search": "| rest /servicesNS/nobody/TA-SNOW/admin/TA_SNOW_account | dedup title",  # noqa: E501
-                                    },
-                                },
-                            ],
-                        }
+                        },
+                        {
+                            "label": "Scripted Endpoint",
+                            "required": False,
+                            "format_type": "text",
+                            "name": "scripted_endpoint",
+                            "help_string": "Scripted REST endpoint to create incident at. Format: /api/<API namespace>/<API ID>/<Relative path>. Default: /api/now/incident",  # noqa: E501
+                        },
+                        {
+                            "label": "Action:",
+                            "required": True,
+                            "format_type": "radio",
+                            "name": "action",
+                            "help_string": "Select the action you want to perform",
+                            "default_value": "two",
+                            "possible_values": {
+                                "update": "Update",
+                                "delete": "Delete",
+                            },
+                        },
+                        {
+                            "label": "Select Account",
+                            "required": True,
+                            "format_type": "dropdownlist_splunk_search",
+                            "name": "account",
+                            "help_string": "Select the account from the dropdown",
+                            "ctrl_props": {
+                                "value-field": "title",
+                                "label-field": "title",
+                                "search": "| rest /servicesNS/nobody/TA-SNOW/admin/TA_SNOW_account | dedup title",  # noqa: E501
+                            },
+                        },
                     ],
-                },
-                logger=mock.MagicMock(),
-                package_path=temp_dir,
-            )
-            expected_alert_html = get_testdata_file("alert.html.generated")
-            self.assertEqual(expected_alert_html, generated["test_alert"])
+                }
+            ],
+        },
+        logger=mock.MagicMock(),
+        package_path=tmp_path,
+    )
+    expected_alert_html = get_testdata_file("alert.html.generated")
+    assert expected_alert_html == generated["test_alert"]

--- a/tests/unit/test_alert_actions_py_gen.py
+++ b/tests/unit/test_alert_actions_py_gen.py
@@ -13,8 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import tempfile
-import unittest
 from unittest import mock
 
 from splunk_add_on_ucc_framework.modular_alert_builder.build_core import (
@@ -23,102 +21,96 @@ from splunk_add_on_ucc_framework.modular_alert_builder.build_core import (
 from tests.unit.helpers import get_testdata_file
 
 
-class AlertActionsPyGenTest(unittest.TestCase):
-    def test_generate_alert_action(self):
-        with tempfile.TemporaryDirectory() as temp_dir:
-            generated = alert_actions_py_gen.generate_alert_actions_py_files(
-                input_setting={
-                    "product_id": "Splunk_TA_UCCExample",
-                    "short_name": "splunk_ta_uccexample",
-                    "modular_alerts": [
+def test_generate_alert_action(tmp_path):
+    generated = alert_actions_py_gen.generate_alert_actions_py_files(
+        input_setting={
+            "product_id": "Splunk_TA_UCCExample",
+            "short_name": "splunk_ta_uccexample",
+            "modular_alerts": [
+                {
+                    "label": "Test Alert",
+                    "description": "Description for test Alert Action",
+                    "short_name": "test_alert",
+                    "active_response": {
+                        "task": ["Create", "Update"],
+                        "subject": ["endpoint"],
+                        "category": [
+                            "Information Conveyance",
+                            "Information Portrayal",
+                        ],
+                        "technology": [
+                            {
+                                "version": ["1.0.0"],
+                                "product": "Test Incident Update",
+                                "vendor": "Splunk",
+                            }
+                        ],
+                        "sourcetype": "test:incident",
+                        "supports_adhoc": True,
+                        "drilldown_uri": 'search?q=search%20index%3D"_internal"&earliest=0&latest=',
+                    },
+                    "parameters": [
                         {
-                            "label": "Test Alert",
-                            "description": "Description for test Alert Action",
-                            "short_name": "test_alert",
-                            "active_response": {
-                                "task": ["Create", "Update"],
-                                "subject": ["endpoint"],
-                                "category": [
-                                    "Information Conveyance",
-                                    "Information Portrayal",
-                                ],
-                                "technology": [
-                                    {
-                                        "version": ["1.0.0"],
-                                        "product": "Test Incident Update",
-                                        "vendor": "Splunk",
-                                    }
-                                ],
-                                "sourcetype": "test:incident",
-                                "supports_adhoc": True,
-                                "drilldown_uri": 'search?q=search%20index%3D"_internal"&earliest=0&latest=',
+                            "label": "Name",
+                            "required": True,
+                            "format_type": "text",
+                            "name": "name",
+                            "default_value": "xyz",
+                            "help_string": "Please enter your name",
+                        },
+                        {
+                            "label": "All Incidents",
+                            "required": False,
+                            "format_type": "checkbox",
+                            "name": "all_incidents",
+                            "default_value": 0,
+                            "help_string": "Tick if you want to update all incidents/problems",
+                        },
+                        {
+                            "label": "Table List",
+                            "required": False,
+                            "format_type": "dropdownlist",
+                            "name": "table_list",
+                            "help_string": "Please select the table",
+                            "default_value": "problem",
+                            "possible_values": {
+                                "incident": "Incident",
+                                "problem": "Problem",
                             },
-                            "parameters": [
-                                {
-                                    "label": "Name",
-                                    "required": True,
-                                    "format_type": "text",
-                                    "name": "name",
-                                    "default_value": "xyz",
-                                    "help_string": "Please enter your name",
-                                },
-                                {
-                                    "label": "All Incidents",
-                                    "required": False,
-                                    "format_type": "checkbox",
-                                    "name": "all_incidents",
-                                    "default_value": 0,
-                                    "help_string": "Tick if you want to update all incidents/problems",
-                                },
-                                {
-                                    "label": "Table List",
-                                    "required": False,
-                                    "format_type": "dropdownlist",
-                                    "name": "table_list",
-                                    "help_string": "Please select the table",
-                                    "default_value": "problem",
-                                    "possible_values": {
-                                        "incident": "Incident",
-                                        "problem": "Problem",
-                                    },
-                                },
-                                {
-                                    "label": "Action:",
-                                    "required": True,
-                                    "format_type": "radio",
-                                    "name": "action",
-                                    "help_string": "Select the action you want to perform",
-                                    "default_value": "two",
-                                    "possible_values": {
-                                        "update": "Update",
-                                        "delete": "Delete",
-                                    },
-                                },
-                                {
-                                    "label": "Select Account",
-                                    "required": True,
-                                    "format_type": "dropdownlist_splunk_search",
-                                    "name": "account",
-                                    "help_string": "Select the account from the dropdown",
-                                    "ctrl_props": {
-                                        "value-field": "title",
-                                        "label-field": "title",
-                                        "search": "| rest /servicesNS/nobody/TA-SNOW/admin/TA_SNOW_account | dedup title",  # noqa: E501
-                                    },
-                                },
-                            ],
-                        }
+                        },
+                        {
+                            "label": "Action:",
+                            "required": True,
+                            "format_type": "radio",
+                            "name": "action",
+                            "help_string": "Select the action you want to perform",
+                            "default_value": "two",
+                            "possible_values": {
+                                "update": "Update",
+                                "delete": "Delete",
+                            },
+                        },
+                        {
+                            "label": "Select Account",
+                            "required": True,
+                            "format_type": "dropdownlist_splunk_search",
+                            "name": "account",
+                            "help_string": "Select the account from the dropdown",
+                            "ctrl_props": {
+                                "value-field": "title",
+                                "label-field": "title",
+                                "search": "| rest /servicesNS/nobody/TA-SNOW/admin/TA_SNOW_account | dedup title",  # noqa: E501
+                            },
+                        },
                     ],
-                },
-                global_settings="",
-                logger=mock.MagicMock(),
-                package_path=temp_dir,
-            )
-            expected_alert_helper = get_testdata_file(
-                "alert_action_helper.py.generated"
-            )
-            expected_alert = get_testdata_file("alert_action.py.generated")
-            self.assertEqual(expected_alert, generated["test_alert"]["test_alert.py"])
-            self.assertEqual(
-                expected_alert_helper, generated["test_alert"]["test_alert_helper.py"]
-            )
+                }
+            ],
+        },
+        global_settings="",
+        logger=mock.MagicMock(),
+        package_path=tmp_path,
+    )
+    expected_alert_helper = get_testdata_file("alert_action_helper.py.generated")
+    expected_alert = get_testdata_file("alert_action.py.generated")
+    assert expected_alert == generated["test_alert"]["test_alert.py"]
+    assert expected_alert_helper == generated["test_alert"]["test_alert_helper.py"]

--- a/tests/unit/test_app_conf.py
+++ b/tests/unit/test_app_conf.py
@@ -14,40 +14,39 @@
 # limitations under the License.
 #
 import io
-import unittest
 from unittest import mock
 
 from splunk_add_on_ucc_framework import app_conf
 from tests.unit.helpers import get_testdata_file, get_testdata_file_path
 
 
-class AppConfTest(unittest.TestCase):
-    @mock.patch("time.time", mock.MagicMock(return_value=12345))
-    def test_update(self):
-        app_config = app_conf.AppConf()
-        app_config.read(get_testdata_file_path("app.conf"))
-        app_config.update(
-            "1.0.0",
-            "Splunk_TA_UCCExample",
-            "Description for Splunk_TA_UCCExample",
-            "Title for Splunk_TA_UCCExample",
-        )
-        app_conf_output = io.StringIO()
-        app_config.write(app_conf_output)
-        app_conf_expected = get_testdata_file("app.conf.updated")
-        self.assertEqual(app_conf_expected, app_conf_output.getvalue())
+@mock.patch("time.time", mock.MagicMock(return_value=12345))
+def test_update():
+    app_config = app_conf.AppConf()
+    app_config.read(get_testdata_file_path("app.conf"))
+    app_config.update(
+        "1.0.0",
+        "Splunk_TA_UCCExample",
+        "Description for Splunk_TA_UCCExample",
+        "Title for Splunk_TA_UCCExample",
+    )
+    app_conf_output = io.StringIO()
+    app_config.write(app_conf_output)
+    app_conf_expected = get_testdata_file("app.conf.updated")
+    assert app_conf_expected == app_conf_output.getvalue()
 
-    @mock.patch("time.time", mock.MagicMock(return_value=12345))
-    def test_update_when_minimal_app_conf(self):
-        app_config = app_conf.AppConf()
-        app_config.read(get_testdata_file_path("app.conf.minimal"))
-        app_config.update(
-            "1.0.0",
-            "Splunk_TA_UCCExample",
-            "Description for Splunk_TA_UCCExample",
-            "Title for Splunk_TA_UCCExample",
-        )
-        app_conf_output = io.StringIO()
-        app_config.write(app_conf_output)
-        app_conf_expected = get_testdata_file("app.conf.minimal.updated")
-        self.assertEqual(app_conf_expected, app_conf_output.getvalue())
+
+@mock.patch("time.time", mock.MagicMock(return_value=12345))
+def test_update_when_minimal_app_conf():
+    app_config = app_conf.AppConf()
+    app_config.read(get_testdata_file_path("app.conf.minimal"))
+    app_config.update(
+        "1.0.0",
+        "Splunk_TA_UCCExample",
+        "Description for Splunk_TA_UCCExample",
+        "Title for Splunk_TA_UCCExample",
+    )
+    app_conf_output = io.StringIO()
+    app_config.write(app_conf_output)
+    app_conf_expected = get_testdata_file("app.conf.minimal.updated")
+    assert app_conf_expected == app_conf_output.getvalue()

--- a/tests/unit/test_app_manifest.py
+++ b/tests/unit/test_app_manifest.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import unittest
+import pytest
 
 from splunk_add_on_ucc_framework import app_manifest
 from tests.unit.helpers import get_testdata_file
@@ -26,54 +26,59 @@ def get_manifest(file_name: str) -> app_manifest.AppManifest:
     return manifest
 
 
-class AppManifestTest(unittest.TestCase):
-    def test_read(self):
-        manifest = get_manifest("app.manifest")
-        self.assertTrue(isinstance(manifest._manifest, dict))
-        self.assertFalse(manifest._comments)
+def test_read():
+    manifest = get_manifest("app.manifest")
+    assert isinstance(manifest._manifest, dict)
+    assert not manifest._comments
 
-    def test_read_with_comments(self):
-        manifest = get_manifest("app.manifest_with_comments")
-        self.assertTrue(isinstance(manifest._manifest, dict))
-        expected_comments = [
-            "# This is a comment.",
-            "# We will keep it after modifying this file.",
-        ]
-        self.assertListEqual(expected_comments, manifest._comments)
 
-    def test_read_with_unsupported_comments_throws_exception(self):
-        with self.assertRaises(app_manifest.AppManifestFormatException):
-            get_manifest("app.manifest_with_unsupported_comments")
+def test_read_with_comments():
+    manifest = get_manifest("app.manifest_with_comments")
+    assert isinstance(manifest._manifest, dict)
+    expected_comments = [
+        "# This is a comment.",
+        "# We will keep it after modifying this file.",
+    ]
+    assert expected_comments == manifest._comments
 
-    def test_get_addon_name(self):
-        manifest = get_manifest("app.manifest")
-        expected_addon_name = "Splunk_TA_UCCExample"
-        self.assertEqual(expected_addon_name, manifest.get_addon_name())
 
-    def test_get_title(self):
-        manifest = get_manifest("app.manifest")
-        expected_title = "Splunk Add-on for UCC Example"
-        self.assertEqual(expected_title, manifest.get_title())
+def test_read_with_unsupported_comments_throws_exception():
+    with pytest.raises(app_manifest.AppManifestFormatException):
+        get_manifest("app.manifest_with_unsupported_comments")
 
-    def test_get_description(self):
-        manifest = get_manifest("app.manifest")
-        expected_description = "Description of Splunk Add-on for UCC Example"
-        self.assertEqual(expected_description, manifest.get_description())
 
-    def test_update_addon_version(self):
-        manifest = get_manifest("app.manifest")
-        expected_addon_version = "v1.1.1"
-        manifest.update_addon_version(expected_addon_version)
-        self.assertEqual(
-            expected_addon_version, manifest._manifest["info"]["id"]["version"]
-        )
+def test_get_addon_name():
+    manifest = get_manifest("app.manifest")
+    expected_addon_name = "Splunk_TA_UCCExample"
+    assert expected_addon_name == manifest.get_addon_name()
 
-    def test_str(self):
-        manifest = get_manifest("app.manifest")
-        expected_content = get_testdata_file("app.manifest_written")
-        self.assertEqual(expected_content, str(manifest))
 
-    def test_str_with_comments(self):
-        manifest = get_manifest("app.manifest_with_comments")
-        expected_content = get_testdata_file("app.manifest_with_comments_written")
-        self.assertEqual(expected_content, str(manifest))
+def test_get_title():
+    manifest = get_manifest("app.manifest")
+    expected_title = "Splunk Add-on for UCC Example"
+    assert expected_title == manifest.get_title()
+
+
+def test_get_description():
+    manifest = get_manifest("app.manifest")
+    expected_description = "Description of Splunk Add-on for UCC Example"
+    assert expected_description == manifest.get_description()
+
+
+def test_update_addon_version():
+    manifest = get_manifest("app.manifest")
+    expected_addon_version = "v1.1.1"
+    manifest.update_addon_version(expected_addon_version)
+    assert expected_addon_version == manifest._manifest["info"]["id"]["version"]
+
+
+def test_str():
+    manifest = get_manifest("app.manifest")
+    expected_content = get_testdata_file("app.manifest_written")
+    assert expected_content == str(manifest)
+
+
+def test_str_with_comments():
+    manifest = get_manifest("app.manifest_with_comments")
+    expected_content = get_testdata_file("app.manifest_with_comments_written")
+    assert expected_content == str(manifest)

--- a/tests/unit/test_config_file_update.py
+++ b/tests/unit/test_config_file_update.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 #
 import json
-import unittest
 
 import tests.unit.helpers as helpers
 from splunk_add_on_ucc_framework import (
@@ -23,42 +22,38 @@ from splunk_add_on_ucc_framework import (
 )
 
 
-class ConfigFileUpdateTest(unittest.TestCase):
-    def test_handle_biased_terms_update(self):
-        config = helpers.get_testdata_file("config_with_biased_terms.json")
-        config = json.loads(config)
-        updated_config = handle_biased_terms_update(config)
-        expected_schema_version = "0.0.1"
-        self.assertEqual(
-            expected_schema_version, updated_config["meta"]["schemaVersion"]
-        )
-        input_entity_1_options_keys = updated_config["pages"]["inputs"]["services"][0][
-            "entity"
-        ][0]["options"].keys()
-        self.assertIn("denyList", input_entity_1_options_keys)
-        self.assertNotIn("blackList", input_entity_1_options_keys)
-        input_entity_2_options_keys = updated_config["pages"]["inputs"]["services"][0][
-            "entity"
-        ][1]["options"].keys()
-        self.assertIn("allowList", input_entity_2_options_keys)
-        self.assertNotIn("whiteList", input_entity_2_options_keys)
-        configuration_entity_1_options_keys = updated_config["pages"]["configuration"][
-            "tabs"
-        ][0]["entity"][0]["options"].keys()
-        self.assertIn("denyList", configuration_entity_1_options_keys)
-        self.assertNotIn("blackList", configuration_entity_1_options_keys)
-        configuration_entity_2_options_keys = updated_config["pages"]["configuration"][
-            "tabs"
-        ][0]["entity"][1]["options"].keys()
-        self.assertIn("allowList", configuration_entity_2_options_keys)
-        self.assertNotIn("whiteList", configuration_entity_2_options_keys)
+def test_handle_biased_terms_update():
+    config = helpers.get_testdata_file("config_with_biased_terms.json")
+    config = json.loads(config)
+    updated_config = handle_biased_terms_update(config)
+    expected_schema_version = "0.0.1"
+    assert expected_schema_version == updated_config["meta"]["schemaVersion"]
+    input_entity_1_options_keys = updated_config["pages"]["inputs"]["services"][0][
+        "entity"
+    ][0]["options"].keys()
+    assert "denyList" in input_entity_1_options_keys
+    assert "blackList" not in input_entity_1_options_keys
+    input_entity_2_options_keys = updated_config["pages"]["inputs"]["services"][0][
+        "entity"
+    ][1]["options"].keys()
+    assert "allowList" in input_entity_2_options_keys
+    assert "whileList" not in input_entity_2_options_keys
+    configuration_entity_1_options_keys = updated_config["pages"]["configuration"][
+        "tabs"
+    ][0]["entity"][0]["options"].keys()
+    assert "denyList" in configuration_entity_1_options_keys
+    assert "blackList" not in configuration_entity_1_options_keys
+    configuration_entity_2_options_keys = updated_config["pages"]["configuration"][
+        "tabs"
+    ][0]["entity"][1]["options"].keys()
+    assert "allowList" in configuration_entity_2_options_keys
+    assert "whileList" not in configuration_entity_2_options_keys
 
-    def test_handle_dropping_api_version_update(self):
-        config = helpers.get_testdata_file("config_with_biased_terms.json")
-        config = json.loads(config)
-        updated_config = handle_dropping_api_version_update(config)
-        expected_schema_version = "0.0.3"
-        self.assertEqual(
-            expected_schema_version, updated_config["meta"]["schemaVersion"]
-        )
-        self.assertNotIn("apiVersion", updated_config["meta"])
+
+def test_handle_dropping_api_version_update():
+    config = helpers.get_testdata_file("config_with_biased_terms.json")
+    config = json.loads(config)
+    updated_config = handle_dropping_api_version_update(config)
+    expected_schema_version = "0.0.3"
+    assert expected_schema_version == updated_config["meta"]["schemaVersion"]
+    assert "apiVersion" not in updated_config["meta"]

--- a/tests/unit/test_config_validation.py
+++ b/tests/unit/test_config_validation.py
@@ -15,7 +15,8 @@
 #
 import json
 import os
-import unittest
+
+import pytest
 
 import tests.unit.helpers as helpers
 from splunk_add_on_ucc_framework.global_config_validator import (
@@ -31,25 +32,26 @@ def _path_to_source_dir() -> str:
     )
 
 
-class ConfigValidationTest(unittest.TestCase):
-    def test_config_validation_when_valid_config_then_no_exception(self):
-        config = helpers.get_testdata_file("valid_config.json")
-        config = json.loads(config)
-        validator = GlobalConfigValidator(_path_to_source_dir(), config)
+def test_config_validation_when_valid_config_then_no_exception():
+    config = helpers.get_testdata_file("valid_config.json")
+    config = json.loads(config)
+    validator = GlobalConfigValidator(_path_to_source_dir(), config)
+    validator.validate()
+
+
+def test_config_validation_when_invalid_config_then_exception():
+    config = helpers.get_testdata_file("invalid_config_no_configuration_tabs.json")
+    config = json.loads(config)
+    validator = GlobalConfigValidator(_path_to_source_dir(), config)
+    with pytest.raises(GlobalConfigValidatorException):
         validator.validate()
 
-    def test_config_validation_when_invalid_config_then_exception(self):
-        config = helpers.get_testdata_file("invalid_config_no_configuration_tabs.json")
-        config = json.loads(config)
-        validator = GlobalConfigValidator(_path_to_source_dir(), config)
-        with self.assertRaises(GlobalConfigValidatorException):
-            validator.validate()
 
-    def test_config_validation_when_configuration_tab_table_has_no_name_field(self):
-        config = helpers.get_testdata_file(
-            "invalid_config_no_name_field_in_configuration_tab_table.json"
-        )
-        config = json.loads(config)
-        validator = GlobalConfigValidator(_path_to_source_dir(), config)
-        with self.assertRaises(GlobalConfigValidatorException):
-            validator.validate()
+def test_config_validation_when_configuration_tab_table_has_no_name_field():
+    config = helpers.get_testdata_file(
+        "invalid_config_no_name_field_in_configuration_tab_table.json"
+    )
+    config = json.loads(config)
+    validator = GlobalConfigValidator(_path_to_source_dir(), config)
+    with pytest.raises(GlobalConfigValidatorException):
+        validator.validate()

--- a/tests/unit/test_meta_conf.py
+++ b/tests/unit/test_meta_conf.py
@@ -14,15 +14,13 @@
 # limitations under the License.
 #
 import io
-import unittest
 
 from splunk_add_on_ucc_framework import meta_conf
 
 
-class MetaConfTest(unittest.TestCase):
-    def test_update(self):
-        meta_config = meta_conf.MetaConf()
-        actual_output = io.StringIO()
-        meta_config.create_default(actual_output)
-        expected_output = meta_conf.DEFAULT
-        self.assertEqual(expected_output, actual_output.getvalue())
+def test_update():
+    meta_config = meta_conf.MetaConf()
+    actual_output = io.StringIO()
+    meta_config.create_default(actual_output)
+    expected_output = meta_conf.DEFAULT
+    assert expected_output == actual_output.getvalue()

--- a/tests/unit/test_uccrestbuilder.py
+++ b/tests/unit/test_uccrestbuilder.py
@@ -13,26 +13,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import unittest
-
-from parameterized import parameterized
+import pytest
 
 from splunk_add_on_ucc_framework.uccrestbuilder.endpoint import base
 
 
-class IndentTest(unittest.TestCase):
-    @parameterized.expand(
-        [
-            (None, "    None"),
-            (
-                "\nmax_len=4096,\nmin_len=0,\n",
-                "\n    max_len=4096,\n    min_len=0,\n",
-            ),
-            (
-                "validator.String(\n    max_len=4096,\n    min_len=0,\n)",
-                "    validator.String(\n        max_len=4096,\n        min_len=0,\n    )",
-            ),
-        ]
-    )
-    def test_indent(self, lines, expected):
-        self.assertEqual(base.indent(lines), expected)
+@pytest.mark.parametrize(
+    "lines,expected",
+    [
+        (None, "    None"),
+        (
+            "\nmax_len=4096,\nmin_len=0,\n",
+            "\n    max_len=4096,\n    min_len=0,\n",
+        ),
+        (
+            "validator.String(\n    max_len=4096,\n    min_len=0,\n)",
+            "    validator.String(\n        max_len=4096,\n        min_len=0,\n    )",
+        ),
+    ],
+)
+def test_indent(lines, expected):
+    assert base.indent(lines) == expected


### PR DESCRIPTION
This allows to remove a "parameterized" dev dependency because we can use "@pytest.mark.parametrize" instead.