### PR TITLE
chore: pin urllib3 to <2 for renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,11 @@
     "config:base",
     "group:all",
     ":disableDependencyDashboard"
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": ["urllib3"],
+      "allowedVersions": "<2.0.0"
+    }
   ]
 }


### PR DESCRIPTION
Splunk add-ons only support urllib3 < 2 as of now, so configuring renovate not to send updates for urllib3 >= 2.