### PR TITLE
fix: resolve failing ucc-gen by pinning pip version

### DIFF
--- a/splunk_add_on_ucc_framework/install_python_libraries.py
+++ b/splunk_add_on_ucc_framework/install_python_libraries.py
@@ -110,7 +110,9 @@ def install_libraries(
     Upgrades `pip` version to the latest one and installs requirements to the
     specified path.
     """
-    pip_update_command = f"{installer} -m pip install pip --upgrade"
+
+    pip_version = "23.1.2"
+    pip_update_command = f"{installer} -m pip install pip --upgrade {pip_version}"
     pip_install_command = (
         f"{installer} "
         f"-m pip "

--- a/splunk_add_on_ucc_framework/install_python_libraries.py
+++ b/splunk_add_on_ucc_framework/install_python_libraries.py
@@ -112,7 +112,7 @@ def install_libraries(
     """
 
     pip_version = "23.1.2"
-    pip_update_command = f"{installer} -m pip install pip --upgrade {pip_version}"
+    pip_update_command = f"{installer} -m pip install pip --upgrade pip=={pip_version}"
     pip_install_command = (
         f"{installer} "
         f"-m pip "

--- a/tests/unit/test_install_python_libraries.py
+++ b/tests/unit/test_install_python_libraries.py
@@ -81,7 +81,7 @@ def test_install_libraries(mock_subprocess_call):
         '--use-deprecated=legacy-resolver --target "'
         '/path/to/output/addon_name/lib"'
     )
-    expected_pip_update_command = "python3 -m pip install pip --upgrade"
+    expected_pip_update_command = "python3 -m pip install pip --upgrade pip==23.1.2"
     mock_subprocess_call.assert_has_calls(
         [
             mock.call(expected_pip_update_command, shell=True),


### PR DESCRIPTION
With the latest pip version, the build started failing because the pip update command is not
deterministic. Since this potentially broke existing pipelines, even though ucc-gen was not  updated

#808