### PR TITLE
fix: remove <add-on-name>_settings.conf from cookicutter for ucc-gen init

### DIFF
--- a/example/globalConfig.json
+++ b/example/globalConfig.json
@@ -161,7 +161,7 @@
     "meta": {
         "name": "Splunk_TA_dummy_data",
         "restRoot": "Splunk_TA_dummy_data",
-        "version": "5.21.0Rb6fb43f1",
+        "version": "5.21.0R64db1b47",
         "displayName": "Splunk_TA_dummy_data",
         "schemaVersion": "0.0.3"
     }

--- a/splunk_add_on_ucc_framework/commands/init.py
+++ b/splunk_add_on_ucc_framework/commands/init.py
@@ -15,6 +15,7 @@
 #
 import logging
 import os
+import sys
 
 from cookiecutter import exceptions, main
 
@@ -27,7 +28,7 @@ def init(
     addon_input_name: str,
     addon_version: str,
     overwrite: bool = False,
-):
+) -> str:
     try:
         generated_addon_path = main.cookiecutter(
             template=os.path.join(
@@ -48,8 +49,10 @@ def init(
             "LICENSE.txt and README.txt are empty, "
             "you may need to modify the content of those files. "
         )
+        return generated_addon_path
     except exceptions.OutputDirExistsException:
         logger.error(
             "The location is already taken, use `--overwrite` "
             "option to overwrite the content of existing folder."
         )
+        sys.exit(1)

--- a/splunk_add_on_ucc_framework/commands/init_template/{{cookiecutter.addon_name}}/package/default/{{cookiecutter.addon_name}}_settings.conf
+++ b/splunk_add_on_ucc_framework/commands/init_template/{{cookiecutter.addon_name}}/package/default/{{cookiecutter.addon_name}}_settings.conf
@@ -1,2 +1,0 @@
-[logging]
-loglevel = INFO

--- a/splunk_add_on_ucc_framework/main.py
+++ b/splunk_add_on_ucc_framework/main.py
@@ -62,14 +62,14 @@ def main(argv: Optional[Sequence[str]] = None):
         "--source",
         type=str,
         nargs="?",
-        help="Folder containing the app.manifest and app source",
+        help="Folder containing the app.manifest and app source.",
         default="package",
     )
     build_parser.add_argument(
         "--config",
         type=str,
         nargs="?",
-        help="Path to configuration file, defaults to globalConfig file in parent directory of source provided",
+        help="Path to configuration file, defaults to globalConfig file in parent directory of source provided.",
         default=None,
     )
     build_parser.add_argument(
@@ -82,42 +82,47 @@ def main(argv: Optional[Sequence[str]] = None):
     build_parser.add_argument(
         "--python-binary-name",
         type=str,
-        help="Python binary name to use to install requirements",
+        help="Python binary name to use to install requirements.",
         default="python3",
     )
     build_parser.add_argument(
         "--openapi",
         type=bool,
-        help="Generate OpenAPI Description document and expose in /static/openapi.json endpoint",
+        help="Generate OpenAPI Description document and expose in /static/openapi.json endpoint.",
         default=True,
     )
 
-    init_parser = subparsers.add_parser("init", description="Bootstrap an add-on")
+    init_parser = subparsers.add_parser("init", description="Bootstrap an add-on.")
     init_parser.add_argument(
         "--addon-name",
         type=str,
-        help="Add-on name",
+        help="Add-on name.",
         required=True,
     )
     init_parser.add_argument(
         "--addon-display-name",
         type=str,
-        help="Add-on display name",
+        help="Add-on display name.",
         required=True,
     )
     init_parser.add_argument(
         "--addon-input-name",
         type=str,
-        help="Add-on input name",
+        help="Add-on input name.",
         required=True,
     )
     init_parser.add_argument(
         "--addon-version",
         type=str,
-        help="Add-on version",
+        help="Add-on version.",
         default="0.0.1",
     )
-    init_parser.add_argument("--overwrite", action="store_true", default=False)
+    init_parser.add_argument(
+        "--overwrite",
+        action="store_true",
+        default=False,
+        help="Overwrite already generated add-on folder.",
+    )
 
     args = parser.parse_args(argv)
     if args.command == "build":

--- a/tests/smoke/test_ucc_init.py
+++ b/tests/smoke/test_ucc_init.py
@@ -1,0 +1,83 @@
+import difflib
+import os
+
+import pytest
+
+from splunk_add_on_ucc_framework.commands import init
+from splunk_add_on_ucc_framework.commands import build
+
+
+def test_ucc_init():
+    addon_name = "demo_addon_for_splunk"
+    generated_addon_path = init.init(
+        addon_name,
+        "Demo Add-on for Splunk",
+        "demo_input",
+        "1.0.0",
+        overwrite=True,
+    )
+    expected_folder = os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "testdata",
+        "expected_addons",
+        "expected_addon_after_init",
+        addon_name,
+    )
+    files_to_be_equal = [
+        ("README.md",),
+        ("globalConfig.json",),
+        ("package", "README.txt"),
+        ("package", "LICENSE.txt"),
+        ("package", "app.manifest"),
+        ("package", "default", "app.conf"),
+        ("package", "default", "server.conf"),
+        ("package", "bin", "demo_input.py"),
+        ("package", "lib", "requirements.txt"),
+    ]
+    diff_results = []
+    for f in files_to_be_equal:
+        expected_file_path = os.path.join(expected_folder, *f)
+        actual_file_path = os.path.join(generated_addon_path, *f)
+        with open(expected_file_path) as expected_file:
+            expected_file_lines = expected_file.readlines()
+        with open(actual_file_path) as actual_file:
+            actual_file_lines = actual_file.readlines()
+        for line in difflib.unified_diff(
+            actual_file_lines,
+            expected_file_lines,
+            fromfile=actual_file_path,
+            tofile=expected_file_path,
+            lineterm="",
+        ):
+            diff_results.append(line)
+    if diff_results:
+        for result in diff_results:
+            print(result)
+        assert False, "Some diffs were found"
+    build.generate(
+        os.path.join(generated_addon_path, "package"),
+        os.path.join(generated_addon_path, "globalConfig.json"),
+        "1.0.0",
+    )
+
+
+def test_ucc_init_if_same_output_then_sys_exit():
+    addon_name = "demo_addon_for_splunk_already_exists"
+    init.init(
+        addon_name,
+        "Demo Add-on for Splunk",
+        "demo_input",
+        "1.0.0",
+        # This `overwrite` is not needed, but it's better to have it for the
+        # local runs, so it overwrites the existing folder locally, but the
+        # next run should produce an error.
+        overwrite=True,
+    )
+    with pytest.raises(SystemExit):
+        init.init(
+            addon_name,
+            "Demo Add-on for Splunk",
+            "demo_input",
+            "1.0.0",
+        )

--- a/tests/testdata/expected_addons/expected_addon_after_init/demo_addon_for_splunk/globalConfig.json
+++ b/tests/testdata/expected_addons/expected_addon_after_init/demo_addon_for_splunk/globalConfig.json
@@ -199,7 +199,7 @@
     "meta": {
         "name": "demo_addon_for_splunk",
         "restRoot": "demo_addon_for_splunk",
-        "version": "5.18.0R2b855ba9",
+        "version": "1.0.0",
         "displayName": "Demo Add-on for Splunk",
         "schemaVersion": "0.0.3"
     }

--- a/tests/testdata/expected_addons/expected_addon_after_init/demo_addon_for_splunk/package/app.manifest
+++ b/tests/testdata/expected_addons/expected_addon_after_init/demo_addon_for_splunk/package/app.manifest
@@ -5,7 +5,7 @@
         "id": {
             "group": null,
             "name": "demo_addon_for_splunk",
-            "version": "0.0.1"
+            "version": "1.0.0"
         },
         "author": [
             {

--- a/tests/testdata/expected_addons/expected_addon_after_init/demo_addon_for_splunk/package/bin/demo_input.py
+++ b/tests/testdata/expected_addons/expected_addon_after_init/demo_addon_for_splunk/package/bin/demo_input.py
@@ -35,7 +35,7 @@ def get_data_from_api(logger: logging.Logger, api_key: str):
         },
         {
             "line2": "world",
-        }
+        },
     ]
     return dummy_data
 

--- a/tests/testdata/expected_addons/expected_addon_after_init/demo_addon_for_splunk/package/default/app.conf
+++ b/tests/testdata/expected_addons/expected_addon_after_init/demo_addon_for_splunk/package/default/app.conf
@@ -5,7 +5,7 @@ build = 1
 
 [launcher]
 description = Demo Add-on for Splunk
-version = 0.0.1
+version = 1.0.0
 
 [ui]
 is_visible = true
@@ -16,7 +16,7 @@ id = demo_addon_for_splunk
 
 [id]
 name = demo_addon_for_splunk
-version = 0.0.1
+version = 1.0.0
 
 [triggers]
 reload.demo_addon_for_splunk_settings = simple

--- a/tests/testdata/expected_addons/expected_addon_after_init/demo_addon_for_splunk/package/default/demo_addon_for_splunk_settings.conf
+++ b/tests/testdata/expected_addons/expected_addon_after_init/demo_addon_for_splunk/package/default/demo_addon_for_splunk_settings.conf
@@ -1,2 +1,0 @@
-[logging]
-loglevel = INFO

--- a/tests/testdata/test_addons/package_global_config_inputs_configuration_alerts/globalConfig.json
+++ b/tests/testdata/test_addons/package_global_config_inputs_configuration_alerts/globalConfig.json
@@ -1108,7 +1108,7 @@
     "meta": {
         "name": "Splunk_TA_UCCExample",
         "restRoot": "splunk_ta_uccexample",
-        "version": "5.21.0Rb6fb43f1",
+        "version": "5.21.0R64db1b47",
         "displayName": "Splunk UCC test Add-on",
         "schemaVersion": "0.0.3"
     }


### PR DESCRIPTION
Now we generate proper `<addon-name>_settings.conf` file in the output folder for the add-on, so no need to keep it generated by default using `ucc-gen init` command.

The autogenerated `<addon-name>_settings.conf` file in the default folder creates more confusion if you want to continue adding more settings in the globalConfig file, the changes will not be reflected in the `package/default` folder.