### PR TITLE
ci: don't skip pipeline on bot commit

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -76,7 +76,7 @@
         "@semantic-release/git",
         {
           "assets": ["NOTICE", "docs/CHANGELOG.md", "pyproject.toml", "splunk_add_on_ucc_framework/__init__.py"],
-          "message": "chore(release): ${nextRelease.version}\n\n${nextRelease.notes} [ci skip]",
+          "message": "chore(release): ${nextRelease.version}\n\n${nextRelease.notes}",
         },
       ],
       ["@semantic-release/github", { "assets": ["NOTICE", "pyproject.toml"] }],


### PR DESCRIPTION
`docs` job is not running then and we could get an outdated version of the docs.