### PR TITLE
feat: update UCC UI to v1.32.0

### DIFF
--- a/docs/entity/components.md
+++ b/docs/entity/components.md
@@ -360,7 +360,6 @@ This is how it looks like in the UI:
 
 ![image](../images/components/help_link_component_example.png)
 
-
 ## `File`
 
 Underlying `@splunk/react-ui` component: [`File`](https://splunkui.splunk.com/Packages/react-ui/File).

--- a/get-ucc-ui.sh
+++ b/get-ucc-ui.sh
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-wget https://github.com/splunk/addonfactory-ucc-base-ui/releases/download/v1.31.0/splunk-ucc-ui.tgz
+wget https://github.com/splunk/addonfactory-ucc-base-ui/releases/download/v1.32.0/splunk-ucc-ui.tgz

--- a/tests/testdata/expected_addons/expected_output_global_config_everything/Splunk_TA_UCCExample/README/inputs.conf.spec
+++ b/tests/testdata/expected_addons/expected_output_global_config_everything/Splunk_TA_UCCExample/README/inputs.conf.spec
@@ -24,6 +24,7 @@ input_two_radio =
 use_existing_checkpoint = 
 start_date = 
 example_help_link = 
+apis = 
 
 [example_input_three://<name>]
 interval = 

--- a/tests/testdata/expected_addons/expected_output_global_config_everything/Splunk_TA_UCCExample/bin/example_input_two.py
+++ b/tests/testdata/expected_addons/expected_output_global_config_everything/Splunk_TA_UCCExample/bin/example_input_two.py
@@ -75,6 +75,13 @@ class EXAMPLE_INPUT_TWO(smi.Script):
             )
         )
         
+        scheme.add_argument(
+            smi.Argument(
+                'apis',
+                required_on_create=False,
+            )
+        )
+        
         return scheme
 
     def validate_input(self, definition):

--- a/tests/testdata/expected_addons/expected_output_global_config_everything/Splunk_TA_UCCExample/bin/splunk_ta_uccexample_rh_example_input_two.py
+++ b/tests/testdata/expected_addons/expected_output_global_config_everything/Splunk_TA_UCCExample/bin/splunk_ta_uccexample_rh_example_input_two.py
@@ -85,6 +85,13 @@ fields = [
         default=None,
         validator=None
     ), 
+    field.RestField(
+        'apis',
+        required=False,
+        encrypted=False,
+        default=None,
+        validator=None
+    ), 
 
     field.RestField(
         'disabled',

--- a/tests/testdata/test_addons/package_global_config_everything/globalConfig.json
+++ b/tests/testdata/test_addons/package_global_config_everything/globalConfig.json
@@ -835,6 +835,161 @@
                                 "text": "Help Link",
                                 "link": "https://docs.splunk.com/Documentation"
                             }
+                        },
+                        {
+                            "field": "apis",
+                            "label": "APIs/Interval (in seconds)",
+                            "type": "checkboxGroup",
+                            "options": {
+                                "groups": [
+                                    {
+                                        "label": "EC2",
+                                        "options": {
+                                            "isExpandable": true
+                                        },
+                                        "fields": [
+                                            "ec2_volumes",
+                                            "ec2_instances",
+                                            "ec2_reserved_instances",
+                                            "ebs_snapshots",
+                                            "rds_instances",
+                                            "rds_reserved_instances",
+                                            "ec2_key_pairs",
+                                            "ec2_security_groups",
+                                            "ec2_images",
+                                            "ec2_addresses"
+                                        ]
+                                    },
+                                    {
+                                        "label": "ELB",
+                                        "options": {
+                                            "isExpandable": true
+                                        },
+                                        "fields": [
+                                            "classic_load_balancers",
+                                            "application_load_balancers"
+                                        ]
+                                    },
+                                    {
+                                        "label": "VPC",
+                                        "options": {
+                                            "isExpandable": true
+                                        },
+                                        "fields": [
+                                            "vpcs",
+                                            "vpc_network_acls",
+                                            "vpc_subnets"
+                                        ]
+                                    }
+                                ],
+                                "rows": [
+                                    {
+                                        "field": "ec2_volumes",
+                                        "text": {
+                                            "defaultValue": 3600,
+                                            "required": true
+                                        }
+                                    },
+                                    {
+                                        "field": "ec2_instances",
+                                        "text": {
+                                            "defaultValue": 3600,
+                                            "required": true
+                                        }
+                                    },
+                                    {
+                                        "field": "ec2_reserved_instances",
+                                        "text": {
+                                            "defaultValue": 3600,
+                                            "required": true
+                                        }
+                                    },
+                                    {
+                                        "field": "ebs_snapshots",
+                                        "text": {
+                                            "defaultValue": 3600,
+                                            "required": true
+                                        }
+                                    },
+                                    {
+                                        "field": "rds_instances",
+                                        "text": {
+                                            "defaultValue": 3600,
+                                            "required": true
+                                        }
+                                    },
+                                    {
+                                        "field": "rds_reserved_instances",
+                                        "text": {
+                                            "defaultValue": 3600,
+                                            "required": true
+                                        }
+                                    },
+                                    {
+                                        "field": "ec2_key_pairs",
+                                        "text": {
+                                            "defaultValue": 3600,
+                                            "required": true
+                                        }
+                                    },
+                                    {
+                                        "field": "ec2_security_groups",
+                                        "text": {
+                                            "defaultValue": 3600,
+                                            "required": true
+                                        }
+                                    },
+                                    {
+                                        "field": "ec2_images",
+                                        "text": {
+                                            "defaultValue": 3600,
+                                            "required": true
+                                        }
+                                    },
+                                    {
+                                        "field": "ec2_addresses",
+                                        "text": {
+                                            "defaultValue": 3600,
+                                            "required": true
+                                        }
+                                    },
+                                    {
+                                        "field": "classic_load_balancers",
+                                        "text": {
+                                            "defaultValue": 3600,
+                                            "required": true
+                                        }
+                                    },
+                                    {
+                                        "field": "application_load_balancers",
+                                        "text": {
+                                            "defaultValue": 3600,
+                                            "required": true
+                                        }
+                                    },
+                                    {
+                                        "field": "vpcs",
+                                        "text": {
+                                            "defaultValue": 3600,
+                                            "required": true
+                                        }
+                                    },
+                                    {
+                                        "field": "vpc_network_acls",
+                                        "text": {
+                                            "defaultValue": 3600,
+                                            "required": true
+                                        }
+                                    },
+                                    {
+                                        "field": "vpc_subnets",
+                                        "text": {
+                                            "defaultValue": 3600,
+                                            "required": true
+                                        }
+                                    }
+                                ]
+                            }
                         }
                     ],
                     "title": "Example Input Two"
@@ -1131,7 +1286,7 @@
     "meta": {
         "name": "Splunk_TA_UCCExample",
         "restRoot": "splunk_ta_uccexample",
-        "version": "5.29.0R87e714a5",
+        "version": "5.29.0R411a911a",
         "displayName": "Splunk UCC test Add-on",
         "schemaVersion": "0.0.3"
     }

--- a/tests/unit/test_global_config_validator.py
+++ b/tests/unit/test_global_config_validator.py
@@ -256,6 +256,27 @@ def test_config_validation_when_deprecated_placeholder_is_used():
                 f"Supported panel names: {dashboard.SUPPORTED_PANEL_NAMES_READABLE}"
             ),
         ),
+        (
+            "invalid_config_checkbox_groups_duplicate_fields_in_options_rows.json",
+            False,
+            (
+                "Entity test_checkbox_group has duplicate field (collectFolderCollaboration) in options.rows"
+            ),
+        ),
+        (
+            "invalid_config_checkbox_groups_undefined_field_used_in_groups.json",
+            False,
+            (
+                "Entity test_checkbox_group uses field (undefined_field_foo) which is not defined in options.rows"
+            ),
+        ),
+        (
+            "invalid_config_checkbox_groups_duplicate_field_in_options_groups.json",
+            False,
+            (
+                "Entity test_checkbox_group has duplicate field (collectTasksAndComments) in options.groups"
+            ),
+        ),
     ],
 )
 def test_config_validation_when_error(filename, is_yaml, exception_message):

--- a/tests/unit/testdata/invalid_config_checkbox_groups_duplicate_field_in_options_groups.json
+++ b/tests/unit/testdata/invalid_config_checkbox_groups_duplicate_field_in_options_groups.json
@@ -1,0 +1,164 @@
+{
+    "pages": {
+        "configuration": {
+            "tabs": [
+                {
+                    "name": "logging",
+                    "entity": [
+                        {
+                            "type": "singleSelect",
+                            "label": "Log level",
+                            "options": {
+                                "disableSearch": true,
+                                "autoCompleteFields": [
+                                    {
+                                        "value": "DEBUG",
+                                        "label": "DEBUG"
+                                    },
+                                    {
+                                        "value": "INFO",
+                                        "label": "INFO"
+                                    },
+                                    {
+                                        "value": "WARNING",
+                                        "label": "WARNING"
+                                    },
+                                    {
+                                        "value": "ERROR",
+                                        "label": "ERROR"
+                                    },
+                                    {
+                                        "value": "CRITICAL",
+                                        "label": "CRITICAL"
+                                    }
+                                ]
+                            },
+                            "defaultValue": "INFO",
+                            "field": "loglevel"
+                        }
+                    ],
+                    "title": "Logging"
+                }
+            ],
+            "title": "Configuration",
+            "description": "Set up your add-on"
+        },
+        "inputs": {
+            "services": [
+                {
+                    "name": "example_input_one",
+                    "entity": [
+                        {
+                            "type": "checkboxGroup",
+                            "label": "Test checkboxGroup",
+                            "field": "test_checkbox_group",
+                            "options": {
+                                "groups": [
+                                    {
+                                        "label": "Collect",
+                                        "fields": [
+                                            "collectFolderCollaboration",
+                                            "collectFileMetadata",
+                                            "collectTasksAndComments"
+                                        ]
+                                    },
+                                    {
+                                        "label": "Collect2",
+                                        "options": {
+                                            "isExpandable": true
+                                        },
+                                        "fields": [
+                                            "collectFolderMetadata",
+                                            "collectTasksAndComments"
+                                        ]
+                                    }
+                                ],
+                                "rows": [
+                                    {
+                                        "field": "collectFolderCollaboration",
+                                        "text": {
+                                            "defaultValue": 1200,
+                                            "required": false,
+                                            "validators": [
+                                                {
+                                                    "type": "number",
+                                                    "range": [1, 1200]
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "field": "collectFileMetadata",
+                                        "checkbox": {
+                                            "label": "Collect file metadata"
+                                        },
+                                        "text": {
+                                            "defaultValue": 1,
+                                            "required": true
+                                        }
+                                    },
+                                    {
+                                        "field": "collectTasksAndComments",
+                                        "checkbox": {
+                                            "label": "This is a very very long line",
+                                            "options": {
+                                                "enable": true
+                                            }
+                                        },
+                                        "text": {
+                                            "defaultValue": 1,
+                                            "required": true
+                                        }
+                                    },
+                                    {
+                                        "field": "collectFolderMetadata",
+                                        "checkbox": {
+                                            "label": "Collect folder metadata",
+                                            "options": {
+                                                "enable": true
+                                            }
+                                        },
+                                        "text": {
+                                            "defaultValue": 3600,
+                                            "required": true
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "title": "Example Input One"
+                }
+            ],
+            "title": "Inputs",
+            "description": "Manage your data inputs",
+            "table": {
+                "actions": [
+                    "edit",
+                    "enable",
+                    "delete",
+                    "clone"
+                ],
+                "header": [
+                    {
+                        "label": "Name",
+                        "field": "name"
+                    }
+                ],
+                "moreInfo": [
+                    {
+                        "label": "Name",
+                        "field": "name"
+                    }
+                ]
+            }
+        }
+    },
+    "meta": {
+        "name": "Splunk_TA_UCCExample",
+        "restRoot": "splunk_ta_uccexample",
+        "version": "1.0.0",
+        "displayName": "Splunk UCC test Add-on",
+        "schemaVersion": "0.0.3"
+    }
+}

--- a/tests/unit/testdata/invalid_config_checkbox_groups_duplicate_fields_in_options_rows.json
+++ b/tests/unit/testdata/invalid_config_checkbox_groups_duplicate_fields_in_options_rows.json
@@ -49,37 +49,59 @@
                     "name": "example_input_one",
                     "entity": [
                         {
-                            "field": "singleSelectTest",
-                            "label": "Single Select",
-                            "type": "singleSelect",
+                            "type": "checkboxGroup",
+                            "label": "Test checkboxGroup",
+                            "field": "test_checkbox_group",
                             "options": {
-                                "createSearchChoice": true,
-                                "autoCompleteFields": [
+                                "rows": [
                                     {
-                                        "label": "Group1",
-                                        "children": [
-                                            {
-                                                "value": "duplication",
-                                                "label": "One"
-                                            },
-                                            {
-                                                "value": "duplication",
-                                                "label": "Two"
-                                            }
-                                        ]
+                                        "field": "collectFolderCollaboration",
+                                        "text": {
+                                            "defaultValue": 1200,
+                                            "required": false,
+                                            "validators": [
+                                                {
+                                                    "type": "number",
+                                                    "range": [1, 1200]
+                                                }
+                                            ]
+                                        }
                                     },
                                     {
-                                        "label": "Group2",
-                                        "children": [
-                                            {
-                                                "value": "three",
-                                                "label": "Three"
-                                            },
-                                            {
-                                                "value": "four",
-                                                "label": "Four"
+                                        "field": "collectFileMetadata",
+                                        "checkbox": {
+                                            "label": "Collect file metadata"
+                                        },
+                                        "text": {
+                                            "defaultValue": 1,
+                                            "required": true
+                                        }
+                                    },
+                                    {
+                                        "field": "collectTasksAndComments",
+                                        "checkbox": {
+                                            "label": "This is a very very long line",
+                                            "options": {
+                                                "enable": true
                                             }
-                                        ]
+                                        },
+                                        "text": {
+                                            "defaultValue": 1,
+                                            "required": true
+                                        }
+                                    },
+                                    {
+                                        "field": "collectFolderCollaboration",
+                                        "checkbox": {
+                                            "label": "Collect folder metadata",
+                                            "options": {
+                                                "enable": true
+                                            }
+                                        },
+                                        "text": {
+                                            "defaultValue": 3600,
+                                            "required": true
+                                        }
                                     }
                                 ]
                             }

--- a/tests/unit/testdata/invalid_config_checkbox_groups_undefined_field_used_in_groups.json
+++ b/tests/unit/testdata/invalid_config_checkbox_groups_undefined_field_used_in_groups.json
@@ -1,0 +1,164 @@
+{
+    "pages": {
+        "configuration": {
+            "tabs": [
+                {
+                    "name": "logging",
+                    "entity": [
+                        {
+                            "type": "singleSelect",
+                            "label": "Log level",
+                            "options": {
+                                "disableSearch": true,
+                                "autoCompleteFields": [
+                                    {
+                                        "value": "DEBUG",
+                                        "label": "DEBUG"
+                                    },
+                                    {
+                                        "value": "INFO",
+                                        "label": "INFO"
+                                    },
+                                    {
+                                        "value": "WARNING",
+                                        "label": "WARNING"
+                                    },
+                                    {
+                                        "value": "ERROR",
+                                        "label": "ERROR"
+                                    },
+                                    {
+                                        "value": "CRITICAL",
+                                        "label": "CRITICAL"
+                                    }
+                                ]
+                            },
+                            "defaultValue": "INFO",
+                            "field": "loglevel"
+                        }
+                    ],
+                    "title": "Logging"
+                }
+            ],
+            "title": "Configuration",
+            "description": "Set up your add-on"
+        },
+        "inputs": {
+            "services": [
+                {
+                    "name": "example_input_one",
+                    "entity": [
+                        {
+                            "type": "checkboxGroup",
+                            "label": "Test checkboxGroup",
+                            "field": "test_checkbox_group",
+                            "options": {
+                                "groups": [
+                                    {
+                                        "label": "Collect",
+                                        "fields": [
+                                            "collectFolderCollaboration",
+                                            "collectFileMetadata",
+                                            "collectTasksAndComments"
+                                        ]
+                                    },
+                                    {
+                                        "label": "Collect2",
+                                        "options": {
+                                            "isExpandable": true
+                                        },
+                                        "fields": [
+                                            "collectFolderMetadata",
+                                            "undefined_field_foo"
+                                        ]
+                                    }
+                                ],
+                                "rows": [
+                                    {
+                                        "field": "collectFolderCollaboration",
+                                        "text": {
+                                            "defaultValue": 1200,
+                                            "required": false,
+                                            "validators": [
+                                                {
+                                                    "type": "number",
+                                                    "range": [1, 1200]
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "field": "collectFileMetadata",
+                                        "checkbox": {
+                                            "label": "Collect file metadata"
+                                        },
+                                        "text": {
+                                            "defaultValue": 1,
+                                            "required": true
+                                        }
+                                    },
+                                    {
+                                        "field": "collectTasksAndComments",
+                                        "checkbox": {
+                                            "label": "This is a very very long line",
+                                            "options": {
+                                                "enable": true
+                                            }
+                                        },
+                                        "text": {
+                                            "defaultValue": 1,
+                                            "required": true
+                                        }
+                                    },
+                                    {
+                                        "field": "collectFolderMetadata",
+                                        "checkbox": {
+                                            "label": "Collect folder metadata",
+                                            "options": {
+                                                "enable": true
+                                            }
+                                        },
+                                        "text": {
+                                            "defaultValue": 3600,
+                                            "required": true
+                                        }
+                                    }
+                                ]
+                            }
+                        }
+                    ],
+                    "title": "Example Input One"
+                }
+            ],
+            "title": "Inputs",
+            "description": "Manage your data inputs",
+            "table": {
+                "actions": [
+                    "edit",
+                    "enable",
+                    "delete",
+                    "clone"
+                ],
+                "header": [
+                    {
+                        "label": "Name",
+                        "field": "name"
+                    }
+                ],
+                "moreInfo": [
+                    {
+                        "label": "Name",
+                        "field": "name"
+                    }
+                ]
+            }
+        }
+    },
+    "meta": {
+        "name": "Splunk_TA_UCCExample",
+        "restRoot": "splunk_ta_uccexample",
+        "version": "1.0.0",
+        "displayName": "Splunk UCC test Add-on",
+        "schemaVersion": "0.0.3"
+    }
+}

--- a/tests/unit/testdata/invalid_config_inputs_entity_duplicates.json
+++ b/tests/unit/testdata/invalid_config_inputs_entity_duplicates.json
@@ -46,9 +46,6 @@
         "inputs": {
             "services": [
                 {
-                    "hook": {
-                        "src": "Hook"
-                    },
                     "name": "duplicate",
                     "entity": [
                         {

--- a/tests/unit/testdata/openapi.json.generated
+++ b/tests/unit/testdata/openapi.json.generated
@@ -454,6 +454,15 @@
                                         "start_date": {
                                                 "type": "string"
                                         },
+                                        "api1": {
+                                                "type": "string"
+                                        },
+                                        "api2": {
+                                                "type": "string"
+                                        },
+                                        "api3": {
+                                                "type": "string"
+                                        },
                                         "disabled": {
                                                 "type": "string",
                                                 "enum": [
@@ -488,6 +497,15 @@
                                                 "type": "string"
                                         },
                                         "start_date": {
+                                                "type": "string"
+                                        },
+                                        "api1": {
+                                                "type": "string"
+                                        },
+                                        "api2": {
+                                                "type": "string"
+                                        },
+                                        "api3": {
                                                 "type": "string"
                                         },
                                         "disabled": {
@@ -527,6 +545,15 @@
                                                 "type": "string"
                                         },
                                         "start_date": {
+                                                "type": "string"
+                                        },
+                                        "api1": {
+                                                "type": "string"
+                                        },
+                                        "api2": {
+                                                "type": "string"
+                                        },
+                                        "api3": {
                                                 "type": "string"
                                         }
                                 }

--- a/tests/unit/testdata/valid_config.json
+++ b/tests/unit/testdata/valid_config.json
@@ -91,7 +91,8 @@
                             "help": "This is an example radio button for the account entity",
                             "required": true,
                             "options": {
-                                "items": [{
+                                "items": [
+                                    {
                                         "value": "yes",
                                         "label": "Yes"
                                     },
@@ -110,7 +111,8 @@
                             "help": "This is an example multipleSelect for account entity",
                             "required": true,
                             "options": {
-                                "items": [{
+                                "items": [
+                                    {
                                         "value": "one",
                                         "label": "Option One"
                                     },
@@ -206,7 +208,7 @@
                                 "rowsMax": 15
                             },
                             "required": true
-                        },             
+                        },
                         {
                             "type": "file",
                             "label": "Upload File",
@@ -214,7 +216,10 @@
                             "field": "service_account",
                             "options": {
                                 "fileSupportMessage": "Here is the support message",
-                                "supportedFileTypes": ["json", "pem"]
+                                "supportedFileTypes": [
+                                    "json",
+                                    "pem"
+                                ]
                             },
                             "encrypted": true,
                             "required": true
@@ -485,7 +490,8 @@
                             "help": "This is an example radio button for the input one entity",
                             "required": false,
                             "options": {
-                                "items": [{
+                                "items": [
+                                    {
                                         "value": "yes",
                                         "label": "Yes"
                                     },
@@ -779,7 +785,8 @@
                             "help": "This is an example multipleSelect for input two entity",
                             "required": true,
                             "options": {
-                                "items": [{
+                                "items": [
+                                    {
                                         "value": "one",
                                         "label": "Option One"
                                     },
@@ -804,7 +811,8 @@
                             "help": "This is an example radio button for the input two entity",
                             "required": false,
                             "options": {
-                                "items": [{
+                                "items": [
+                                    {
                                         "value": "yes",
                                         "label": "Yes"
                                     },
@@ -859,6 +867,263 @@
                             "options": {
                                 "text": "Help Link",
                                 "link": "https://docs.splunk.com/Documentation"
+                            }
+                        },
+                        {
+                            "type": "checkboxGroup",
+                            "label": "Two groups",
+                            "field": "api1",
+                            "options": {
+                                "groups": [
+                                    {
+                                        "label": "Collect",
+                                        "fields": [
+                                            "collectFolderCollaboration",
+                                            "collectFileMetadata",
+                                            "collectTasksAndComments"
+                                        ]
+                                    },
+                                    {
+                                        "label": "Collect2",
+                                        "options": {
+                                            "isExpandable": true
+                                        },
+                                        "fields": ["collectFolderMetadata"]
+                                    }
+                                ],
+                                "rows": [
+                                    {
+                                        "field": "collectFolderCollaboration",
+                                        "text": {
+                                            "defaultValue": 1200,
+                                            "required": false,
+                                            "validators": [
+                                                {
+                                                    "type": "number",
+                                                    "range": [1, 1200]
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "field": "collectFileMetadata",
+                                        "checkbox": {
+                                            "label": "Collect file metadata"
+                                        },
+                                        "text": {
+                                            "defaultValue": 1,
+                                            "required": true
+                                        }
+                                    },
+                                    {
+                                        "field": "collectTasksAndComments",
+                                        "checkbox": {
+                                            "label": "This is a very very long line",
+                                            "options": {
+                                                "enable": true
+                                            }
+                                        },
+                                        "text": {
+                                            "defaultValue": 1,
+                                            "required": true
+                                        }
+                                    },
+                                    {
+                                        "field": "collectFolderMetadata",
+                                        "checkbox": {
+                                            "label": "Collect folder metadata",
+                                            "options": {
+                                                "enable": true
+                                            }
+                                        },
+                                        "text": {
+                                            "defaultValue": 3600,
+                                            "required": true
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "type": "checkboxGroup",
+                            "label": "No groups",
+                            "field": "api2",
+                            "options": {
+                                "rows": [
+                                    {
+                                        "field": "collectFolderMetadata",
+                                        "checkbox": {
+                                            "label": "Collect folder metadata",
+                                            "options": {
+                                                "enable": true
+                                            }
+                                        },
+                                        "text": {
+                                            "defaultValue": 3600,
+                                            "required": true
+                                        }
+                                    },
+                                    {
+                                        "field": "collectFolderCollaboration",
+                                        "checkbox": {
+                                            "label": "Collect folder collaboration"
+                                        },
+                                        "text": {
+                                            "defaultValue": 1200,
+                                            "required": false,
+                                            "validators": [
+                                                {
+                                                    "type": "number",
+                                                    "range": [1, 1200]
+                                                }
+                                            ]
+                                        }
+                                    },
+                                    {
+                                        "field": "collectFileMetadata",
+                                        "checkbox": {
+                                            "label": "Collect file metadata"
+                                        },
+                                        "text": {
+                                            "defaultValue": 1,
+                                            "required": true
+                                        }
+                                    },
+                                    {
+                                        "field": "collectTasksAndComments",
+                                        "checkbox": {
+                                            "label": "Collect tasks and comments"
+                                        },
+                                        "text": {
+                                            "defaultValue": 1,
+                                            "required": true
+                                        }
+                                    }
+                                ]
+                            }
+                        },
+                        {
+                            "type": "checkboxGroup",
+                            "label": "Mixed",
+                            "field": "api3",
+                            "options": {
+                                "groups": [
+                                    {
+                                        "label": "Group 1",
+                                        "options": {
+                                            "isExpandable": true,
+                                            "expand": true
+                                        },
+                                        "fields": ["collectFolderCollaboration"]
+                                    },
+                                    {
+                                        "label": "Group 3",
+                                        "options": {
+                                            "isExpandable": true,
+                                            "expand": true
+                                        },
+                                        "fields": ["collectFolderMetadata"]
+                                    }
+                                ],
+                                "rows": [
+                                    {
+                                        "field": "collectFolderCollaboration",
+                                        "checkbox": {
+                                            "label": "Collect folder collaboration",
+                                            "options": {
+                                                "enable": true
+                                            }
+                                        },
+                                        "text": {
+                                            "defaultValue": 1200,
+                                            "required": false
+                                        }
+                                    },
+                                    {
+                                        "field": "collectFileMetadata",
+                                        "checkbox": {
+                                            "label": "Collect file metadata",
+                                            "options": {
+                                                "enable": true
+                                            }
+                                        },
+                                        "text": {
+                                            "defaultValue": 1,
+                                            "required": true
+                                        }
+                                    },
+                                    {
+                                        "field": "collectTasksAndComments",
+                                        "checkbox": {
+                                            "label": "Collect tasks and comments",
+                                            "options": {
+                                                "enable": true
+                                            }
+                                        },
+                                        "text": {
+                                            "defaultValue": 1,
+                                            "required": true
+                                        }
+                                    },
+                                    {
+                                        "field": "collectFolderMetadata",
+                                        "checkbox": {
+                                            "label": "Collect folder metadata",
+                                            "options": {
+                                                "enable": true
+                                            }
+                                        },
+                                        "text": {
+                                            "defaultValue": 3600,
+                                            "required": true
+                                        }
+                                    },
+                                    {
+                                        "field": "field223",
+                                        "checkbox": {
+                                            "label": "Required field",
+                                            "options": {
+                                                "enable": true
+                                            }
+                                        },
+                                        "text": {
+                                            "required": true
+                                        }
+                                    },
+                                    {
+                                        "field": "field23",
+                                        "checkbox": {
+                                            "label": "No more 2 characters",
+                                            "options": {
+                                                "enable": true
+                                            }
+                                        },
+                                        "text": {
+                                            "validators": [
+                                                {
+                                                    "type": "string",
+                                                    "minLength": 0,
+                                                    "maxLength": 2
+                                                }
+                                            ],
+                                            "defaultValue": "aa"
+                                        }
+                                    },
+                                    {
+                                        "field": "160validation",
+                                        "checkbox": {
+                                            "label": "from 1 to 60 validation"
+                                        },
+                                        "text": {
+                                            "validators": [
+                                                {
+                                                    "type": "number",
+                                                    "range": [1, 60]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                ]
                             }
                         }
                     ],


### PR DESCRIPTION
This PR updates UCC UI to the v1.32.0 which includes this [PR](https://github.com/splunk/addonfactory-ucc-base-ui/pull/438).

This allows us to define a new `checkboxGroup` (see PR's description) to be used for the Inputs page.