### PR TITLE
Add selected python version to build output

### DIFF
--- a/splunk_add_on_ucc_framework/commands/build.py
+++ b/splunk_add_on_ucc_framework/commands/build.py
@@ -324,9 +324,13 @@ def generate(
     logger.info(f"Python binary name to use: {python_binary_name}")
 
     try:
-        python_binary_version = subprocess.run([python_binary_name, '--version'], stdout=subprocess.PIPE).stdout.decode('utf-8')
+        python_binary_version = subprocess.run(
+            [python_binary_name, "--version"], stdout=subprocess.PIPE
+        ).stdout.decode("utf-8")
     except subprocess.CalledProcessError as e:
-        logger.error(f"Failed to identify Python version for library installation. Error: {e}")
+        logger.error(
+            f"Failed to identify Python version for library installation. Error: {e}"
+        )
         sys.exit(1)
 
     logger.info(f"Python Version: {python_binary_version}")

--- a/splunk_add_on_ucc_framework/commands/build.py
+++ b/splunk_add_on_ucc_framework/commands/build.py
@@ -313,15 +313,18 @@ def _get_build_output_path(output_directory: Optional[str] = None) -> str:
             return os.path.join(os.getcwd(), output_directory)
         return output_directory
 
-def _get_python_version_from_executable(python_binary_name: str) -> str:
-        try:
-            python_binary_version = subprocess.run(
-                [python_binary_name, "--version"], stdout=subprocess.PIPE
-            ).stdout.decode("utf-8")
 
-            return python_binary_version.strip()
-        except (subprocess.CalledProcessError, FileNotFoundError) as e:
-            raise exceptions.CouldNotIdentifyPythonVersionException()
+def _get_python_version_from_executable(python_binary_name: str) -> str:
+    try:
+        python_binary_version = subprocess.run(
+            [python_binary_name, "--version"], stdout=subprocess.PIPE
+        ).stdout.decode("utf-8")
+
+        return python_binary_version.strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        raise exceptions.CouldNotIdentifyPythonVersionException(
+            f"Failed to identify python version for binary {python_binary_name}"
+        )
 
 
 def generate(
@@ -337,7 +340,7 @@ def generate(
     try:
         python_binary_version = _get_python_version_from_executable(python_binary_name)
         logger.info(f"Python Version: {python_binary_version}")
-    except:
+    except exceptions.CouldNotIdentifyPythonVersionException as e:
         logger.error(
             f"Failed to identify Python version for library installation. Error: {e}"
         )

--- a/splunk_add_on_ucc_framework/commands/build.py
+++ b/splunk_add_on_ucc_framework/commands/build.py
@@ -312,6 +312,16 @@ def _get_build_output_path(output_directory: Optional[str] = None) -> str:
             return os.path.join(os.getcwd(), output_directory)
         return output_directory
 
+def _get_python_version_from_executable(python_binary_name: str) -> str:
+        try:
+            python_binary_version = subprocess.run(
+                [python_binary_name, "--version"], stdout=subprocess.PIPE
+            ).stdout.decode("utf-8")
+
+            return python_binary_version.strip()
+        except (subprocess.CalledProcessError, FileNotFoundError) as e:
+            raise exceptions.CouldNotIdentifyPythonVersionException()
+
 
 def generate(
     source: str,
@@ -324,16 +334,13 @@ def generate(
     logger.info(f"Python binary name to use: {python_binary_name}")
 
     try:
-        python_binary_version = subprocess.run(
-            [python_binary_name, "--version"], stdout=subprocess.PIPE
-        ).stdout.decode("utf-8")
-    except subprocess.CalledProcessError as e:
+        python_binary_version = _get_python_version_from_executable(python_binary_name)
+        logger.info(f"Python Version: {python_binary_version}")
+    except:
         logger.error(
             f"Failed to identify Python version for library installation. Error: {e}"
         )
         sys.exit(1)
-
-    logger.info(f"Python Version: {python_binary_version}")
 
     output_directory = _get_build_output_path(output_directory)
     logger.info(f"Output folder is {output_directory}")

--- a/splunk_add_on_ucc_framework/commands/build.py
+++ b/splunk_add_on_ucc_framework/commands/build.py
@@ -20,6 +20,7 @@ import os
 import shutil
 import sys
 from typing import Optional
+import subprocess
 
 from openapi3 import OpenAPI
 
@@ -321,6 +322,15 @@ def generate(
 ):
     logger.info(f"ucc-gen version {__version__} is used")
     logger.info(f"Python binary name to use: {python_binary_name}")
+
+    try:
+        python_binary_version = subprocess.run([python_binary_name, '--version'], stdout=subprocess.PIPE).stdout.decode('utf-8')
+    except subprocess.CalledProcessError as e:
+        logger.error(f"Failed to identify Python version for library installation. Error: {e}")
+        sys.exit(1)
+
+    logger.info(f"Python Version: {python_binary_version}")
+
     output_directory = _get_build_output_path(output_directory)
     logger.info(f"Output folder is {output_directory}")
     addon_version = _get_addon_version(addon_version)

--- a/splunk_add_on_ucc_framework/exceptions.py
+++ b/splunk_add_on_ucc_framework/exceptions.py
@@ -20,5 +20,6 @@ class CouldNotVersionFromGitException(Exception):
 class IsNotAGitRepo(Exception):
     pass
 
+
 class CouldNotIdentifyPythonVersionException(Exception):
     pass

--- a/splunk_add_on_ucc_framework/exceptions.py
+++ b/splunk_add_on_ucc_framework/exceptions.py
@@ -19,3 +19,6 @@ class CouldNotVersionFromGitException(Exception):
 
 class IsNotAGitRepo(Exception):
     pass
+
+class CouldNotIdentifyPythonVersionException(Exception):
+    pass

--- a/tests/unit/commands/test_build.py
+++ b/tests/unit/commands/test_build.py
@@ -3,8 +3,13 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from splunk_add_on_ucc_framework.commands.build import _get_build_output_path, _get_python_version_from_executable
-from splunk_add_on_ucc_framework.exceptions import CouldNotIdentifyPythonVersionException
+from splunk_add_on_ucc_framework.commands.build import (
+    _get_build_output_path,
+    _get_python_version_from_executable,
+)
+from splunk_add_on_ucc_framework.exceptions import (
+    CouldNotIdentifyPythonVersionException,
+)
 
 CURRENT_PATH = os.getcwd()
 
@@ -21,16 +26,13 @@ CURRENT_PATH = os.getcwd()
 def test_get_build_output_path(output_directory, expected_output_directory):
     assert expected_output_directory == _get_build_output_path(output_directory)
 
+
 @patch("splunk_add_on_ucc_framework.commands.build.subprocess.run")
 def test_get_python_version_from_executable(mock_run):
     target_python_version = "Python 3.8.17"
 
     mock_stdout = MagicMock()
-    mock_stdout.configure_mock(
-        **{
-            "stdout.decode.return_value": target_python_version
-        }
-    )
+    mock_stdout.configure_mock(**{"stdout.decode.return_value": target_python_version})
 
     mock_run.return_value = mock_stdout
 
@@ -38,10 +40,11 @@ def test_get_python_version_from_executable(mock_run):
 
     assert python_version == target_python_version
 
+
 def test_get_python_version_from_executable_nonexisting_command():
-    target_python_version = "acommandthatdoesnotexistda39a3ee5e6b4b0d3255bfef95601890afd80709"
+    target_python_version = (
+        "acommandthatdoesnotexistda39a3ee5e6b4b0d3255bfef95601890afd80709"
+    )
 
     with pytest.raises(CouldNotIdentifyPythonVersionException):
         _get_python_version_from_executable(target_python_version)
-
-

--- a/tests/unit/commands/test_build.py
+++ b/tests/unit/commands/test_build.py
@@ -1,8 +1,10 @@
 import os
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-from splunk_add_on_ucc_framework.commands.build import _get_build_output_path
+from splunk_add_on_ucc_framework.commands.build import _get_build_output_path, _get_python_version_from_executable
+from splunk_add_on_ucc_framework.exceptions import CouldNotIdentifyPythonVersionException
 
 CURRENT_PATH = os.getcwd()
 
@@ -18,3 +20,28 @@ CURRENT_PATH = os.getcwd()
 )
 def test_get_build_output_path(output_directory, expected_output_directory):
     assert expected_output_directory == _get_build_output_path(output_directory)
+
+@patch("splunk_add_on_ucc_framework.commands.build.subprocess.run")
+def test_get_python_version_from_executable(mock_run):
+    target_python_version = "Python 3.8.17"
+
+    mock_stdout = MagicMock()
+    mock_stdout.configure_mock(
+        **{
+            "stdout.decode.return_value": target_python_version
+        }
+    )
+
+    mock_run.return_value = mock_stdout
+
+    python_version = _get_python_version_from_executable("python3")
+
+    assert python_version == target_python_version
+
+def test_get_python_version_from_executable_nonexisting_command():
+    target_python_version = "acommandthatdoesnotexistda39a3ee5e6b4b0d3255bfef95601890afd80709"
+
+    with pytest.raises(CouldNotIdentifyPythonVersionException):
+        _get_python_version_from_executable(target_python_version)
+
+


### PR DESCRIPTION
When running `ucc-gen build` it is important to know which Python executable is used (this already exists) but it does not print the version of the executable.

This PR introduces a new log statement and a call to receive the Python version of the executable in use.