### PR TITLE
fix help text for generated account

### DIFF
--- a/splunk_add_on_ucc_framework/commands/init_template/{{cookiecutter.addon_name}}/globalConfig.json
+++ b/splunk_add_on_ucc_framework/commands/init_template/{{cookiecutter.addon_name}}/globalConfig.json
@@ -24,7 +24,7 @@
                             "validators": [
                                 {
                                     "type": "regex",
-                                    "errorMsg": "Input Name must begin with a letter and consist exclusively of alphanumeric characters and underscores.",
+                                    "errorMsg": "Account Name must begin with a letter and consist exclusively of alphanumeric characters and underscores.",
                                     "pattern": "^[a-zA-Z]\\w*$"
                                 },
                                 {
@@ -35,7 +35,7 @@
                                 }
                             ],
                             "field": "name",
-                            "help": "A unique name for the data input.",
+                            "help": "A unique name for the account.",
                             "required": true
                         },
                         {

--- a/tests/testdata/expected_addons/expected_addon_after_init/demo_addon_for_splunk/globalConfig.json
+++ b/tests/testdata/expected_addons/expected_addon_after_init/demo_addon_for_splunk/globalConfig.json
@@ -24,7 +24,7 @@
                             "validators": [
                                 {
                                     "type": "regex",
-                                    "errorMsg": "Input Name must begin with a letter and consist exclusively of alphanumeric characters and underscores.",
+                                    "errorMsg": "Account Name must begin with a letter and consist exclusively of alphanumeric characters and underscores.",
                                     "pattern": "^[a-zA-Z]\\w*$"
                                 },
                                 {
@@ -35,7 +35,7 @@
                                 }
                             ],
                             "field": "name",
-                            "help": "A unique name for the data input.",
+                            "help": "A unique name for the account.",
                             "required": true
                         },
                         {


### PR DESCRIPTION
There is a small inaccuracy in the new template generated by `ucc-init`.