### PR TITLE
feat: generate default values in .conf files

### DIFF
--- a/example/globalConfig.json
+++ b/example/globalConfig.json
@@ -161,7 +161,7 @@
     "meta": {
         "name": "Splunk_TA_dummy_data",
         "restRoot": "Splunk_TA_dummy_data",
-        "version": "5.20.0R9f9c8fed",
+        "version": "5.21.0Rd1ef222d",
         "displayName": "Splunk_TA_dummy_data",
         "schemaVersion": "0.0.3"
     }

--- a/splunk_add_on_ucc_framework/commands/rest_builder/builder.py
+++ b/splunk_add_on_ucc_framework/commands/rest_builder/builder.py
@@ -96,7 +96,7 @@ class RestBuilder:
                     self.output.put(
                         self.output.default,
                         endpoint.conf_name + ".conf",
-                        endpoint.generate_default_conf(),
+                        endpoint.generate_conf_with_default_values(),
                     )
 
                 self.output.put(

--- a/splunk_add_on_ucc_framework/commands/rest_builder/endpoint/base.py
+++ b/splunk_add_on_ucc_framework/commands/rest_builder/endpoint/base.py
@@ -63,11 +63,15 @@ field.RestField(
     def name_rh(self):
         raise NotImplementedError()
 
-    def generate_spec(self, omit_kv_pairs=False):
+    def generate_spec(self):
         title = self._title_template.format(self.name_spec)
-        if omit_kv_pairs:
-            return title
         lines = [field.generate_spec() for field in self._fields]
+        lines.insert(0, title)
+        return "\n".join(lines)
+
+    def generate_conf_with_default_values(self):
+        title = self._title_template.format(self.name_spec)
+        lines = [field.generate_conf_with_default_value() for field in self._fields]
         lines.insert(0, title)
         return "\n".join(lines)
 
@@ -147,8 +151,10 @@ class RestEndpointBuilder:
         specs = [entity.generate_spec() for entity in self._entities]
         return "\n\n".join(specs)
 
-    def generate_default_conf(self):
-        specs = [entity.generate_spec(True) for entity in self._entities]
+    def generate_conf_with_default_values(self):
+        specs = [
+            entity.generate_conf_with_default_values() for entity in self._entities
+        ]
         return "\n\n".join(specs)
 
     def generate_rh(self) -> str:

--- a/splunk_add_on_ucc_framework/commands/rest_builder/endpoint/field.py
+++ b/splunk_add_on_ucc_framework/commands/rest_builder/endpoint/field.py
@@ -45,6 +45,11 @@ class RestFieldBuilder:
             value="",
         )
 
+    def generate_conf_with_default_value(self) -> str:
+        return self._kv_template.format(
+            name=self._name, value=self._default if self._default is not None else ""
+        )
+
     def _indent_validator(self) -> str:
         validator = indent(self._validator)
         return validator[4:]

--- a/tests/testdata/expected_addons/expected_output_global_config_configuration/Splunk_TA_UCCExample/default/splunk_ta_uccexample_settings.conf
+++ b/tests/testdata/expected_addons/expected_output_global_config_configuration/Splunk_TA_UCCExample/default/splunk_ta_uccexample_settings.conf
@@ -1,5 +1,20 @@
 [proxy]
+proxy_enabled = 
+proxy_type = http
+proxy_url = 
+proxy_port = 
+proxy_username = 
+proxy_password = 
+proxy_rdns = 
 
 [logging]
+loglevel = INFO
 
 [custom_abc]
+testString = 
+testNumber = 
+testRegex = 
+testEmail = 
+testIpv4 = 
+testDate = 
+testUrl = 

--- a/tests/testdata/expected_addons/expected_output_global_config_inputs_configuration_alerts/Splunk_TA_UCCExample/default/splunk_ta_uccexample_settings.conf
+++ b/tests/testdata/expected_addons/expected_output_global_config_inputs_configuration_alerts/Splunk_TA_UCCExample/default/splunk_ta_uccexample_settings.conf
@@ -1,5 +1,20 @@
 [proxy]
+proxy_enabled = 
+proxy_type = http
+proxy_url = 
+proxy_port = 
+proxy_username = 
+proxy_password = 
+proxy_rdns = 
 
 [logging]
+loglevel = INFO
 
 [custom_abc]
+testString = 
+testNumber = 
+testRegex = 
+testEmail = 
+testIpv4 = 
+testDate = 
+testUrl = 

--- a/tests/testdata/test_addons/package_global_config_inputs_configuration_alerts/globalConfig.json
+++ b/tests/testdata/test_addons/package_global_config_inputs_configuration_alerts/globalConfig.json
@@ -1108,7 +1108,7 @@
     "meta": {
         "name": "Splunk_TA_UCCExample",
         "restRoot": "splunk_ta_uccexample",
-        "version": "5.20.0R9f9c8fed",
+        "version": "5.21.0Rd1ef222d",
         "displayName": "Splunk UCC test Add-on",
         "schemaVersion": "0.0.3"
     }


### PR DESCRIPTION
`ucc-gen` will now generate the default values for the `splunk_ta_<add-on-name>_settings.conf` file. For example, if you have a logging tab and it is "INFO" by default, it will be generated right now.

The UI already shows the default value from the globalConfig, the .conf part was missing. It is important when you want to get your add-on setting via API (with recent OpenAPI file implementation). If you don't set anything in the `.conf` file, the API response will not contain the default value, if the default value is set in the `.conf` file, API will return the default value, so there is no inconsistency anymore.