### PR TITLE
fix(code): ADDON-57703 handle globalConfig flag

### DIFF
--- a/splunk_add_on_ucc_framework/commands/build.py
+++ b/splunk_add_on_ucc_framework/commands/build.py
@@ -454,7 +454,7 @@ def generate(source, config, ta_version, outputdir=None, python_binary_name="pyt
             )
             is_global_config_yaml = True
     else:
-        is_global_config_yaml = True if config.endswith('.yaml') else False
+        is_global_config_yaml = True if config.endswith(".yaml") else False
 
     logger.info(f"Cleaning out directory {outputdir}")
     shutil.rmtree(os.path.join(outputdir), ignore_errors=True)

--- a/splunk_add_on_ucc_framework/commands/build.py
+++ b/splunk_add_on_ucc_framework/commands/build.py
@@ -453,6 +453,8 @@ def generate(source, config, ta_version, outputdir=None, python_binary_name="pyt
                 os.path.join(source, PARENT_DIR, "globalConfig.yaml")
             )
             is_global_config_yaml = True
+    else:
+        is_global_config_yaml = True if config.endswith('.yaml') else False
 
     logger.info(f"Cleaning out directory {outputdir}")
     shutil.rmtree(os.path.join(outputdir), ignore_errors=True)

--- a/splunk_add_on_ucc_framework/main.py
+++ b/splunk_add_on_ucc_framework/main.py
@@ -34,14 +34,14 @@ def main(argv: Optional[Sequence[str]] = None):
         "--config",
         type=str,
         nargs="?",
-        help="Path to configuration file, defaults to globalConfig.json in parent directory of source provided",
+        help="Path to configuration file, defaults to globalConfig file in parent directory of source provided",
         default=None,
     )
     parser.add_argument(
         "--ta-version",
         type=str,
         help="Version of TA, default version is version specified in the "
-        "package such as app.manifest, app.conf, and globalConfig.json",
+        "package such as app.manifest, app.conf, and globalConfig file.",
         default=None,
     )
     parser.add_argument(

--- a/tests/data/package_global_config_configuration/globalConfig.json
+++ b/tests/data/package_global_config_configuration/globalConfig.json
@@ -421,7 +421,7 @@
     "meta": {
         "name": "Splunk_TA_UCCExample",
         "restRoot": "splunk_ta_uccexample",
-        "version": "5.7.0Rc1c9ff9f",
+        "version": "5.15.0",
         "displayName": "Splunk UCC test Add-on",
         "schemaVersion": "0.0.3"
     }

--- a/tests/data/package_global_config_inputs_configuration_alerts/globalConfig.json
+++ b/tests/data/package_global_config_inputs_configuration_alerts/globalConfig.json
@@ -1025,7 +1025,7 @@
     "meta": {
         "name": "Splunk_TA_UCCExample",
         "restRoot": "splunk_ta_uccexample",
-        "version": "5.7.0Rc1c9ff9f",
+        "version": "5.15.0",
         "displayName": "Splunk UCC test Add-on",
         "schemaVersion": "0.0.3"
     }

--- a/tests/data/test_ucc_generate.py
+++ b/tests/data/test_ucc_generate.py
@@ -15,6 +15,22 @@ class UccGenerateTest(unittest.TestCase):
         )
         ucc.generate(source=package_folder)
 
+    def test_ucc_generate_with_config_param(self):
+        """
+        Checks whether the package is build when the `config` flag is provided in the CLI
+        """
+        package_folder = path.join(
+            path.dirname(path.realpath(__file__)),
+            "package_global_config_inputs_configuration_alerts",
+            "package",
+        )
+        config_path = path.join(
+            path.dirname(path.realpath(__file__)),
+            "package_global_config_inputs_configuration_alerts",
+            "globalConfig.json",
+        )
+        ucc.generate(source=package_folder, config=config_path)
+
     def test_ucc_generate_with_inputs_configuration_alerts(self):
         with tempfile.TemporaryDirectory() as temp_dir:
             package_folder = path.join(

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -46,7 +46,7 @@ def get_testdata_file(file_name: str) -> str:
 
 def get_testdata(file_name: str) -> Dict:
     config = get_testdata_file(file_name)
-    if file_name[-4] == "json":
+    if file_name.endswith(".json"):
         return json.loads(config)
     else:
         return yaml_load(config)

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -84,6 +84,24 @@ from splunk_add_on_ucc_framework import main
                 "python_binary_name": "python.exe",
             },
         ),
+        (
+            [
+                "--source",
+                "package",
+                "--config",
+                "/path/to/globalConfig.yaml",
+                "--ta-version",
+                "2.2.0",
+                "--python-binary-name",
+                "python.exe",
+            ],
+            {
+                "source": "package",
+                "config": "/path/to/globalConfig.yaml",
+                "ta_version": "2.2.0",
+                "python_binary_name": "python.exe",
+            },
+        ),
     ],
 )
 @mock.patch("splunk_add_on_ucc_framework.main.generate")


### PR DESCRIPTION
Updated code to handle when the config param is provided while invoking the `ucc-gen` command. 
Added a test case for the same.