### PR TITLE
fix: don't sort yaml as part of the dump

### DIFF
--- a/splunk_add_on_ucc_framework/utils.py
+++ b/splunk_add_on_ucc_framework/utils.py
@@ -30,7 +30,7 @@ def dump_json_config(config: Dict[Any, Any], file_path: str):
 
 def dump_yaml_config(config: Dict[Any, Any], file_path: str):
     with open(file_path, "w") as f:
-        yaml.dump(config, f, indent=4)
+        yaml.dump(config, f, indent=4, sort_keys=False)
 
 
 def get_version_from_git():

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -79,11 +79,15 @@ def test_dump_json_config(tmp_path):
 
 def test_dump_yaml_config(tmp_path):
     tmp_file_to_dump = tmp_path / "globalConfig.yaml"
-    config = {"hello": "world", "test": "config_to_dump"}
+    config = {
+        "hello": "world",
+        "test": "config_to_dump",
+        "afoo": "bar",
+    }
 
     utils.dump_yaml_config(config, str(tmp_file_to_dump))
 
-    expected_content = "hello: world\ntest: config_to_dump\n"
+    expected_content = "hello: world\ntest: config_to_dump\nafoo: bar\n"
 
     with open(tmp_file_to_dump) as f:
         content = f.read()


### PR DESCRIPTION
sometimes developers prefer a certain, non alphabetic structure to their definition. generally, we should not modify the globalConfig during the build in my opinion. It is unexpected by the developer