### PR TITLE
refactor: remove dependency on defusedxml

### DIFF
--- a/.ucc-ui-version
+++ b/.ucc-ui-version
@@ -1,2 +1,0 @@
-#https://github.com/splunk/addonfactory-ucc-base-ui/releases/download/v1.10.0/splunk-ucc-ui.tgz
-VERSION=v1.10.0

--- a/get-ucc-ui.sh
+++ b/get-ucc-ui.sh
@@ -13,6 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-if [ -z ${1+x} ]; then source .ucc-ui-version; else VERSION=$1; fi
-
-wget https://github.com/splunk/addonfactory-ucc-base-ui/releases/download/${VERSION}/splunk-ucc-ui.tgz
+wget https://github.com/splunk/addonfactory-ucc-base-ui/releases/download/1.11.0/splunk-ucc-ui.tgz

--- a/get-ucc-ui.sh
+++ b/get-ucc-ui.sh
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-wget https://github.com/splunk/addonfactory-ucc-base-ui/releases/download/1.11.0/splunk-ucc-ui.tgz
+wget https://github.com/splunk/addonfactory-ucc-base-ui/releases/download/v1.11.0/splunk-ucc-ui.tgz

--- a/poetry.lock
+++ b/poetry.lock
@@ -55,14 +55,6 @@ tomli = {version = "*", optional = true, markers = "python_full_version <= \"3.1
 toml = ["tomli"]
 
 [[package]]
-name = "defusedxml"
-version = "0.7.1"
-description = "XML bomb protection for Python stdlib modules"
-category = "main"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-
-[[package]]
 name = "dunamai"
 version = "1.13.0"
 description = "Dynamic version generation"
@@ -438,7 +430,7 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "29ebb8231ff391996e13981033612581ebd43489172820f72eb612205ee1ffb9"
+content-hash = "b35e5a2770afdf9e11ae32e3037f484561ed7b80347a60058c31f3ff397678fb"
 
 [metadata.files]
 addonfactory-splunk-conf-parser-lib = [
@@ -508,10 +500,6 @@ coverage = [
     {file = "coverage-6.4.4-cp39-cp39-win_amd64.whl", hash = "sha256:1238b08f3576201ebf41f7c20bf59baa0d05da941b123c6656e42cdb668e9827"},
     {file = "coverage-6.4.4-pp36.pp37.pp38-none-any.whl", hash = "sha256:f67cf9f406cf0d2f08a3515ce2db5b82625a7257f88aad87904674def6ddaec1"},
     {file = "coverage-6.4.4.tar.gz", hash = "sha256:e16c45b726acb780e1e6f88b286d3c10b3914ab03438f32117c4aa52d7f30d58"},
-]
-defusedxml = [
-    {file = "defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61"},
-    {file = "defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69"},
 ]
 dunamai = [
     {file = "dunamai-1.13.0-py3-none-any.whl", hash = "sha256:9bc19b8c53c62f922f2835e210f2295089669ab18222601cef44eb8c3a51929e"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ classifiers = [
 [tool.poetry.dependencies]
 python = "^3.7"
 jinja2 = ">=2,<4"
-defusedxml = "^0.7.1"
 addonfactory-splunk-conf-parser-lib = "^0.3.3"
 dunamai = "^1.9.0"
 jsonschema = "^4.4.0"

--- a/tests/data/test_ucc_generate.py
+++ b/tests/data/test_ucc_generate.py
@@ -85,6 +85,12 @@ class UccGenerateTest(unittest.TestCase):
             for f in files_to_exist:
                 expected_file_path = path.join(expected_folder, *f)
                 self.assertTrue(path.exists(expected_file_path))
+            files_to_not_exist = [
+                ("default", "data", "ui", "nav", "default_no_input.xml"),
+            ]
+            for f in files_to_not_exist:
+                expected_file_path = path.join(expected_folder, *f)
+                self.assertFalse(path.exists(expected_file_path))
 
     def test_ucc_generate_with_configuration(self):
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -142,6 +148,12 @@ class UccGenerateTest(unittest.TestCase):
             for f in files_to_exist:
                 expected_file_path = path.join(expected_folder, *f)
                 self.assertTrue(path.exists(expected_file_path))
+            files_to_not_exist = [
+                ("default", "data", "ui", "nav", "default_no_input.xml"),
+            ]
+            for f in files_to_not_exist:
+                expected_file_path = path.join(expected_folder, *f)
+                self.assertFalse(path.exists(expected_file_path))
 
     def test_ucc_generate_with_configuration_files_only(self):
         with tempfile.TemporaryDirectory() as temp_dir:
@@ -181,6 +193,12 @@ class UccGenerateTest(unittest.TestCase):
                     ),
                     msg=f"Expected file {expected_file_path} is different from {actual_file_path}",
                 )
+            files_to_not_exist = [
+                ("default", "data", "ui", "nav", "default_no_input.xml"),
+            ]
+            for f in files_to_not_exist:
+                expected_file_path = path.join(expected_folder, *f)
+                self.assertFalse(path.exists(expected_file_path))
 
 
 if __name__ == "__main__":

--- a/tests/expected_output_global_config_configuration/Splunk_TA_UCCExample/default/data/ui/nav/default.xml
+++ b/tests/expected_output_global_config_configuration/Splunk_TA_UCCExample/default/data/ui/nav/default.xml
@@ -1,4 +1,20 @@
+<!--
+  ~ Copyright 2021 Splunk Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+-->
 <nav>
-    <view default="true" name="configuration" />
+    <view name="configuration" default="true" />
     <view name="search" />
 </nav>


### PR DESCRIPTION
defusedxml library was only used in 1 place which was refactored to remove the dependency by introducing a new file in the UCC UI library and making some manipulations in the file system during the build process.