### PR TITLE
fix: change modular input template according to globalConfig file

### DIFF
--- a/splunk_add_on_ucc_framework/commands/init_template/{{cookiecutter.addon_name}}/package/bin/{{cookiecutter.addon_input_name}}.py
+++ b/splunk_add_on_ucc_framework/commands/init_template/{{cookiecutter.addon_name}}/package/bin/{{cookiecutter.addon_input_name}}.py
@@ -21,7 +21,7 @@ def get_account_api_key(session_key: str, account_name: str):
         realm=f"__REST_CREDENTIAL__#{ADDON_NAME}#configs/conf-{{cookiecutter.addon_name}}_account",
     )
     account_conf_file = cfm.get_conf("{{cookiecutter.addon_name}}_account")
-    return account_conf_file.get(account_name).get("username")
+    return account_conf_file.get(account_name).get("api_key")
 
 
 def get_data_from_api(logger: logging.Logger, api_key: str):

--- a/tests/testdata/expected_addons/expected_addon_after_init/demo_addon_for_splunk/package/bin/demo_input.py
+++ b/tests/testdata/expected_addons/expected_addon_after_init/demo_addon_for_splunk/package/bin/demo_input.py
@@ -21,7 +21,7 @@ def get_account_api_key(session_key: str, account_name: str):
         realm=f"__REST_CREDENTIAL__#{ADDON_NAME}#configs/conf-demo_addon_for_splunk_account",
     )
     account_conf_file = cfm.get_conf("demo_addon_for_splunk_account")
-    return account_conf_file.get(account_name).get("username")
+    return account_conf_file.get(account_name).get("api_key")
 
 
 def get_data_from_api(logger: logging.Logger, api_key: str):


### PR DESCRIPTION
This PR makes an adjustment to the template of the modular input for the `ucc-gen init` command.