### PR TITLE
fix: add-on without globalConfig file should not be visible

### DIFF
--- a/splunk_add_on_ucc_framework/app_conf.py
+++ b/splunk_add_on_ucc_framework/app_conf.py
@@ -34,6 +34,7 @@ class AppConf:
         version: str,
         app_manifest: app_manifest_lib.AppManifest,
         conf_file_names: Sequence[str],
+        is_visible: bool,
     ) -> None:
         if "launcher" not in self._app_conf:
             self._app_conf.add_section("launcher")
@@ -60,7 +61,7 @@ class AppConf:
         self._app_conf["install"]["state"] = "enabled"
         self._app_conf["package"]["id"] = app_manifest.get_addon_name()
         self._app_conf["ui"]["label"] = app_manifest.get_title()
-        self._app_conf["ui"]["is_visible"] = "true"
+        self._app_conf["ui"]["is_visible"] = "true" if is_visible else "false"
         for conf_file_name in conf_file_names:
             self._app_conf["triggers"][f"reload.{conf_file_name}"] = "simple"
 

--- a/splunk_add_on_ucc_framework/commands/build.py
+++ b/splunk_add_on_ucc_framework/commands/build.py
@@ -513,7 +513,8 @@ def generate(
         output_directory, ta_name, "default", app_conf_lib.APP_CONF_FILE_NAME
     )
     app_conf.read(output_app_conf_path)
-    app_conf.update(addon_version, app_manifest, conf_file_names)
+    should_be_visible = True if global_config else False
+    app_conf.update(addon_version, app_manifest, conf_file_names, should_be_visible)
     app_conf.write(output_app_conf_path)
     logger.info(f"Updated {app_conf_lib.APP_CONF_FILE_NAME} file in the output folder")
 

--- a/tests/testdata/test_addons/package_global_config_configuration/package/default/app.conf
+++ b/tests/testdata/test_addons/package_global_config_configuration/package/default/app.conf
@@ -1,11 +1,3 @@
-######################################################
-#
-# ${package.name}
-#
-# ${copyright}
-#
-######################################################
-
 [install]
 build = 0
 
@@ -15,7 +7,7 @@ version = 0.1.0
 description = Splunk_TA_UCCExample
 
 [ui]
-is_visible = true
+is_visible = false
 label = Splunk_TA_UCCExample
 docs_section_override=AddOns:released
 

--- a/tests/testdata/test_addons/package_global_config_everything/globalConfig.json
+++ b/tests/testdata/test_addons/package_global_config_everything/globalConfig.json
@@ -1134,7 +1134,7 @@
     "meta": {
         "name": "Splunk_TA_UCCExample",
         "restRoot": "splunk_ta_uccexample",
-        "version": "5.28.2Rc7d26d54",
+        "version": "5.28.3Rec9a414a",
         "displayName": "Splunk UCC test Add-on",
         "schemaVersion": "0.0.3"
     }

--- a/tests/unit/test_app_conf.py
+++ b/tests/unit/test_app_conf.py
@@ -30,11 +30,43 @@ def test_update():
             "splunk_ta_uccexample_settings",
             "splunk_ta_uccexample_accounts",
         ],
+        True,
     )
     with tempfile.TemporaryDirectory() as temp_dir:
         output_app_conf_path = os.path.join(temp_dir, app_conf_lib.APP_CONF_FILE_NAME)
         app_conf.write(output_app_conf_path)
         app_conf_expected = get_testdata_file("app.conf.updated")
+        with open(output_app_conf_path) as output_app_conf_fd:
+            assert app_conf_expected == output_app_conf_fd.read()
+
+
+@mock.patch("time.time", mock.MagicMock(return_value=12345))
+def test_update_when_should_not_be_visible():
+    app_conf = app_conf_lib.AppConf()
+    app_conf.read(get_testdata_file_path("app.conf"))
+    app_manifest_mock = mock.MagicMock()
+    app_manifest_mock.get_description.return_value = (
+        "Description for Splunk_TA_UCCExample"
+    )
+    app_manifest_mock.get_addon_name.return_value = "Splunk_TA_UCCExample"
+    app_manifest_mock.get_title.return_value = "Title for Splunk_TA_UCCExample"
+    app_manifest_mock.get_authors.return_value = [
+        {
+            "name": "Company name",
+            "email": "email@example.com",
+            "company": "Company name",
+        },
+    ]
+    app_conf.update(
+        "1.0.0",
+        app_manifest_mock,
+        [],
+        False,
+    )
+    with tempfile.TemporaryDirectory() as temp_dir:
+        output_app_conf_path = os.path.join(temp_dir, app_conf_lib.APP_CONF_FILE_NAME)
+        app_conf.write(output_app_conf_path)
+        app_conf_expected = get_testdata_file("app.conf.updated_not_visible")
         with open(output_app_conf_path) as output_app_conf_fd:
             assert app_conf_expected == output_app_conf_fd.read()
 
@@ -60,6 +92,7 @@ def test_update_when_minimal_app_conf():
         "1.0.0",
         app_manifest_mock,
         [],
+        True,
     )
     with tempfile.TemporaryDirectory() as temp_dir:
         output_app_conf_path = os.path.join(temp_dir, app_conf_lib.APP_CONF_FILE_NAME)

--- a/tests/unit/testdata/app.conf.updated_not_visible
+++ b/tests/unit/testdata/app.conf.updated_not_visible
@@ -1,22 +1,22 @@
 [install]
-build = 1628341075
+build = 12345
 is_configured = false
 state = enabled
 
 [launcher]
-author = Splunk Inc.
+author = Company name
 version = 1.0.0
-description = Splunk Add-on for UCC Example
+description = Description for Splunk_TA_UCCExample
 
 [ui]
 is_visible = false
-label = Splunk Add-on for UCC Example
+label = Title for Splunk_TA_UCCExample
 docs_section_override = AddOns:released
 
 [package]
 id = Splunk_TA_UCCExample
 
 [id]
-name = Splunk_TA_UCCExample
 version = 1.0.0
+name = Splunk_TA_UCCExample
 


### PR DESCRIPTION
So called `.conf`-only add-ons should not be visible in the UI.