### PR TITLE
chore: ignore some test paths for fossa

### DIFF
--- a/.fossa.yml
+++ b/.fossa.yml
@@ -12,6 +12,6 @@ targets:
     - type: setuptools
       path: tests/testdata/expected_addons/expected_addon_after_init/demo_addon_for_splunk/package/lib
     - type: setuptools
-      path: tests/testdata/test_addons/package_global_config_configuration/package/lib/requirements.txt
+      path: tests/testdata/test_addons/package_global_config_configuration/package/lib
     - type: setuptools
-      path: tests/testdata/test_addons/package_global_config_inputs_configuration_alerts/package/lib/requirements.txt
+      path: tests/testdata/test_addons/package_global_config_inputs_configuration_alerts/package/lib

--- a/.fossa.yml
+++ b/.fossa.yml
@@ -5,9 +5,13 @@ project:
   id: "addonfactory-ucc-generator"
   team: "TA-Automation"
 
-paths:
+targets:
   exclude:
-    - ./splunk_add_on_ucc_framework/commands/init_template/{{cookiecutter.addon_name}}/package/lib/requirements.txt
-    - ./tests/testdata/expected_addons/expected_addon_after_init/demo_addon_for_splunk/package/lib/requirements.txt
-    - ./tests/testdata/test_addons/package_global_config_configuration/package/lib/requirements.txt
-    - ./tests/testdata/test_addons/package_global_config_inputs_configuration_alerts/package/lib/requirements.txt
+    - type: setuptools
+      path: splunk_add_on_ucc_framework/commands/init_template/{{cookiecutter.addon_name}}/package/lib
+    - type: setuptools
+      path: tests/testdata/expected_addons/expected_addon_after_init/demo_addon_for_splunk/package/lib
+    - type: setuptools
+      path: tests/testdata/test_addons/package_global_config_configuration/package/lib/requirements.txt
+    - type: setuptools
+      path: tests/testdata/test_addons/package_global_config_inputs_configuration_alerts/package/lib/requirements.txt

--- a/.fossa.yml
+++ b/.fossa.yml
@@ -4,3 +4,10 @@ server: https://app.fossa.com
 project:
   id: "addonfactory-ucc-generator"
   team: "TA-Automation"
+
+paths:
+  exclude:
+    - ./splunk_add_on_ucc_framework/commands/init_template/{{cookiecutter.addon_name}}/package/lib/requirements.txt
+    - ./tests/testdata/expected_addons/expected_addon_after_init/demo_addon_for_splunk/package/lib/requirements.txt
+    - ./tests/testdata/test_addons/package_global_config_configuration/package/lib/requirements.txt
+    - ./tests/testdata/test_addons/package_global_config_inputs_configuration_alerts/package/lib/requirements.txt


### PR DESCRIPTION
Those requirement files should not be scanned by FOSSA.