### PR TITLE
refactor: introduce and reuse GlobalConfig class to manage globalConfig file

### DIFF
--- a/example/globalConfig.json
+++ b/example/globalConfig.json
@@ -161,7 +161,7 @@
     "meta": {
         "name": "Splunk_TA_dummy_data",
         "restRoot": "Splunk_TA_dummy_data",
-        "version": "5.20.0R1ba37ac7",
+        "version": "5.20.0Rce361b78",
         "displayName": "Splunk_TA_dummy_data",
         "schemaVersion": "0.0.3"
     }

--- a/example/globalConfig.json
+++ b/example/globalConfig.json
@@ -161,7 +161,7 @@
     "meta": {
         "name": "Splunk_TA_dummy_data",
         "restRoot": "Splunk_TA_dummy_data",
-        "version": "5.20.0Rc5bf18ae",
+        "version": "5.20.0Rc667430b",
         "displayName": "Splunk_TA_dummy_data",
         "schemaVersion": "0.0.3"
     }

--- a/example/globalConfig.json
+++ b/example/globalConfig.json
@@ -161,7 +161,7 @@
     "meta": {
         "name": "Splunk_TA_dummy_data",
         "restRoot": "Splunk_TA_dummy_data",
-        "version": "5.20.0Rc667430b",
+        "version": "5.20.0Re3a8812b",
         "displayName": "Splunk_TA_dummy_data",
         "schemaVersion": "0.0.3"
     }

--- a/example/globalConfig.json
+++ b/example/globalConfig.json
@@ -161,7 +161,7 @@
     "meta": {
         "name": "Splunk_TA_dummy_data",
         "restRoot": "Splunk_TA_dummy_data",
-        "version": "5.20.0Rce361b78",
+        "version": "5.20.0R770b015b",
         "displayName": "Splunk_TA_dummy_data",
         "schemaVersion": "0.0.3"
     }

--- a/example/globalConfig.json
+++ b/example/globalConfig.json
@@ -161,7 +161,7 @@
     "meta": {
         "name": "Splunk_TA_dummy_data",
         "restRoot": "Splunk_TA_dummy_data",
-        "version": "5.20.0Re3a8812b",
+        "version": "5.20.0R1ba37ac7",
         "displayName": "Splunk_TA_dummy_data",
         "schemaVersion": "0.0.3"
     }

--- a/splunk_add_on_ucc_framework/global_config.py
+++ b/splunk_add_on_ucc_framework/global_config.py
@@ -27,8 +27,6 @@ yaml_load = functools.partial(yaml.load, Loader=Loader)
 class GlobalConfig:
     def __init__(self):
         self._content = None
-        self._inputs = []
-        self._tabs = []
         self._configs = []
         self._settings = []
         self._is_global_config_yaml = None
@@ -49,19 +47,6 @@ class GlobalConfig:
         else:
             utils.dump_json_config(self._content, path)
 
-    def _parse_components(self):
-        pages = self._content["pages"]
-        configuration = pages.get("configuration", {})
-        self._tabs = configuration.get("tabs", [])
-        # TODO: do we need this?
-        for tab in self._tabs:
-            if "table" in tab:
-                self._configs.append(tab)
-            else:
-                self._settings.append(tab)
-        if "inputs" in pages:
-            self._inputs = pages["inputs"]["services"]
-
     @property
     def is_global_config_yaml(self) -> bool:
         return self._is_global_config_yaml
@@ -76,11 +61,13 @@ class GlobalConfig:
 
     @property
     def inputs(self):
-        return self._inputs
+        if "inputs" in self._content["pages"]:
+            return self._content["pages"]["inputs"]["services"]
+        return []
 
     @property
     def tabs(self):
-        return self._tabs
+        return self._content["pages"]["configuration"]["tabs"]
 
     @property
     def configs(self):
@@ -112,3 +99,6 @@ class GlobalConfig:
 
     def update_addon_version(self, version: str) -> None:
         self._content.setdefault("meta", {})["version"] = version
+
+    def has_inputs(self) -> bool:
+        return bool(self.inputs)

--- a/splunk_add_on_ucc_framework/global_config.py
+++ b/splunk_add_on_ucc_framework/global_config.py
@@ -1,0 +1,114 @@
+#
+# Copyright 2021 Splunk Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import functools
+import json
+
+import yaml
+
+from splunk_add_on_ucc_framework import utils
+
+Loader = getattr(yaml, "CSafeLoader", yaml.SafeLoader)
+yaml_load = functools.partial(yaml.load, Loader=Loader)
+
+
+class GlobalConfig:
+    def __init__(self):
+        self._content = None
+        self._inputs = []
+        self._tabs = []
+        self._configs = []
+        self._settings = []
+        self._is_global_config_yaml = None
+        self._original_path = None
+
+    def parse(self, global_config_path: str, is_global_config_yaml: bool) -> None:
+        with open(global_config_path) as f_config:
+            config_raw = f_config.read()
+        self._content = (
+            yaml_load(config_raw) if is_global_config_yaml else json.loads(config_raw)
+        )
+        self._is_global_config_yaml = is_global_config_yaml
+        self._original_path = global_config_path
+
+    def dump(self, path: str):
+        if self._is_global_config_yaml:
+            utils.dump_yaml_config(self._content, path)
+        else:
+            utils.dump_json_config(self._content, path)
+
+    def _parse_components(self):
+        pages = self._content["pages"]
+        configuration = pages.get("configuration", {})
+        self._tabs = configuration.get("tabs", [])
+        # TODO: do we need this?
+        for tab in self._tabs:
+            if "table" in tab:
+                self._configs.append(tab)
+            else:
+                self._settings.append(tab)
+        if "inputs" in pages:
+            self._inputs = pages["inputs"]["services"]
+
+    @property
+    def is_global_config_yaml(self) -> bool:
+        return self._is_global_config_yaml
+
+    @property
+    def content(self):
+        return self._content
+
+    @content.setter
+    def content(self, new_content):
+        self._content = new_content
+
+    @property
+    def inputs(self):
+        return self._inputs
+
+    @property
+    def tabs(self):
+        return self._tabs
+
+    @property
+    def configs(self):
+        return self._configs
+
+    @property
+    def settings(self):
+        return self._settings
+
+    @property
+    def meta(self):
+        return self._content["meta"]
+
+    @property
+    def namespace(self) -> str:
+        return self.meta["restRoot"]
+
+    @property
+    def product(self) -> str:
+        return self.meta["name"]
+
+    @property
+    def version(self) -> str:
+        return self.meta["version"]
+
+    @property
+    def original_path(self) -> str:
+        return self._original_path
+
+    def update_addon_version(self, version: str) -> None:
+        self._content.setdefault("meta", {})["version"] = version

--- a/splunk_add_on_ucc_framework/global_config.py
+++ b/splunk_add_on_ucc_framework/global_config.py
@@ -15,6 +15,7 @@
 #
 import functools
 import json
+from typing import Optional
 
 import yaml
 
@@ -48,16 +49,8 @@ class GlobalConfig:
             utils.dump_json_config(self._content, path)
 
     @property
-    def is_global_config_yaml(self) -> bool:
-        return self._is_global_config_yaml
-
-    @property
     def content(self):
         return self._content
-
-    @content.setter
-    def content(self, new_content):
-        self._content = new_content
 
     @property
     def inputs(self):
@@ -68,14 +61,6 @@ class GlobalConfig:
     @property
     def tabs(self):
         return self._content["pages"]["configuration"]["tabs"]
-
-    @property
-    def configs(self):
-        return self._configs
-
-    @property
-    def settings(self):
-        return self._settings
 
     @property
     def meta(self):
@@ -96,6 +81,13 @@ class GlobalConfig:
     @property
     def original_path(self) -> str:
         return self._original_path
+
+    @property
+    def schema_version(self) -> Optional[str]:
+        return self.meta.get("schemaVersion")
+
+    def update_schema_version(self, new_schema_version):
+        self.meta["schemaVersion"] = new_schema_version
 
     def update_addon_version(self, version: str) -> None:
         self._content.setdefault("meta", {})["version"] = version

--- a/splunk_add_on_ucc_framework/global_config.py
+++ b/splunk_add_on_ucc_framework/global_config.py
@@ -28,8 +28,6 @@ yaml_load = functools.partial(yaml.load, Loader=Loader)
 class GlobalConfig:
     def __init__(self):
         self._content = None
-        self._configs = []
-        self._settings = []
         self._is_global_config_yaml = None
         self._original_path = None
 

--- a/splunk_add_on_ucc_framework/global_config_validator.py
+++ b/splunk_add_on_ucc_framework/global_config_validator.py
@@ -21,6 +21,8 @@ from typing import Any, Dict
 
 import jsonschema
 
+from splunk_add_on_ucc_framework import global_config as global_config_lib
+
 
 class GlobalConfigValidatorException(Exception):
     pass
@@ -34,9 +36,9 @@ class GlobalConfigValidator:
     Custom validation should be implemented here.
     """
 
-    def __init__(self, source_dir: str, config: dict):
+    def __init__(self, source_dir: str, global_config: global_config_lib.GlobalConfig):
         self._source_dir = source_dir
-        self._config = config
+        self._config = global_config.content
 
     def _validate_config_against_schema(self) -> None:
         """

--- a/tests/testdata/test_addons/package_global_config_configuration/globalConfig.json
+++ b/tests/testdata/test_addons/package_global_config_configuration/globalConfig.json
@@ -421,7 +421,7 @@
     "meta": {
         "name": "Splunk_TA_UCCExample",
         "restRoot": "splunk_ta_uccexample",
-        "version": "5.20.0Rc5bf18ae",
+        "version": "5.20.0Rc667430b",
         "displayName": "Splunk UCC test Add-on",
         "schemaVersion": "0.0.3"
     }

--- a/tests/testdata/test_addons/package_global_config_configuration/globalConfig.json
+++ b/tests/testdata/test_addons/package_global_config_configuration/globalConfig.json
@@ -421,7 +421,7 @@
     "meta": {
         "name": "Splunk_TA_UCCExample",
         "restRoot": "splunk_ta_uccexample",
-        "version": "5.20.0Rc667430b",
+        "version": "5.20.0Re3a8812b",
         "displayName": "Splunk UCC test Add-on",
         "schemaVersion": "0.0.3"
     }

--- a/tests/testdata/test_addons/package_global_config_configuration/globalConfig.json
+++ b/tests/testdata/test_addons/package_global_config_configuration/globalConfig.json
@@ -421,7 +421,7 @@
     "meta": {
         "name": "Splunk_TA_UCCExample",
         "restRoot": "splunk_ta_uccexample",
-        "version": "5.20.0R1ba37ac7",
+        "version": "5.20.0Rce361b78",
         "displayName": "Splunk UCC test Add-on",
         "schemaVersion": "0.0.3"
     }

--- a/tests/testdata/test_addons/package_global_config_configuration/globalConfig.json
+++ b/tests/testdata/test_addons/package_global_config_configuration/globalConfig.json
@@ -421,7 +421,7 @@
     "meta": {
         "name": "Splunk_TA_UCCExample",
         "restRoot": "splunk_ta_uccexample",
-        "version": "5.20.0Re3a8812b",
+        "version": "5.20.0R1ba37ac7",
         "displayName": "Splunk UCC test Add-on",
         "schemaVersion": "0.0.3"
     }

--- a/tests/testdata/test_addons/package_global_config_configuration/globalConfig.json
+++ b/tests/testdata/test_addons/package_global_config_configuration/globalConfig.json
@@ -421,7 +421,7 @@
     "meta": {
         "name": "Splunk_TA_UCCExample",
         "restRoot": "splunk_ta_uccexample",
-        "version": "5.20.0Rce361b78",
+        "version": "5.20.0R770b015b",
         "displayName": "Splunk UCC test Add-on",
         "schemaVersion": "0.0.3"
     }

--- a/tests/testdata/test_addons/package_global_config_inputs_configuration_alerts/globalConfig.json
+++ b/tests/testdata/test_addons/package_global_config_inputs_configuration_alerts/globalConfig.json
@@ -1108,7 +1108,7 @@
     "meta": {
         "name": "Splunk_TA_UCCExample",
         "restRoot": "splunk_ta_uccexample",
-        "version": "5.20.0Re3a8812b",
+        "version": "5.20.0R1ba37ac7",
         "displayName": "Splunk UCC test Add-on",
         "schemaVersion": "0.0.3"
     }

--- a/tests/testdata/test_addons/package_global_config_inputs_configuration_alerts/globalConfig.json
+++ b/tests/testdata/test_addons/package_global_config_inputs_configuration_alerts/globalConfig.json
@@ -1108,7 +1108,7 @@
     "meta": {
         "name": "Splunk_TA_UCCExample",
         "restRoot": "splunk_ta_uccexample",
-        "version": "5.20.0Rc667430b",
+        "version": "5.20.0Re3a8812b",
         "displayName": "Splunk UCC test Add-on",
         "schemaVersion": "0.0.3"
     }

--- a/tests/testdata/test_addons/package_global_config_inputs_configuration_alerts/globalConfig.json
+++ b/tests/testdata/test_addons/package_global_config_inputs_configuration_alerts/globalConfig.json
@@ -1108,7 +1108,7 @@
     "meta": {
         "name": "Splunk_TA_UCCExample",
         "restRoot": "splunk_ta_uccexample",
-        "version": "5.20.0R1ba37ac7",
+        "version": "5.20.0Rce361b78",
         "displayName": "Splunk UCC test Add-on",
         "schemaVersion": "0.0.3"
     }

--- a/tests/testdata/test_addons/package_global_config_inputs_configuration_alerts/globalConfig.json
+++ b/tests/testdata/test_addons/package_global_config_inputs_configuration_alerts/globalConfig.json
@@ -1108,7 +1108,7 @@
     "meta": {
         "name": "Splunk_TA_UCCExample",
         "restRoot": "splunk_ta_uccexample",
-        "version": "5.20.0Rc5bf18ae",
+        "version": "5.20.0Rc667430b",
         "displayName": "Splunk UCC test Add-on",
         "schemaVersion": "0.0.3"
     }

--- a/tests/testdata/test_addons/package_global_config_inputs_configuration_alerts/globalConfig.json
+++ b/tests/testdata/test_addons/package_global_config_inputs_configuration_alerts/globalConfig.json
@@ -1108,7 +1108,7 @@
     "meta": {
         "name": "Splunk_TA_UCCExample",
         "restRoot": "splunk_ta_uccexample",
-        "version": "5.20.0Rce361b78",
+        "version": "5.20.0R770b015b",
         "displayName": "Splunk UCC test Add-on",
         "schemaVersion": "0.0.3"
     }

--- a/tests/unit/test_global_config.py
+++ b/tests/unit/test_global_config.py
@@ -1,0 +1,39 @@
+#
+# Copyright 2021 Splunk Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import pytest
+
+import tests.unit.helpers as helpers
+
+from splunk_add_on_ucc_framework import global_config as global_config_lib
+
+
+@pytest.mark.parametrize(
+    "filename,is_yaml",
+    [
+        ("valid_config.json", False),
+        ("valid_config.yaml", True),
+    ],
+)
+def test_global_config_parse(filename, is_yaml):
+    global_config_path = helpers.get_testdata_file_path(filename)
+    global_config = global_config_lib.GlobalConfig()
+    global_config.parse(global_config_path, is_yaml)
+
+    assert global_config.namespace == "splunk_ta_uccexample"
+    assert global_config.product == "Splunk_TA_UCCExample"
+    assert global_config.original_path == global_config_path
+    assert global_config.schema_version is None
+    assert global_config.has_inputs() is True

--- a/tests/unit/test_global_config_update.py
+++ b/tests/unit/test_global_config_update.py
@@ -21,44 +21,53 @@ from splunk_add_on_ucc_framework.global_config_update import (
     _handle_biased_terms_update,
     _handle_dropping_api_version_update,
 )
+from splunk_add_on_ucc_framework import global_config as global_config_lib
 
 
 @pytest.mark.parametrize(
-    "file_name", ["config_with_biased_terms.json", "config_with_biased_terms.yaml"]
+    "filename,is_yaml",
+    [
+        ("config_with_biased_terms.json", False),
+        ("config_with_biased_terms.yaml", True),
+    ],
 )
-def test_handle_biased_terms_update(file_name):
-    config = helpers.get_testdata(file_name)
-    updated_config = _handle_biased_terms_update(config)
+def test_handle_biased_terms_update(filename, is_yaml):
+    global_config_path = helpers.get_testdata_file_path(filename)
+    global_config = global_config_lib.GlobalConfig()
+    global_config.parse(global_config_path, is_yaml)
+    _handle_biased_terms_update(global_config)
     expected_schema_version = "0.0.1"
-    assert expected_schema_version == updated_config["meta"]["schemaVersion"]
-    input_entity_1_options_keys = updated_config["pages"]["inputs"]["services"][0][
-        "entity"
-    ][0]["options"].keys()
+    assert expected_schema_version == global_config.schema_version
+    input_entity_1_options_keys = global_config.inputs[0]["entity"][0]["options"].keys()
     assert "denyList" in input_entity_1_options_keys
     assert "blackList" not in input_entity_1_options_keys
-    input_entity_2_options_keys = updated_config["pages"]["inputs"]["services"][0][
-        "entity"
-    ][1]["options"].keys()
+    input_entity_2_options_keys = global_config.inputs[0]["entity"][1]["options"].keys()
     assert "allowList" in input_entity_2_options_keys
     assert "whileList" not in input_entity_2_options_keys
-    configuration_entity_1_options_keys = updated_config["pages"]["configuration"][
-        "tabs"
-    ][0]["entity"][0]["options"].keys()
+    configuration_entity_1_options_keys = global_config.tabs[0]["entity"][0][
+        "options"
+    ].keys()
     assert "denyList" in configuration_entity_1_options_keys
     assert "blackList" not in configuration_entity_1_options_keys
-    configuration_entity_2_options_keys = updated_config["pages"]["configuration"][
-        "tabs"
-    ][0]["entity"][1]["options"].keys()
+    configuration_entity_2_options_keys = global_config.tabs[0]["entity"][1][
+        "options"
+    ].keys()
     assert "allowList" in configuration_entity_2_options_keys
     assert "whileList" not in configuration_entity_2_options_keys
 
 
 @pytest.mark.parametrize(
-    "file_name", ["config_with_biased_terms.json", "config_with_biased_terms.yaml"]
+    "filename,is_yaml",
+    [
+        ("config_with_biased_terms.json", False),
+        ("config_with_biased_terms.yaml", True),
+    ],
 )
-def test_handle_dropping_api_version_update(file_name):
-    config = helpers.get_testdata(file_name)
-    updated_config = _handle_dropping_api_version_update(config)
+def test_handle_dropping_api_version_update(filename, is_yaml):
+    global_config_path = helpers.get_testdata_file_path(filename)
+    global_config = global_config_lib.GlobalConfig()
+    global_config.parse(global_config_path, is_yaml)
+    _handle_dropping_api_version_update(global_config)
     expected_schema_version = "0.0.3"
-    assert expected_schema_version == updated_config["meta"]["schemaVersion"]
-    assert "apiVersion" not in updated_config["meta"]
+    assert expected_schema_version == global_config.schema_version
+    assert "apiVersion" not in global_config.meta

--- a/tests/unit/test_global_config_validator.py
+++ b/tests/unit/test_global_config_validator.py
@@ -23,6 +23,7 @@ from splunk_add_on_ucc_framework.global_config_validator import (
     GlobalConfigValidator,
     GlobalConfigValidatorException,
 )
+from splunk_add_on_ucc_framework import global_config as global_config_lib
 
 
 def _path_to_source_dir() -> str:
@@ -33,29 +34,33 @@ def _path_to_source_dir() -> str:
 
 
 @pytest.mark.parametrize(
-    "filename",
+    "filename,is_yaml",
     [
-        "valid_config.json",
-        "valid_config.yaml",
+        ("valid_config.json", False),
+        ("valid_config.yaml", True),
     ],
 )
-def test_config_validation_when_valid(filename):
-    config = helpers.get_testdata(filename)
-    validator = GlobalConfigValidator(_path_to_source_dir(), config)
+def test_config_validation_when_valid(filename, is_yaml):
+    global_config_path = helpers.get_testdata_file_path(filename)
+    global_config = global_config_lib.GlobalConfig()
+    global_config.parse(global_config_path, is_yaml)
+    validator = GlobalConfigValidator(_path_to_source_dir(), global_config)
     with does_not_raise():
         validator.validate()
 
 
 @pytest.mark.parametrize(
-    "filename,expectation,exception_message",
+    "filename,is_yaml,expectation,exception_message",
     [
         (
             "invalid_config_no_configuration_tabs.json",
+            False,
             pytest.raises(GlobalConfigValidatorException),
             "[] is too short",
         ),
         (
             "invalid_config_no_name_field_in_configuration_tab_table.json",
+            False,
             pytest.raises(GlobalConfigValidatorException),
             "Tab 'account' should have entity with field 'name'",
         ),
@@ -63,6 +68,7 @@ def test_config_validation_when_valid(filename):
         # "example_input_one" input
         (
             "invalid_config_both_rest_handler_name_module_are_present.json",
+            False,
             pytest.raises(GlobalConfigValidatorException),
             (
                 "Input 'example_input_one' has both 'restHandlerName' and "
@@ -75,6 +81,7 @@ def test_config_validation_when_valid(filename):
         # "example_input_one" input
         (
             "invalid_config_both_rest_handler_name_class_are_present.json",
+            False,
             pytest.raises(GlobalConfigValidatorException),
             (
                 "Input 'example_input_one' has both 'restHandlerName' and "
@@ -86,6 +93,7 @@ def test_config_validation_when_valid(filename):
         # Only restHandlerModule is present in the "example_input_one" input
         (
             "invalid_config_only_rest_handler_module_is_present.json",
+            False,
             pytest.raises(GlobalConfigValidatorException),
             (
                 "Input 'example_input_one' should have both 'restHandlerModule'"
@@ -95,6 +103,7 @@ def test_config_validation_when_valid(filename):
         # Only restHandlerClass is present in the "example_input_one" input
         (
             "invalid_config_only_rest_handler_class_is_present.json",
+            False,
             pytest.raises(GlobalConfigValidatorException),
             (
                 "Input 'example_input_one' should have both 'restHandlerModule'"
@@ -103,11 +112,13 @@ def test_config_validation_when_valid(filename):
         ),
         (
             "invalid_config_validators_missing_for_file_input.json",
+            False,
             pytest.raises(GlobalConfigValidatorException),
             ("File validator should be present for " "'service_account' field."),
         ),
         (
             "invalid_config_supported_file_types_field_is_missing.json",
+            False,
             pytest.raises(GlobalConfigValidatorException),
             (
                 "`json` should be present in the "
@@ -117,6 +128,7 @@ def test_config_validation_when_valid(filename):
         ),
         (
             "invalid_config_json_is_missing_in_supported_file_types.json",
+            False,
             pytest.raises(GlobalConfigValidatorException),
             (
                 "`json` is only currently supported for "
@@ -125,6 +137,7 @@ def test_config_validation_when_valid(filename):
         ),
         (
             "invalid_config_configuration_string_validator_maxLength_less_than_minLength.json",
+            False,
             pytest.raises(GlobalConfigValidatorException),
             (
                 "Entity 'name' has incorrect string validator, "
@@ -133,6 +146,7 @@ def test_config_validation_when_valid(filename):
         ),
         (
             "invalid_config_configuration_number_validator_range_should_have_2_elements.json",
+            False,
             pytest.raises(GlobalConfigValidatorException),
             (
                 "Entity 'interval' has incorrect number validator, "
@@ -141,6 +155,7 @@ def test_config_validation_when_valid(filename):
         ),
         (
             "invalid_config_configuration_number_validator_range_second_element_smaller_than_first.json",
+            False,
             pytest.raises(GlobalConfigValidatorException),
             (
                 "Entity 'interval' has incorrect number validator, "
@@ -149,6 +164,7 @@ def test_config_validation_when_valid(filename):
         ),
         (
             "invalid_config_configuration_regex_validator_non_compilable_pattern.json",
+            False,
             pytest.raises(GlobalConfigValidatorException),
             (
                 "Entity 'name' has incorrect regex validator, "
@@ -157,6 +173,7 @@ def test_config_validation_when_valid(filename):
         ),
         (
             "invalid_config_inputs_string_validator_maxLength_less_than_minLength.json",
+            False,
             pytest.raises(GlobalConfigValidatorException),
             (
                 "Entity 'name' has incorrect string validator, "
@@ -165,6 +182,7 @@ def test_config_validation_when_valid(filename):
         ),
         (
             "invalid_config_inputs_number_validator_range_should_have_2_elements.json",
+            False,
             pytest.raises(GlobalConfigValidatorException),
             (
                 "Entity 'port' has incorrect number validator, "
@@ -173,6 +191,7 @@ def test_config_validation_when_valid(filename):
         ),
         (
             "invalid_config_inputs_number_validator_range_second_element_smaller_than_first.json",
+            False,
             pytest.raises(GlobalConfigValidatorException),
             (
                 "Entity 'port' has incorrect number validator, "
@@ -181,6 +200,7 @@ def test_config_validation_when_valid(filename):
         ),
         (
             "invalid_config_inputs_regex_validator_non_compilable_pattern.json",
+            False,
             pytest.raises(GlobalConfigValidatorException),
             (
                 "Entity 'name' has incorrect regex validator, "
@@ -189,59 +209,73 @@ def test_config_validation_when_valid(filename):
         ),
         (
             "invalid_config_no_configuration_tabs.yaml",
+            True,
             pytest.raises(GlobalConfigValidatorException),
             "[] is too short",
         ),
         (
             "invalid_config_no_name_field_in_configuration_tab_table.yaml",
+            True,
             pytest.raises(GlobalConfigValidatorException),
             "Tab 'account' should have entity with field 'name'",
         ),
         (
             "invalid_config_configuration_autoCompleteFields_duplicates.json",
+            False,
             pytest.raises(GlobalConfigValidatorException),
             "Duplicates found for autoCompleteFields: 'Duplicate'",
         ),
         (
             "invalid_config_configuration_children_duplicates.json",
+            False,
             pytest.raises(GlobalConfigValidatorException),
             "Duplicates found for autoCompleteFields children in entity 'Duplicate'",
         ),
         (
             "invalid_config_configuration_entity_duplicates.json",
+            False,
             pytest.raises(GlobalConfigValidatorException),
             "Duplicates found for entity field or label",
         ),
         (
             "invalid_config_configuration_tabs_duplicates.json",
+            False,
             pytest.raises(GlobalConfigValidatorException),
             "Duplicates found for tabs names or titles",
         ),
         (
             "invalid_config_inputs_services_duplicates.json",
+            False,
             pytest.raises(GlobalConfigValidatorException),
             "Duplicates found for inputs (services) names or titles",
         ),
         (
             "invalid_config_inputs_entity_duplicates.json",
+            False,
             pytest.raises(GlobalConfigValidatorException),
             "Duplicates found for entity field or label",
         ),
         (
             "invalid_config_inputs_children_duplicates.json",
+            False,
             pytest.raises(GlobalConfigValidatorException),
             "Duplicates found for autoCompleteFields children in entity 'Single Select'",
         ),
         (
             "invalid_config_inputs_autoCompleteFields_duplicates.json",
+            False,
             pytest.raises(GlobalConfigValidatorException),
             "Duplicates found for autoCompleteFields: 'Single Select'",
         ),
     ],
 )
-def test_config_validation_when_error(filename, expectation, exception_message):
-    config = helpers.get_testdata(filename)
-    validator = GlobalConfigValidator(_path_to_source_dir(), config)
+def test_config_validation_when_error(
+    filename, is_yaml, expectation, exception_message
+):
+    global_config_path = helpers.get_testdata_file_path(filename)
+    global_config = global_config_lib.GlobalConfig()
+    global_config.parse(global_config_path, is_yaml)
+    validator = GlobalConfigValidator(_path_to_source_dir(), global_config)
     with expectation as exc_info:
         validator.validate()
     (msg,) = exc_info.value.args


### PR DESCRIPTION
This PR introduces a new class for handling globalConfig file which is reused across some part of the codebase as part of this PR. I did not touch code for generating alerts, but a goal is to reuse it across 100% of the codebase.

No breaking changes are expected as it is only an internal refactoring.