### PR TITLE
chore: don't show traceback when not a git repo

### DIFF
--- a/example/globalConfig.json
+++ b/example/globalConfig.json
@@ -161,7 +161,7 @@
     "meta": {
         "name": "Splunk_TA_dummy_data",
         "restRoot": "Splunk_TA_dummy_data",
-        "version": "5.24.0R29395c7a",
+        "version": "5.24.0R53833250",
         "displayName": "Splunk_TA_dummy_data",
         "schemaVersion": "0.0.3"
     }

--- a/splunk_add_on_ucc_framework/commands/build.py
+++ b/splunk_add_on_ucc_framework/commands/build.py
@@ -417,6 +417,13 @@ def _get_addon_version(addon_version: Optional[str]) -> str:
     if not addon_version:
         try:
             return utils.get_version_from_git()
+        except exceptions.IsNotAGitRepo:
+            logger.error(
+                "Could not determine a version using Git (maybe not a Git "
+                "repository?). Use `--ta-version` to specify the version you "
+                "want."
+            )
+            exit(1)
         except exceptions.CouldNotVersionFromGitException:
             logger.error(
                 "Could not find the proper version from git tags. "

--- a/splunk_add_on_ucc_framework/exceptions.py
+++ b/splunk_add_on_ucc_framework/exceptions.py
@@ -15,3 +15,7 @@
 #
 class CouldNotVersionFromGitException(Exception):
     pass
+
+
+class IsNotAGitRepo(Exception):
+    pass

--- a/splunk_add_on_ucc_framework/utils.py
+++ b/splunk_add_on_ucc_framework/utils.py
@@ -34,7 +34,10 @@ def dump_yaml_config(config: Dict[Any, Any], file_path: str):
 
 
 def get_version_from_git():
-    version = dunamai.Version.from_git()
+    try:
+        version = dunamai.Version.from_git()
+    except RuntimeError:
+        raise exceptions.IsNotAGitRepo()
     if not version.stage:
         stage = "R"
     else:

--- a/tests/testdata/test_addons/package_global_config_inputs_configuration_alerts/globalConfig.json
+++ b/tests/testdata/test_addons/package_global_config_inputs_configuration_alerts/globalConfig.json
@@ -1121,7 +1121,7 @@
     "meta": {
         "name": "Splunk_TA_UCCExample",
         "restRoot": "splunk_ta_uccexample",
-        "version": "5.24.0R29395c7a",
+        "version": "5.24.0R53833250",
         "displayName": "Splunk UCC test Add-on",
         "schemaVersion": "0.0.3"
     }

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -22,6 +22,14 @@ from splunk_add_on_ucc_framework import exceptions, utils
 
 
 @mock.patch("splunk_add_on_ucc_framework.utils.dunamai.Version", autospec=True)
+def test_get_version_from_git_when_runtime_error_from_dunamai(mock_version_class):
+    mock_version_class.from_git.side_effect = RuntimeError
+
+    with pytest.raises(exceptions.IsNotAGitRepo):
+        utils.get_version_from_git()
+
+
+@mock.patch("splunk_add_on_ucc_framework.utils.dunamai.Version", autospec=True)
 def test_get_version_from_git_when_tags_are_not_semver(mock_version_class):
     mock_version = mock.MagicMock()
     mock_version.serialize.side_effect = ValueError


### PR DESCRIPTION
Instead of showing a traceback, show an error message in logs and suggest users a solution.