### PR TITLE
ci: upload built add-on as an artifact

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -81,7 +81,6 @@ jobs:
           # Puts package and schema subdirs along with NOTICE (THIRDPARTY.npm)
           tar -zxf splunk-ucc-ui.tgz -C splunk_add_on_ucc_framework/
           poetry install
-          poetry build
       - name: Ensure all UCC UI files are in the final package
         run: ./.github/workflows/check_ucc_ui_files.sh
       - run: poetry run pytest tests/smoke
@@ -109,7 +108,6 @@ jobs:
           # Puts package and schema subdirs along with NOTICE (THIRDPARTY.npm)
           tar -zxf splunk-ucc-ui.tgz -C splunk_add_on_ucc_framework/
           poetry install
-          poetry build
       - run: ./.github/workflows/check_ucc_ui_files.sh
       - run: poetry run pytest --cov=splunk_add_on_ucc_framework --cov-report=xml tests/unit
 
@@ -125,7 +123,6 @@ jobs:
       - run: |
           ./get-ucc-ui.sh
           tar -zxf splunk-ucc-ui.tgz -C splunk_add_on_ucc_framework/
-          poetry build
       - run: poetry run ucc-gen build --source tests/testdata/test_addons/package_global_config_everything/package
       - run: poetry run ucc-gen package --path output/Splunk_TA_UCCExample
       - uses: actions/upload-artifact@v3
@@ -172,9 +169,6 @@ jobs:
         run: |
           export PATH=$PATH:$CHROMEWEBDRIVER
           chromedriver --version
-      - run: |
-          ./get-ucc-ui.sh
-          tar -zxf splunk-ucc-ui.tgz -C splunk_add_on_ucc_framework/
       - uses: actions/download-artifact@v3
         with:
           name: output
@@ -215,12 +209,15 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.7"
-      - run: pip install splunk-packaging-toolkit
-      - name: Slim tests/expected_output_global_config_everything/Splunk_TA_UCCExample
-        run: mkdir tests/slimmed; slim package tests/testdata/expected_addons/expected_output_global_config_everything/Splunk_TA_UCCExample -o tests/slimmed
-      - uses: splunk/appinspect-cli-action@v1.11
+      - run: curl -sSL https://install.python-poetry.org | python3 - --version 1.5.1
+      - name: Package tests/expected_output_global_config_everything/Splunk_TA_UCCExample
+        run: |
+          poetry install
+          mkdir tests/packaged
+          poetry run ucc-gen package tests/testdata/expected_addons/expected_output_global_config_everything/Splunk_TA_UCCExample -o tests/packaged
+      - uses: splunk/appinspect-cli-action@v1.12
         with:
-          app_path: tests/slimmed
+          app_path: tests/packaged
           included_tags: ${{ matrix.tags }}
           appinspect_manual_checks: tests/testdata/expected_addons/expected_output_global_config_everything/.appinspect.manualcheck.yaml
           appinspect_expected_failures: tests/testdata/expected_addons/expected_output_global_config_everything/.appinspect.expect.yaml

--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -127,10 +127,15 @@ jobs:
           tar -zxf splunk-ucc-ui.tgz -C splunk_add_on_ucc_framework/
           poetry build
       - run: poetry run ucc-gen build --source tests/testdata/test_addons/package_global_config_everything/package
+      - run: poetry run ucc-gen package --path output/Splunk_TA_UCCExample
       - uses: actions/upload-artifact@v3
         with:
           name: output
           path: output/*
+      - uses: actions/upload-artifact@v3
+        with:
+          name: Splunk_TA_UCCExample.tar.gz
+          path: Splunk_TA_UCCExample*.tar.gz
 
   test-ui:
     name: test-ui Splunk ${{ matrix.splunk.version }} -m ${{ matrix.test-mark }}

--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -113,6 +113,25 @@ jobs:
       - run: ./.github/workflows/check_ucc_ui_files.sh
       - run: poetry run pytest --cov=splunk_add_on_ucc_framework --cov-report=xml tests/unit
 
+  build-test-addon:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.7"
+      - run: curl -sSL https://install.python-poetry.org | python3 - --version 1.5.1
+      - run: poetry install
+      - run: |
+          ./get-ucc-ui.sh
+          tar -zxf splunk-ucc-ui.tgz -C splunk_add_on_ucc_framework/
+          poetry build
+      - run: poetry run ucc-gen build --source tests/testdata/test_addons/package_global_config_everything/package
+      - uses: actions/upload-artifact@v3
+        with:
+          name: output
+          path: output/*
+
   test-ui:
     name: test-ui Splunk ${{ matrix.splunk.version }} -m ${{ matrix.test-mark }}
     if: |
@@ -123,6 +142,7 @@ jobs:
     continue-on-error: true
     needs:
       - meta
+      - build-test-addon
       - test-unit
       - test-smoke
     strategy:
@@ -150,18 +170,26 @@ jobs:
       - run: |
           ./get-ucc-ui.sh
           tar -zxf splunk-ucc-ui.tgz -C splunk_add_on_ucc_framework/
-          poetry build
-      - run: poetry run ucc-gen build --source tests/testdata/test_addons/package_global_config_everything/package
+      - uses: actions/download-artifact@v3
+        with:
+          name: output
+          path: output/
       - run: |
           ./run_splunk.sh ${{ matrix.splunk.version }}
           until curl -Lsk "https://localhost:8088/services/collector/health" &>/dev/null ; do echo -n "Waiting for HEC-" && sleep 5 ; done
         timeout-minutes: 5
       - run: poetry run pytest tests/ui -m "${{ matrix.test-mark }}" --headless --junitxml=test-results/junit.xml
       - uses: actions/upload-artifact@v3
-        if: success() || failure()
+        if: always()
         with:
-          name: test-results-ui-${{ matrix.test-mark }}
+          name: test-results-ui-${{ matrix.splunk.version }}-${{ matrix.test-mark }}
           path: test-results/*
+      - uses: dorny/test-reporter@v1
+        if: always()
+        with:
+          name: test-report-ui-${{ matrix.splunk.version }}-${{ matrix.test-mark }}
+          path: "test-results/*.xml"
+          reporter: java-junit
 
   appinspect-for-expected-outputs:
     name: splunk-appinspect ${{ matrix.tags }} tests/testdata/expected_addons/expected_output_global_config_everything/Splunk_TA_UCCExample

--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -81,6 +81,7 @@ jobs:
           # Puts package and schema subdirs along with NOTICE (THIRDPARTY.npm)
           tar -zxf splunk-ucc-ui.tgz -C splunk_add_on_ucc_framework/
           poetry install
+          poetry build
       - name: Ensure all UCC UI files are in the final package
         run: ./.github/workflows/check_ucc_ui_files.sh
       - run: poetry run pytest tests/smoke
@@ -108,6 +109,7 @@ jobs:
           # Puts package and schema subdirs along with NOTICE (THIRDPARTY.npm)
           tar -zxf splunk-ucc-ui.tgz -C splunk_add_on_ucc_framework/
           poetry install
+          poetry build
       - run: ./.github/workflows/check_ucc_ui_files.sh
       - run: poetry run pytest --cov=splunk_add_on_ucc_framework --cov-report=xml tests/unit
 
@@ -127,11 +129,11 @@ jobs:
       - run: poetry run ucc-gen package --path output/Splunk_TA_UCCExample
       - uses: actions/upload-artifact@v3
         with:
-          name: output
+          name: Splunk_TA_UCCExample-raw-output
           path: output/*
       - uses: actions/upload-artifact@v3
         with:
-          name: Splunk_TA_UCCExample.tar.gz
+          name: Splunk_TA_UCCExample-packaged
           path: Splunk_TA_UCCExample*.tar.gz
 
   test-ui:
@@ -171,7 +173,7 @@ jobs:
           chromedriver --version
       - uses: actions/download-artifact@v3
         with:
-          name: output
+          name: Splunk_TA_UCCExample-raw-output
           path: output/
       - run: |
           ./run_splunk.sh ${{ matrix.splunk.version }}
@@ -214,7 +216,7 @@ jobs:
         run: |
           poetry install
           mkdir tests/packaged
-          poetry run ucc-gen package tests/testdata/expected_addons/expected_output_global_config_everything/Splunk_TA_UCCExample -o tests/packaged
+          poetry run ucc-gen package --path tests/testdata/expected_addons/expected_output_global_config_everything/Splunk_TA_UCCExample -o tests/packaged
       - uses: splunk/appinspect-cli-action@v1.12
         with:
           app_path: tests/packaged


### PR DESCRIPTION
This PR has a separate step to build the test add-on for UI tests and now it will be uploaded as an artefact for quick local testing purposes. Also we use `dorny/test-reporter` to have a better view on run tests.