### PR TITLE
ci: update splunk/appinspect-cli-action to v1.7

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -195,7 +195,7 @@ jobs:
       - run: pip install splunk-packaging-toolkit
       - name: Slim tests/expected_output_global_config_inputs_configuration_alerts/Splunk_TA_UCCExample
         run: mkdir tests/slimmed; slim package tests/testdata/expected_addons/expected_output_global_config_inputs_configuration_alerts/Splunk_TA_UCCExample -o tests/slimmed
-      - uses: splunk/appinspect-cli-action@v1.6
+      - uses: splunk/appinspect-cli-action@v1.7
         with:
           app_path: tests/slimmed
           included_tags: ${{ matrix.tags }}


### PR DESCRIPTION
Today we released a new version of `splunk/appinspect-cli-action` (https://github.com/splunk/appinspect-cli-action/releases/tag/v1.7.0).