### PR TITLE
fix: change the order in the sys.path in import_declare_test

### DIFF
--- a/example/globalConfig.json
+++ b/example/globalConfig.json
@@ -161,7 +161,7 @@
     "meta": {
         "name": "Splunk_TA_dummy_data",
         "restRoot": "Splunk_TA_dummy_data",
-        "version": "5.24.0R198becae",
+        "version": "5.24.0R29395c7a",
         "displayName": "Splunk_TA_dummy_data",
         "schemaVersion": "0.0.3"
     }

--- a/splunk_add_on_ucc_framework/commands/rest_builder/global_config_post_processor.py
+++ b/splunk_add_on_ucc_framework/commands/rest_builder/global_config_post_processor.py
@@ -36,7 +36,7 @@ from os.path import dirname
 ta_name = '{ta_name}'
 pattern = re.compile(r'[\\\\/]etc[\\\\/]apps[\\\\/][^\\\\/]+[\\\\/]bin[\\\\/]?$')
 new_paths = [path for path in sys.path if not pattern.search(path) or ta_name in path]
-new_paths.append(os.path.join(dirname(dirname(__file__)), "lib"))
+new_paths.insert(0, os.path.join(dirname(dirname(__file__)), "lib"))
 new_paths.insert(0, os.path.sep.join([os.path.dirname(__file__), ta_name]))
 sys.path = new_paths
 """

--- a/tests/testdata/expected_addons/expected_output_global_config_configuration/Splunk_TA_UCCExample/bin/import_declare_test.py
+++ b/tests/testdata/expected_addons/expected_output_global_config_configuration/Splunk_TA_UCCExample/bin/import_declare_test.py
@@ -7,6 +7,6 @@ from os.path import dirname
 ta_name = 'Splunk_TA_UCCExample'
 pattern = re.compile(r'[\\/]etc[\\/]apps[\\/][^\\/]+[\\/]bin[\\/]?$')
 new_paths = [path for path in sys.path if not pattern.search(path) or ta_name in path]
-new_paths.append(os.path.join(dirname(dirname(__file__)), "lib"))
+new_paths.insert(0, os.path.join(dirname(dirname(__file__)), "lib"))
 new_paths.insert(0, os.path.sep.join([os.path.dirname(__file__), ta_name]))
 sys.path = new_paths

--- a/tests/testdata/expected_addons/expected_output_global_config_inputs_configuration_alerts/Splunk_TA_UCCExample/bin/import_declare_test.py
+++ b/tests/testdata/expected_addons/expected_output_global_config_inputs_configuration_alerts/Splunk_TA_UCCExample/bin/import_declare_test.py
@@ -7,6 +7,6 @@ from os.path import dirname
 ta_name = 'Splunk_TA_UCCExample'
 pattern = re.compile(r'[\\/]etc[\\/]apps[\\/][^\\/]+[\\/]bin[\\/]?$')
 new_paths = [path for path in sys.path if not pattern.search(path) or ta_name in path]
-new_paths.append(os.path.join(dirname(dirname(__file__)), "lib"))
+new_paths.insert(0, os.path.join(dirname(dirname(__file__)), "lib"))
 new_paths.insert(0, os.path.sep.join([os.path.dirname(__file__), ta_name]))
 sys.path = new_paths

--- a/tests/testdata/test_addons/package_global_config_inputs_configuration_alerts/globalConfig.json
+++ b/tests/testdata/test_addons/package_global_config_inputs_configuration_alerts/globalConfig.json
@@ -1121,7 +1121,7 @@
     "meta": {
         "name": "Splunk_TA_UCCExample",
         "restRoot": "splunk_ta_uccexample",
-        "version": "5.24.0R198becae",
+        "version": "5.24.0R29395c7a",
         "displayName": "Splunk UCC test Add-on",
         "schemaVersion": "0.0.3"
     }


### PR DESCRIPTION
The add-on should use libraries packaged with it first and only then try to use libraries provided by Splunk (one of the cases of such a library is `urllib3` which can be packaged with an add-on and it available from Splunk's Python).