### PR TITLE
test: refactor file content comparison logic

### DIFF
--- a/example/globalConfig.json
+++ b/example/globalConfig.json
@@ -161,7 +161,7 @@
     "meta": {
         "name": "Splunk_TA_dummy_data",
         "restRoot": "Splunk_TA_dummy_data",
-        "version": "5.21.0R64db1b47",
+        "version": "5.21.0R3d3022aa",
         "displayName": "Splunk_TA_dummy_data",
         "schemaVersion": "0.0.3"
     }

--- a/tests/smoke/helpers.py
+++ b/tests/smoke/helpers.py
@@ -1,0 +1,30 @@
+import difflib
+import os
+from typing import List, Tuple
+
+
+def compare_file_content(
+    files_to_be_equal: List[Tuple[str]],
+    expected_folder: str,
+    actual_folder: str,
+):
+    diff_results = []
+    for f in files_to_be_equal:
+        expected_file_path = os.path.join(expected_folder, *f)
+        actual_file_path = os.path.join(actual_folder, *f)
+        with open(expected_file_path) as expected_file:
+            expected_file_lines = expected_file.readlines()
+        with open(actual_file_path) as actual_file:
+            actual_file_lines = actual_file.readlines()
+        for line in difflib.unified_diff(
+            actual_file_lines,
+            expected_file_lines,
+            fromfile=actual_file_path,
+            tofile=expected_file_path,
+            lineterm="",
+        ):
+            diff_results.append(line)
+    if diff_results:
+        for result in diff_results:
+            print(result)
+        assert False, "Some diffs were found"

--- a/tests/smoke/test_ucc_build.py
+++ b/tests/smoke/test_ucc_build.py
@@ -1,6 +1,7 @@
-import difflib
 import tempfile
 from os import path
+
+from tests.smoke import helpers
 
 import splunk_add_on_ucc_framework as ucc
 
@@ -119,26 +120,11 @@ def test_ucc_generate_with_inputs_configuration_alerts():
             ("README", "splunk_ta_uccexample_settings.conf.spec"),
             ("metadata", "default.meta"),
         ]
-        diff_results = []
-        for f in files_to_be_equal:
-            expected_file_path = path.join(expected_folder, *f)
-            actual_file_path = path.join(actual_folder, *f)
-            with open(expected_file_path) as expected_file:
-                expected_file_lines = expected_file.readlines()
-            with open(actual_file_path) as actual_file:
-                actual_file_lines = actual_file.readlines()
-            for line in difflib.unified_diff(
-                actual_file_lines,
-                expected_file_lines,
-                fromfile=actual_file_path,
-                tofile=expected_file_path,
-                lineterm="",
-            ):
-                diff_results.append(line)
-        if diff_results:
-            for result in diff_results:
-                print(result)
-            assert False, "Some diffs were found"
+        helpers.compare_file_content(
+            files_to_be_equal,
+            expected_folder,
+            actual_folder,
+        )
         files_to_exist = [
             ("static", "appIcon.png"),
             ("static", "appIcon_2x.png"),
@@ -199,26 +185,11 @@ def test_ucc_generate_with_configuration():
             ("metadata", "default.meta"),
             ("static", "openapi.json"),
         ]
-        diff_results = []
-        for f in files_to_be_equal:
-            expected_file_path = path.join(expected_folder, *f)
-            actual_file_path = path.join(actual_folder, *f)
-            with open(expected_file_path) as expected_file:
-                expected_file_lines = expected_file.readlines()
-            with open(actual_file_path) as actual_file:
-                actual_file_lines = actual_file.readlines()
-            for line in difflib.unified_diff(
-                actual_file_lines,
-                expected_file_lines,
-                fromfile=actual_file_path,
-                tofile=expected_file_path,
-                lineterm="",
-            ):
-                diff_results.append(line)
-        if diff_results:
-            for result in diff_results:
-                print(result)
-            assert False, "Some diffs were found"
+        helpers.compare_file_content(
+            files_to_be_equal,
+            expected_folder,
+            actual_folder,
+        )
         files_to_exist = [
             ("static", "appIcon.png"),
             ("static", "appIcon_2x.png"),
@@ -269,26 +240,11 @@ def test_ucc_generate_with_configuration_files_only():
             ("default", "tags.conf"),
             ("metadata", "default.meta"),
         ]
-        diff_results = []
-        for f in files_to_be_equal:
-            expected_file_path = path.join(expected_folder, *f)
-            actual_file_path = path.join(actual_folder, *f)
-            with open(expected_file_path) as expected_file:
-                expected_file_lines = expected_file.readlines()
-            with open(actual_file_path) as actual_file:
-                actual_file_lines = actual_file.readlines()
-            for line in difflib.unified_diff(
-                actual_file_lines,
-                expected_file_lines,
-                fromfile=actual_file_path,
-                tofile=expected_file_path,
-                lineterm="",
-            ):
-                diff_results.append(line)
-        if diff_results:
-            for result in diff_results:
-                print(result)
-            assert False, "Some diffs were found"
+        helpers.compare_file_content(
+            files_to_be_equal,
+            expected_folder,
+            actual_folder,
+        )
         files_to_not_exist = [
             ("default", "data", "ui", "nav", "default_no_input.xml"),
         ]

--- a/tests/smoke/test_ucc_init.py
+++ b/tests/smoke/test_ucc_init.py
@@ -1,7 +1,8 @@
-import difflib
 import os
 
 import pytest
+
+from tests.smoke import helpers
 
 from splunk_add_on_ucc_framework.commands import init
 from splunk_add_on_ucc_framework.commands import build
@@ -35,26 +36,11 @@ def test_ucc_init():
         ("package", "bin", "demo_input.py"),
         ("package", "lib", "requirements.txt"),
     ]
-    diff_results = []
-    for f in files_to_be_equal:
-        expected_file_path = os.path.join(expected_folder, *f)
-        actual_file_path = os.path.join(generated_addon_path, *f)
-        with open(expected_file_path) as expected_file:
-            expected_file_lines = expected_file.readlines()
-        with open(actual_file_path) as actual_file:
-            actual_file_lines = actual_file.readlines()
-        for line in difflib.unified_diff(
-            actual_file_lines,
-            expected_file_lines,
-            fromfile=actual_file_path,
-            tofile=expected_file_path,
-            lineterm="",
-        ):
-            diff_results.append(line)
-    if diff_results:
-        for result in diff_results:
-            print(result)
-        assert False, "Some diffs were found"
+    helpers.compare_file_content(
+        files_to_be_equal,
+        expected_folder,
+        generated_addon_path,
+    )
     build.generate(
         os.path.join(generated_addon_path, "package"),
         os.path.join(generated_addon_path, "globalConfig.json"),

--- a/tests/testdata/test_addons/package_global_config_inputs_configuration_alerts/globalConfig.json
+++ b/tests/testdata/test_addons/package_global_config_inputs_configuration_alerts/globalConfig.json
@@ -1108,7 +1108,7 @@
     "meta": {
         "name": "Splunk_TA_UCCExample",
         "restRoot": "splunk_ta_uccexample",
-        "version": "5.21.0R64db1b47",
+        "version": "5.21.0R3d3022aa",
         "displayName": "Splunk UCC test Add-on",
         "schemaVersion": "0.0.3"
     }


### PR DESCRIPTION
Extract file content comparison logic into a separate helper module to be reused in `test_ucc_build.py` and `test_ucc_init.py`.