### PR TITLE
feat: update UCC UI to 1.15.0

### DIFF
--- a/get-ucc-ui.sh
+++ b/get-ucc-ui.sh
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-wget https://github.com/splunk/addonfactory-ucc-base-ui/releases/download/v1.14.2/splunk-ucc-ui.tgz
+wget https://github.com/splunk/addonfactory-ucc-base-ui/releases/download/v1.15.0/splunk-ucc-ui.tgz


### PR DESCRIPTION
Changes from UCC UI v1.14.2 to v1.15.0:

* most of the version of UCC UI libraries were updated
* the build size was reduced by not including the dev dependencies (the archived size of the splunk-ucc-ui file is dropped from ~2.6 MB to ~400 KB, non-archived size dropped from ~10 MB to ~2 MB).