### PR TITLE
refactor: remove time from logs

### DIFF
--- a/splunk_add_on_ucc_framework/__init__.py
+++ b/splunk_add_on_ucc_framework/__init__.py
@@ -19,7 +19,7 @@ import logging
 
 logger = logging.getLogger("ucc_gen")
 logger.setLevel(logging.INFO)
-formatter = logging.Formatter("%(asctime)s %(levelname)s: %(message)s")
+formatter = logging.Formatter("%(levelname)s: %(message)s")
 stream_handler = logging.StreamHandler()
 stream_handler.setLevel(logging.INFO)
 stream_handler.setFormatter(formatter)


### PR DESCRIPTION
Having time in the console output is not useful.