### PR TITLE
fix: remove build function from init file

### DIFF
--- a/example/globalConfig.json
+++ b/example/globalConfig.json
@@ -161,7 +161,7 @@
     "meta": {
         "name": "Splunk_TA_dummy_data",
         "restRoot": "Splunk_TA_dummy_data",
-        "version": "5.21.0Re4d49394",
+        "version": "5.21.0Rbf25c5d2",
         "displayName": "Splunk_TA_dummy_data",
         "schemaVersion": "0.0.3"
     }

--- a/splunk_add_on_ucc_framework/__init__.py
+++ b/splunk_add_on_ucc_framework/__init__.py
@@ -17,8 +17,6 @@ __version__ = "5.21.0"
 
 import logging
 
-from splunk_add_on_ucc_framework.commands import build
-
 logger = logging.getLogger("ucc_gen")
 logger.setLevel(logging.INFO)
 formatter = logging.Formatter("%(asctime)s %(levelname)s: %(message)s")
@@ -26,13 +24,3 @@ stream_handler = logging.StreamHandler()
 stream_handler.setLevel(logging.INFO)
 stream_handler.setFormatter(formatter)
 logger.addHandler(stream_handler)
-
-
-def generate(
-    source="package",
-    config=None,
-    ta_version=None,
-    outputdir=None,
-    python_binary_name="python3",
-):
-    build.generate(source, config, ta_version, outputdir, python_binary_name)

--- a/splunk_add_on_ucc_framework/commands/build.py
+++ b/splunk_add_on_ucc_framework/commands/build.py
@@ -426,11 +426,11 @@ def _get_addon_version(addon_version: Optional[str]) -> str:
 
 
 def generate(
-    source,
-    config_path,
-    addon_version,
-    outputdir=None,
-    python_binary_name="python3",
+    source: str,
+    config_path: Optional[str] = None,
+    addon_version: Optional[str] = None,
+    outputdir: Optional[str] = None,
+    python_binary_name: str = "python3",
 ):
     logger.info(f"ucc-gen version {__version__} is used")
     logger.info(f"Python binary name to use: {python_binary_name}")

--- a/splunk_add_on_ucc_framework/main.py
+++ b/splunk_add_on_ucc_framework/main.py
@@ -17,7 +17,7 @@ import argparse
 import sys
 from typing import Optional, Sequence
 
-from splunk_add_on_ucc_framework import generate
+from splunk_add_on_ucc_framework.commands import build
 from splunk_add_on_ucc_framework.commands import init
 
 
@@ -120,10 +120,10 @@ def main(argv: Optional[Sequence[str]] = None):
 
     args = parser.parse_args(argv)
     if args.command == "build":
-        generate(
+        build.generate(
             source=args.source,
-            config=args.config,
-            ta_version=args.ta_version,
+            config_path=args.config,
+            addon_version=args.ta_version,
             python_binary_name=args.python_binary_name,
         )
     if args.command == "init":

--- a/tests/smoke/test_ucc_build.py
+++ b/tests/smoke/test_ucc_build.py
@@ -3,7 +3,7 @@ from os import path
 
 from tests.smoke import helpers
 
-import splunk_add_on_ucc_framework as ucc
+from splunk_add_on_ucc_framework.commands import build
 
 
 def test_ucc_generate():
@@ -15,7 +15,7 @@ def test_ucc_generate():
         "package_global_config_inputs_configuration_alerts",
         "package",
     )
-    ucc.generate(source=package_folder)
+    build.generate(source=package_folder)
 
 
 def test_ucc_generate_with_add_on_from_example_folder():
@@ -33,7 +33,7 @@ def test_ucc_generate_with_add_on_from_example_folder():
         "example",
         "globalConfig.json",
     )
-    ucc.generate(source=package_folder, config=config_path)
+    build.generate(source=package_folder, config_path=config_path)
 
 
 def test_ucc_generate_with_config_param():
@@ -56,7 +56,7 @@ def test_ucc_generate_with_config_param():
         "package_global_config_inputs_configuration_alerts",
         "globalConfig.json",
     )
-    ucc.generate(source=package_folder, config=config_path)
+    build.generate(source=package_folder, config_path=config_path)
 
 
 def test_ucc_generate_with_inputs_configuration_alerts():
@@ -69,7 +69,7 @@ def test_ucc_generate_with_inputs_configuration_alerts():
             "package_global_config_inputs_configuration_alerts",
             "package",
         )
-        ucc.generate(source=package_folder, outputdir=temp_dir)
+        build.generate(source=package_folder, outputdir=temp_dir)
 
         expected_folder = path.join(
             path.dirname(__file__),
@@ -153,7 +153,7 @@ def test_ucc_generate_with_configuration():
             "package_global_config_configuration",
             "package",
         )
-        ucc.generate(source=package_folder, outputdir=temp_dir, ta_version="1.1.1")
+        build.generate(source=package_folder, outputdir=temp_dir, addon_version="1.1.1")
 
         expected_folder = path.join(
             path.dirname(__file__),
@@ -219,7 +219,7 @@ def test_ucc_generate_with_configuration_files_only():
             "package_no_global_config",
             "package",
         )
-        ucc.generate(source=package_folder, outputdir=temp_dir)
+        build.generate(source=package_folder, outputdir=temp_dir)
 
         expected_folder = path.join(
             path.dirname(__file__),
@@ -265,7 +265,7 @@ def test_ucc_generate_openapi_with_configuration_files_only():
             "package_no_global_config",
             "package",
         )
-        ucc.generate(source=package_folder, outputdir=temp_dir)
+        build.generate(source=package_folder, outputdir=temp_dir)
 
         expected_file_path = path.join(
             temp_dir, "Splunk_TA_UCCExample", "static", "openapi.json"

--- a/tests/testdata/test_addons/package_global_config_inputs_configuration_alerts/globalConfig.json
+++ b/tests/testdata/test_addons/package_global_config_inputs_configuration_alerts/globalConfig.json
@@ -1108,7 +1108,7 @@
     "meta": {
         "name": "Splunk_TA_UCCExample",
         "restRoot": "splunk_ta_uccexample",
-        "version": "5.21.0Re4d49394",
+        "version": "5.21.0Rbf25c5d2",
         "displayName": "Splunk UCC test Add-on",
         "schemaVersion": "0.0.3"
     }

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -27,8 +27,8 @@ from splunk_add_on_ucc_framework import main
             [],
             {
                 "source": "package",
-                "config": None,
-                "ta_version": None,
+                "config_path": None,
+                "addon_version": None,
                 "python_binary_name": "python3",
             },
         ),
@@ -36,8 +36,8 @@ from splunk_add_on_ucc_framework import main
             ["build"],
             {
                 "source": "package",
-                "config": None,
-                "ta_version": None,
+                "config_path": None,
+                "addon_version": None,
                 "python_binary_name": "python3",
             },
         ),
@@ -45,8 +45,8 @@ from splunk_add_on_ucc_framework import main
             ["--source", "package"],
             {
                 "source": "package",
-                "config": None,
-                "ta_version": None,
+                "config_path": None,
+                "addon_version": None,
                 "python_binary_name": "python3",
             },
         ),
@@ -54,8 +54,8 @@ from splunk_add_on_ucc_framework import main
             ["build", "--source", "package"],
             {
                 "source": "package",
-                "config": None,
-                "ta_version": None,
+                "config_path": None,
+                "addon_version": None,
                 "python_binary_name": "python3",
             },
         ),
@@ -63,8 +63,8 @@ from splunk_add_on_ucc_framework import main
             ["--source", "package", "--ta-version", "2.1.0"],
             {
                 "source": "package",
-                "config": None,
-                "ta_version": "2.1.0",
+                "config_path": None,
+                "addon_version": "2.1.0",
                 "python_binary_name": "python3",
             },
         ),
@@ -79,8 +79,8 @@ from splunk_add_on_ucc_framework import main
             ],
             {
                 "source": "package",
-                "config": None,
-                "ta_version": "2.2.0",
+                "config_path": None,
+                "addon_version": "2.2.0",
                 "python_binary_name": "python.exe",
             },
         ),
@@ -97,8 +97,8 @@ from splunk_add_on_ucc_framework import main
             ],
             {
                 "source": "package",
-                "config": "/path/to/globalConfig.json",
-                "ta_version": "2.2.0",
+                "config_path": "/path/to/globalConfig.json",
+                "addon_version": "2.2.0",
                 "python_binary_name": "python.exe",
             },
         ),
@@ -115,8 +115,8 @@ from splunk_add_on_ucc_framework import main
             ],
             {
                 "source": "package",
-                "config": "/path/to/globalConfig.yaml",
-                "ta_version": "2.2.0",
+                "config_path": "/path/to/globalConfig.yaml",
+                "addon_version": "2.2.0",
                 "python_binary_name": "python.exe",
             },
         ),
@@ -134,14 +134,14 @@ from splunk_add_on_ucc_framework import main
             ],
             {
                 "source": "package",
-                "config": "/path/to/globalConfig.yaml",
-                "ta_version": "2.2.0",
+                "config_path": "/path/to/globalConfig.yaml",
+                "addon_version": "2.2.0",
                 "python_binary_name": "python.exe",
             },
         ),
     ],
 )
-@mock.patch("splunk_add_on_ucc_framework.main.generate")
+@mock.patch("splunk_add_on_ucc_framework.commands.build.generate")
 def test_build_command(mock_ucc_gen_generate, args, expected_parameters):
     main.main(args)
 


### PR DESCRIPTION
This is a breaking change for the Add-on Builder, because it directly uses `ucc-gen` library to build the add-ons. I am not going to release it as a breaking change for everyone, because it is not a breaking change for the users of the `ucc-gen`.