### PR TITLE
fix: config endpoint addresses

### DIFF
--- a/splunk_add_on_ucc_framework/commands/openapi_generator/ucc_to_oas.py
+++ b/splunk_add_on_ucc_framework/commands/openapi_generator/ucc_to_oas.py
@@ -309,9 +309,9 @@ def __add_paths(
     for tab in global_config.pages.configuration.tabs:
         open_api_object = __assign_ta_paths(
             open_api_object=open_api_object,
-            path=f"/{global_config.meta.restRoot}_settings/{tab.name}"
-            if tab.name in ["logging", "proxy"]
-            else f"/{global_config.meta.restRoot}_{tab.name}",
+            path= f"/{global_config.meta.restRoot}_{tab.name}"
+            if hasattr(tab, "table")
+            else f"/{global_config.meta.restRoot}_settings/{tab.name}",
             path_name=tab.name,
             actions=tab.table.actions
             if hasattr(tab, "table") and hasattr(tab.table, "actions")

--- a/splunk_add_on_ucc_framework/commands/openapi_generator/ucc_to_oas.py
+++ b/splunk_add_on_ucc_framework/commands/openapi_generator/ucc_to_oas.py
@@ -309,7 +309,7 @@ def __add_paths(
     for tab in global_config.pages.configuration.tabs:
         open_api_object = __assign_ta_paths(
             open_api_object=open_api_object,
-            path= f"/{global_config.meta.restRoot}_{tab.name}"
+            path=f"/{global_config.meta.restRoot}_{tab.name}"
             if hasattr(tab, "table")
             else f"/{global_config.meta.restRoot}_settings/{tab.name}",
             path_name=tab.name,

--- a/tests/testdata/expected_addons/expected_output_global_config_configuration/Splunk_TA_UCCExample/static/openapi.json
+++ b/tests/testdata/expected_addons/expected_output_global_config_configuration/Splunk_TA_UCCExample/static/openapi.json
@@ -507,7 +507,7 @@
                 }
             ]
         },
-        "/splunk_ta_uccexample_custom_abc": {
+        "/splunk_ta_uccexample_settings/custom_abc": {
             "get": {
                 "responses": {
                     "200": {


### PR DESCRIPTION
The initial assumption was just too specific about the tabs that need a separate endpoint. The current approach is a correct one.