### PR TITLE
ci: introduce cache to setup-python job

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -70,6 +70,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          cache: "poetry"
       - name: Install and build
         run: |
           curl -sSL https://install.python-poetry.org | python3 -
@@ -99,6 +100,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          cache: "poetry"
       - name: Install and build
         run: |
           curl -sSL https://install.python-poetry.org | python3 -
@@ -135,6 +137,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.7"
+          cache: "poetry"
       - name: Install Poetry and Python dependencies
         run: |
           curl -sSL https://install.python-poetry.org | python3 -
@@ -233,6 +236,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.7"
+          cache: "poetry"
       - name: Install Poetry
         run: |
           curl -sSL https://install.python-poetry.org | python3 -

--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -67,13 +67,14 @@ jobs:
           - "3.11"
     steps:
       - uses: actions/checkout@v3
+      - run: |
+          pipx install poetry==1.1.15
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
           cache: "poetry"
       - name: Install and build
         run: |
-          curl -sSL https://install.python-poetry.org | python3 -
           ./get-ucc-ui.sh
           # Puts package and schema subdirs along with NOTICE (THIRDPARTY.npm)
           tar -zxf splunk-ucc-ui.tgz -C splunk_add_on_ucc_framework/
@@ -97,13 +98,14 @@ jobs:
           - "3.11"
     steps:
       - uses: actions/checkout@v3
+      - run: |
+          pipx install poetry==1.1.15
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
           cache: "poetry"
       - name: Install and build
         run: |
-          curl -sSL https://install.python-poetry.org | python3 -
           ./get-ucc-ui.sh
           # Puts package and schema subdirs along with NOTICE (THIRDPARTY.npm)
           tar -zxf splunk-ucc-ui.tgz -C splunk_add_on_ucc_framework/
@@ -134,13 +136,13 @@ jobs:
           - "input"
     steps:
       - uses: actions/checkout@v3
+      - run: |
+          pipx install poetry==1.1.15
       - uses: actions/setup-python@v4
         with:
           python-version: "3.7"
           cache: "poetry"
-      - name: Install Poetry and Python dependencies
-        run: |
-          curl -sSL https://install.python-poetry.org | python3 -
+      - run: |
           poetry install
       - name: Link chromedriver
         # Use installed chromedriver https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md
@@ -233,13 +235,14 @@ jobs:
           # Very important: semantic-release won't trigger a tagged
           # build if this is not set false
           persist-credentials: false
+      - run: |
+          pipx install poetry==1.1.15
       - uses: actions/setup-python@v4
         with:
           python-version: "3.7"
           cache: "poetry"
       - name: Install Poetry
         run: |
-          curl -sSL https://install.python-poetry.org | python3 -
           ./get-ucc-ui.sh
           # Puts package and schema subdirs along with NOTICE (THIRDPARTY.npm)
           tar -zxf splunk-ucc-ui.tgz -C splunk_add_on_ucc_framework/


### PR DESCRIPTION
I made a rerun to see how cache works and it saves ~30 seconds on each job which uses the same version of Python.