### PR TITLE
refactor: introduce build subcommand

### DIFF
--- a/docs/how_to_use.md
+++ b/docs/how_to_use.md
@@ -4,7 +4,7 @@
 
 You need to have Python 3.7+ and Git available in the machine to be able to utilize `ucc-gen` command.
 
-> Git is used to generate the add-on version from Git tags. Alternatively you can use `--ta-version` parameter. More info [here](#parameters).
+> Git is used to generate the add-on version from Git tags. Alternatively you can use `--ta-version` parameter. More info below.
 
 To be able to create an add-on using UCC framework, you need to have at least:
 
@@ -70,19 +70,29 @@ folder and extending their functionality. The generated inputs are using
 update the modular input code, you can run `ucc-gen` again and `ucc-gen` will 
 use updated modular inputs from `package/bin` instead of generating new ones.
 
+## Subcommands
+
+As of now, running `ucc-gen` does the same thing as running `ucc-gen build`, 
+but eventually calling `ucc-gen` without specifying a subcommand will be 
+deprecated. 
+
+* `build` - [optional] used to build the add-on 
+
+    * `source` - [optional] folder containing the `app.manifest` and app 
+        source.
+    * `config` - [optional] path to the configuration file, defaults to
+        globalConfig file in the parent directory of source provided.
+    * `ta-version` - [optional] override current version of TA, default
+        version is version specified in `globalConfig.json` or `globalConfig.yaml`. 
+        Splunkbase compatible version of SEMVER will be used by default.
+    * `python-binary-name` - [optional] Python binary name to use when
+        installing Python libraries.
+
 ## Parameters
 
 `ucc-gen` supports the following params:
 
-* `source` - [optional] folder containing the `app.manifest` and app 
-    source.
-* `config` - [optional] path to the configuration file, defaults to
-    globalConfig file in the parent directory of source provided.
-* `ta-version` - [optional] override current version of TA, default
-    version is version specified in `globalConfig.json` or `globalConfig.yaml`. 
-    Splunkbase compatible version of SEMVER will be used by default.
-* `python-binary-name` - [optional] Python binary name to use when
-    installing Python libraries.
+
 
 ## What `ucc-gen` does
 

--- a/example/globalConfig.json
+++ b/example/globalConfig.json
@@ -161,7 +161,7 @@
     "meta": {
         "name": "Splunk_TA_dummy_data",
         "restRoot": "Splunk_TA_dummy_data",
-        "version": "5.18.0R204e10cd",
+        "version": "5.18.0R26de98e0",
         "displayName": "Splunk_TA_dummy_data",
         "schemaVersion": "0.0.3"
     }

--- a/splunk_add_on_ucc_framework/main.py
+++ b/splunk_add_on_ucc_framework/main.py
@@ -20,43 +20,77 @@ from typing import Optional, Sequence
 from splunk_add_on_ucc_framework import generate
 
 
+# This is a necessary change to have, so we don't release a breaking change.
+# This class adds a default subparser if none specified. In our case it will be
+# `build`subclass.
+# This is a temporary change and everyone migrates to `ucc-gen build` instead of
+# just using `ucc-gen` this will be removed.
+# The limitation of this approach is that we can't have global options without a
+# subparser being specified. Example is `--version`, the default subparser will
+# be added here as well. But this is not a big deal for now, we don't have
+# global options anyway.
+class DefaultSubcommandArgumentParser(argparse.ArgumentParser):
+    __default_subparser = None
+
+    def set_default_subparser(self, name):
+        self.__default_subparser = name
+
+    def _parse_known_args(self, arg_strings, *args, **kwargs):
+        in_args = set(arg_strings)
+        d_sp = self.__default_subparser
+        if d_sp is not None and not {"-h", "--help"}.intersection(in_args):
+            for x in self._subparsers._actions:
+                subparser_found = isinstance(
+                    x, argparse._SubParsersAction
+                ) and in_args.intersection(x._name_parser_map.keys())
+                if subparser_found:
+                    break
+            else:
+                arg_strings = [d_sp] + arg_strings
+        return super()._parse_known_args(arg_strings, *args, **kwargs)
+
+
 def main(argv: Optional[Sequence[str]] = None):
     argv = argv if argv is not None else sys.argv[1:]
-    parser = argparse.ArgumentParser(description="Build the add-on")
-    parser.add_argument(
+    parser = DefaultSubcommandArgumentParser(description="Build the add-on")
+    parser.set_default_subparser("build")
+    subparsers = parser.add_subparsers(dest="command")
+    build_parser = subparsers.add_parser("build")
+    build_parser.add_argument(
         "--source",
         type=str,
         nargs="?",
         help="Folder containing the app.manifest and app source",
         default="package",
     )
-    parser.add_argument(
+    build_parser.add_argument(
         "--config",
         type=str,
         nargs="?",
         help="Path to configuration file, defaults to globalConfig file in parent directory of source provided",
         default=None,
     )
-    parser.add_argument(
+    build_parser.add_argument(
         "--ta-version",
         type=str,
         help="Version of TA, default version is version specified in the "
         "package such as app.manifest, app.conf, and globalConfig file.",
         default=None,
     )
-    parser.add_argument(
+    build_parser.add_argument(
         "--python-binary-name",
         type=str,
         help="Python binary name to use to install requirements",
         default="python3",
     )
     args = parser.parse_args(argv)
-    generate(
-        source=args.source,
-        config=args.config,
-        ta_version=args.ta_version,
-        python_binary_name=args.python_binary_name,
-    )
+    if args.command == "build":
+        generate(
+            source=args.source,
+            config=args.config,
+            ta_version=args.ta_version,
+            python_binary_name=args.python_binary_name,
+        )
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -33,7 +33,25 @@ from splunk_add_on_ucc_framework import main
             },
         ),
         (
+            ["build"],
+            {
+                "source": "package",
+                "config": None,
+                "ta_version": None,
+                "python_binary_name": "python3",
+            },
+        ),
+        (
             ["--source", "package"],
+            {
+                "source": "package",
+                "config": None,
+                "ta_version": None,
+                "python_binary_name": "python3",
+            },
+        ),
+        (
+            ["build", "--source", "package"],
             {
                 "source": "package",
                 "config": None,
@@ -86,6 +104,25 @@ from splunk_add_on_ucc_framework import main
         ),
         (
             [
+                "--source",
+                "package",
+                "--config",
+                "/path/to/globalConfig.yaml",
+                "--ta-version",
+                "2.2.0",
+                "--python-binary-name",
+                "python.exe",
+            ],
+            {
+                "source": "package",
+                "config": "/path/to/globalConfig.yaml",
+                "ta_version": "2.2.0",
+                "python_binary_name": "python.exe",
+            },
+        ),
+        (
+            [
+                "build",
                 "--source",
                 "package",
                 "--config",


### PR DESCRIPTION
This is not a breaking change.

This PR introduces a subcommand `build`. The effect from running `ucc-gen` is the same as from running `ucc-gen build`, but running `ucc-gen` without a subcommand will be deprecated in the future releases.