### PR TITLE
ci: fix dorny/test-reporter permissions

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -142,6 +142,10 @@ jobs:
       github.base_ref == 'main' ||
       github.ref_name == 'main' ||
       contains(github.event.pull_request.labels.*.name, 'run-ui-tests')
+    permissions:
+      id-token: write
+      contents: read
+      checks: write
     runs-on: ubuntu-latest
     continue-on-error: true
     needs:


### PR DESCRIPTION
Fixes https://github.com/splunk/addonfactory-ucc-generator/actions/runs/6380223274/job/17314260563?pr=854