### PR TITLE
fix: input.template should not render interval field

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -115,7 +115,10 @@ jobs:
 
   test-ui:
     name: test-ui Splunk ${{ matrix.splunk.version }} -m ${{ matrix.test-mark }}
-    if: contains(github.event.pull_request.labels.*.name, 'run-ui-tests')
+    if: |
+      github.base_ref == 'main' ||
+      github.ref_name == 'main' ||
+      contains(github.event.pull_request.labels.*.name, 'run-ui-tests')
     runs-on: ubuntu-latest
     continue-on-error: true
     needs:

--- a/splunk_add_on_ucc_framework/commands/build.py
+++ b/splunk_add_on_ucc_framework/commands/build.py
@@ -131,7 +131,7 @@ def _add_modular_input(
         class_name = input_name.upper()
         description = service.get("title")
         entity = service.get("entity")
-        field_allow_list = frozenset(["name", "index", "sourcetype"])
+        field_allow_list = frozenset(["name", "interval", "index", "sourcetype"])
         template = "input.template"
         if "template" in service:
             template = service.get("template") + ".template"

--- a/tests/testdata/expected_addons/expected_output_global_config_everything/Splunk_TA_UCCExample/bin/example_input_four.py
+++ b/tests/testdata/expected_addons/expected_output_global_config_everything/Splunk_TA_UCCExample/bin/example_input_four.py
@@ -26,13 +26,6 @@ class EXAMPLE_INPUT_FOUR(smi.Script):
             )
         )
         
-        scheme.add_argument(
-            smi.Argument(
-                'interval',
-                required_on_create=True,
-            )
-        )
-        
         return scheme
 
     def validate_input(self, definition):

--- a/tests/testdata/expected_addons/expected_output_global_config_everything/Splunk_TA_UCCExample/bin/example_input_one.py
+++ b/tests/testdata/expected_addons/expected_output_global_config_everything/Splunk_TA_UCCExample/bin/example_input_one.py
@@ -56,13 +56,6 @@ class EXAMPLE_INPUT_ONE(smi.Script):
         
         scheme.add_argument(
             smi.Argument(
-                'interval',
-                required_on_create=True,
-            )
-        )
-        
-        scheme.add_argument(
-            smi.Argument(
                 'account',
                 required_on_create=True,
             )

--- a/tests/testdata/expected_addons/expected_output_global_config_everything/Splunk_TA_UCCExample/bin/example_input_three.py
+++ b/tests/testdata/expected_addons/expected_output_global_config_everything/Splunk_TA_UCCExample/bin/example_input_three.py
@@ -26,13 +26,6 @@ class EXAMPLE_INPUT_THREE(smi.Script):
             )
         )
         
-        scheme.add_argument(
-            smi.Argument(
-                'interval',
-                required_on_create=True,
-            )
-        )
-        
         return scheme
 
     def validate_input(self, definition):

--- a/tests/testdata/expected_addons/expected_output_global_config_everything/Splunk_TA_UCCExample/bin/example_input_two.py
+++ b/tests/testdata/expected_addons/expected_output_global_config_everything/Splunk_TA_UCCExample/bin/example_input_two.py
@@ -28,13 +28,6 @@ class EXAMPLE_INPUT_TWO(smi.Script):
         
         scheme.add_argument(
             smi.Argument(
-                'interval',
-                required_on_create=True,
-            )
-        )
-        
-        scheme.add_argument(
-            smi.Argument(
                 'account',
                 required_on_create=True,
             )

--- a/tests/testdata/test_addons/package_global_config_everything/globalConfig.json
+++ b/tests/testdata/test_addons/package_global_config_everything/globalConfig.json
@@ -1134,7 +1134,7 @@
     "meta": {
         "name": "Splunk_TA_UCCExample",
         "restRoot": "splunk_ta_uccexample",
-        "version": "5.28.1Rae92dd48",
+        "version": "5.28.1R4adbf5c3",
         "displayName": "Splunk UCC test Add-on",
         "schemaVersion": "0.0.3"
     }

--- a/tests/testdata/test_addons/package_global_config_everything/globalConfig.json
+++ b/tests/testdata/test_addons/package_global_config_everything/globalConfig.json
@@ -1134,7 +1134,7 @@
     "meta": {
         "name": "Splunk_TA_UCCExample",
         "restRoot": "splunk_ta_uccexample",
-        "version": "5.26.0Reeb03d63",
+        "version": "5.28.1Rae92dd48",
         "displayName": "Splunk UCC test Add-on",
         "schemaVersion": "0.0.3"
     }


### PR DESCRIPTION
This is a regression from v5.24.0 when use_single_instance parameter value was changed from true to false.

Not to have such an issue again - we are going to run at least all UI tests for PR to main / push to main or if the label is set. Also, we will need to have some quicker tests to figure out if something is wrong.