### PR TITLE
feat: app.manifest is being validated now according to the docs

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -12,6 +12,8 @@ To be able to create an add-on using UCC framework, you need to have at least:
 * `package` folder
 * `app.manifest` in the `package` folder ([documentation here](https://dev.splunk.com/enterprise/reference/packagingtoolkit/pkgtoolkitappmanifest/)).
 
+`app.manifest` file now is being validated according to the [documentation here](https://dev.splunk.com/enterprise/reference/packagingtoolkit/pkgtoolkitappmanifest/#JSON-schema-200).
+
 > If both globalConfig.json and globalConfig.yaml files are present, then the globalConfig.json file will take precedence.
 
 An example of creating a basic add-on from scratch can be found [here](example.md).

--- a/example/package/app.manifest
+++ b/example/package/app.manifest
@@ -46,6 +46,9 @@
         "_standalone",
         "_distributed"
     ],
-    "targetWorkloads": null,
+    "targetWorkloads": [
+        "_search_heads",
+        "_indexers"
+    ],
     "tasks": null
 }

--- a/splunk_add_on_ucc_framework/commands/build.py
+++ b/splunk_add_on_ucc_framework/commands/build.py
@@ -318,12 +318,13 @@ def _get_app_manifest(source: str) -> app_manifest_lib.AppManifest:
     app_manifest = app_manifest_lib.AppManifest()
     try:
         app_manifest.read(app_manifest_content)
+        app_manifest.validate()
         return app_manifest
-    except app_manifest_lib.AppManifestFormatException:
+    except app_manifest_lib.AppManifestFormatException as e:
         logger.error(
             f"Manifest file @ {app_manifest_path} has invalid format.\n"
             f"Please refer to {app_manifest_lib.APP_MANIFEST_WEBSITE}.\n"
-            f"Only JSON format is supported.\n"
+            f"Error message: {e}.\n"
         )
         sys.exit(1)
 

--- a/tests/testdata/test_addons/package_global_config_configuration/package/app.manifest
+++ b/tests/testdata/test_addons/package_global_config_configuration/package/app.manifest
@@ -47,5 +47,8 @@
     "_standalone",
     "_distributed"
   ],
-  "targetWorkloads": null
+  "targetWorkloads": [
+    "_search_heads",
+    "_indexers"
+  ]
 }

--- a/tests/testdata/test_addons/package_global_config_inputs_configuration_alerts/globalConfig.json
+++ b/tests/testdata/test_addons/package_global_config_inputs_configuration_alerts/globalConfig.json
@@ -1121,7 +1121,7 @@
     "meta": {
         "name": "Splunk_TA_UCCExample",
         "restRoot": "splunk_ta_uccexample",
-        "version": "5.26.0Rcd19a1ce",
+        "version": "5.26.0R0300c5e7",
         "displayName": "Splunk UCC test Add-on",
         "schemaVersion": "0.0.3"
     }

--- a/tests/testdata/test_addons/package_global_config_inputs_configuration_alerts/package/app.manifest
+++ b/tests/testdata/test_addons/package_global_config_inputs_configuration_alerts/package/app.manifest
@@ -47,5 +47,8 @@
     "_standalone",
     "_distributed"
   ],
-  "targetWorkloads": null
+  "targetWorkloads": [
+    "_search_heads",
+    "_indexers"
+  ]
 }

--- a/tests/testdata/test_addons/package_no_global_config/package/app.manifest
+++ b/tests/testdata/test_addons/package_no_global_config/package/app.manifest
@@ -47,5 +47,7 @@
     "_standalone",
     "_distributed"
   ],
-  "targetWorkloads": null
+  "targetWorkloads": [
+    "_indexers"
+  ]
 }

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,7 +1,16 @@
 import pytest
 
 from splunk_add_on_ucc_framework import global_config as global_config_lib
+from splunk_add_on_ucc_framework import app_manifest as app_manifest_lib
 import tests.unit.helpers as helpers
+
+
+@pytest.fixture
+def app_manifest_correct() -> app_manifest_lib.AppManifest:
+    content = helpers.get_testdata_file("app.manifest")
+    app_manifest = app_manifest_lib.AppManifest()
+    app_manifest.read(content)
+    return app_manifest
 
 
 @pytest.fixture

--- a/tests/unit/testdata/app.manifest_incorrect_schema_version
+++ b/tests/unit/testdata/app.manifest_incorrect_schema_version
@@ -1,5 +1,5 @@
 {
-  "schemaVersion": "2.0.0",
+  "schemaVersion": "1.0.0",
   "info": {
     "title": "Splunk Add-on for UCC Example",
     "id": {
@@ -42,13 +42,5 @@
   "tasks": null,
   "inputGroups": null,
   "incompatibleApps": null,
-  "platformRequirements": null,
-  "supportedDeployments": [
-    "_standalone",
-    "_distributed"
-  ],
-  "targetWorkloads": [
-    "_search_heads",
-    "_indexers"
-   ]
+  "platformRequirements": null
 }

--- a/tests/unit/testdata/app.manifest_written
+++ b/tests/unit/testdata/app.manifest_written
@@ -46,6 +46,9 @@
         "_standalone",
         "_distributed"
     ],
-    "targetWorkloads": null,
+    "targetWorkloads": [
+        "_search_heads",
+        "_indexers"
+    ],
     "tasks": null
 }


### PR DESCRIPTION
Docs link: https://dev.splunk.com/enterprise/reference/packagingtoolkit/pkgtoolkitappmanifest/#JSON-schema-200

`schemaVersion`, `targetWorkloads` and `supportedDeployments` keys are now being validated.