### PR TITLE
feat: trigger v5.20.0 release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,9 +3,9 @@ updates:
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
   - package-ecosystem: "github-actions"
     directory: "/"
     target-branch: "main"
     schedule:
-      interval: "daily"
+      interval: "weekly"


### PR DESCRIPTION
The previous commit I squashed had "ci skip" in it, that's why GitHub decided to skip the whole pipeline.