### PR TITLE
fix: dropdownlist_splunk_search does not require options

### DIFF
--- a/example/globalConfig.json
+++ b/example/globalConfig.json
@@ -161,7 +161,7 @@
     "meta": {
         "name": "Splunk_TA_dummy_data",
         "restRoot": "Splunk_TA_dummy_data",
-        "version": "5.22.0R164bd4c4",
+        "version": "5.23.0Rcc389503",
         "displayName": "Splunk_TA_dummy_data",
         "schemaVersion": "0.0.3"
     }

--- a/splunk_add_on_ucc_framework/normalize.py
+++ b/splunk_add_on_ucc_framework/normalize.py
@@ -57,7 +57,12 @@ def transform_params(parameter_list):
                 "label-field": label_field,
                 "search": search,
             }
-            options = param.pop("options")
+            try:
+                # `options` field is optional for `dropdownlist_splunk_search`
+                # type.
+                options = param.pop("options")
+            except KeyError:
+                options = None
             if options is not None:
                 earliest_time = None
                 latest_time = None

--- a/tests/testdata/test_addons/package_global_config_inputs_configuration_alerts/globalConfig.json
+++ b/tests/testdata/test_addons/package_global_config_inputs_configuration_alerts/globalConfig.json
@@ -1121,7 +1121,7 @@
     "meta": {
         "name": "Splunk_TA_UCCExample",
         "restRoot": "splunk_ta_uccexample",
-        "version": "5.22.0R164bd4c4",
+        "version": "5.23.0Rcc389503",
         "displayName": "Splunk UCC test Add-on",
         "schemaVersion": "0.0.3"
     }

--- a/tests/unit/test_normalize.py
+++ b/tests/unit/test_normalize.py
@@ -1,0 +1,90 @@
+#
+# Copyright 2021 Splunk Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from splunk_add_on_ucc_framework.normalize import transform_params
+
+
+def test_normalize_type_dropdownlist_splunk_search_wo_options():
+    parameter_list = [
+        {
+            "label": "Select Account",
+            "search": "| rest /servicesNS/nobody/Splunk_TA_UCCExample/splunk_ta_uccexample_account | dedup title",
+            "required": True,
+            "format_type": "dropdownlist_splunk_search",
+            "name": "account",
+            "value-field": "title",
+            "label-field": "title",
+            "help_string": "Select the account from the dropdown",
+        }
+    ]
+
+    transform_params(parameter_list)
+
+    expected_result = [
+        {
+            "label": "Select Account",
+            "required": True,
+            "format_type": "dropdownlist_splunk_search",
+            "name": "account",
+            "help_string": "Select the account from the dropdown",
+            "ctrl_props": {
+                "value-field": "title",
+                "label-field": "title",
+                "search": "| rest /servicesNS/nobody/Splunk_TA_UCCExample/splunk_ta_uccexample_account | dedup title",
+            },
+        }
+    ]
+    assert expected_result == parameter_list
+
+
+def test_normalize_type_dropdownlist_splunk_search_with_options():
+    parameter_list = [
+        {
+            "label": "Select Account",
+            "search": "| rest /servicesNS/nobody/Splunk_TA_UCCExample/splunk_ta_uccexample_account | dedup title",
+            "options": {
+                "items": [
+                    {"label": "earliest", "value": "-4@h"},
+                    {"label": "latest", "value": "now"},
+                ]
+            },
+            "required": True,
+            "format_type": "dropdownlist_splunk_search",
+            "name": "account",
+            "value-field": "title",
+            "label-field": "title",
+            "help_string": "Select the account from the dropdown",
+        }
+    ]
+
+    transform_params(parameter_list)
+
+    expected_result = [
+        {
+            "label": "Select Account",
+            "required": True,
+            "format_type": "dropdownlist_splunk_search",
+            "name": "account",
+            "help_string": "Select the account from the dropdown",
+            "ctrl_props": {
+                "value-field": "title",
+                "label-field": "title",
+                "search": "| rest /servicesNS/nobody/Splunk_TA_UCCExample/splunk_ta_uccexample_account | dedup title",
+                "earliest": "-4@h",
+                "latest": "now",
+            },
+        }
+    ]
+    assert expected_result == parameter_list


### PR DESCRIPTION
This PR introduces a simple test for `transform_param` function and fixes an issue when `options` were not provided for  `dropdownlist_splunk_search` type.

In the future this code needs to be refactored and properly unit tested.