### PR TITLE
test(ui): use SPLUNK_DISABLE_POPUPS and remove workarounds

### DIFF
--- a/run_splunk.sh
+++ b/run_splunk.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 docker run \
-  -v "$PWD/output:/opt/splunk/etc/apps/" \
+  -v "$PWD/output/Splunk_TA_UCCExample:/opt/splunk/etc/apps/Splunk_TA_UCCExample" \
   -p 8000:8000 \
   -p 8088:8088 \
   -p 8089:8089 \
@@ -22,6 +22,7 @@ docker run \
   -e "SPLUNK_START_ARGS=--accept-license" \
   -e "SPLUNK_PASSWORD=Chang3d!" \
   -e "SPLUNK_HEC_TOKEN=4a8a737d-5452-426c-a6f7-106dca4e813f" \
+  -e "SPLUNK_DISABLE_POPUPS=true" \
   -d \
   --rm \
   --name splunk splunk/splunk:${1:-latest}

--- a/tests/ui/test_alert_actions_page.py
+++ b/tests/ui/test_alert_actions_page.py
@@ -1,54 +1,7 @@
 import pytest
 from pytest_splunk_addon_ui_smartx.base_test import UccTester
 
-# from pytest_splunk_addon_ui_smartx.components.base_component import Selector
-# from pytest_splunk_addon_ui_smartx.components.controls.button import Button
-
 from tests.ui.pages.alert_action_page import AlertPage
-
-#
-#
-# @pytest.fixture(autouse=True)
-# def setup_alert(ucc_smartx_selenium_helper):
-#     """
-#     Skip the popups in Splunk before executing the tests
-#     """
-#     try:
-#         # Splunk 8.x
-#         if not setup_alert.first_execution:
-#             return
-#         AlertPage(ucc_smartx_selenium_helper, None, open_page=False)
-#         intro_popup = Button(
-#             ucc_smartx_selenium_helper.browser,
-#             Selector(select=".modal-footer .btn-save"),
-#         )
-#         intro_popup.wait_to_be_clickable()
-#         intro_popup.click()
-#         setup_alert.first_execution = False
-#
-#         # Splunk 8.2.x
-#         intro_popup = Button(
-#             ucc_smartx_selenium_helper.browser,
-#             Selector(select='[data-test="label"]'),
-#         )
-#         intro_popup.wait_to_be_clickable()
-#         intro_popup.click()
-#
-#         # Splunk 8.0.x
-#         important_changes_coming = Button(
-#             ucc_smartx_selenium_helper.browser,
-#             Selector(
-#                 select='div[data-test-name="python3-notification-modal"] '
-#                 'button[data-test="button"][data-appearance="secondary"]'
-#             ),
-#         )
-#         important_changes_coming.wait_to_be_clickable()
-#         important_changes_coming.click()
-#     except:  # noqa: E722
-#         pass
-#
-#
-# setup_alert.first_execution = True
 
 
 @pytest.fixture

--- a/tests/ui/test_alert_actions_page.py
+++ b/tests/ui/test_alert_actions_page.py
@@ -1,52 +1,54 @@
 import pytest
 from pytest_splunk_addon_ui_smartx.base_test import UccTester
-from pytest_splunk_addon_ui_smartx.components.base_component import Selector
-from pytest_splunk_addon_ui_smartx.components.controls.button import Button
+
+# from pytest_splunk_addon_ui_smartx.components.base_component import Selector
+# from pytest_splunk_addon_ui_smartx.components.controls.button import Button
 
 from tests.ui.pages.alert_action_page import AlertPage
 
-
-@pytest.fixture(autouse=True)
-def setup_alert(ucc_smartx_selenium_helper):
-    """
-    Skip the popups in Splunk before executing the tests
-    """
-    try:
-        # Splunk 8.x
-        if not setup_alert.first_execution:
-            return
-        AlertPage(ucc_smartx_selenium_helper, None, open_page=False)
-        intro_popup = Button(
-            ucc_smartx_selenium_helper.browser,
-            Selector(select=".modal-footer .btn-save"),
-        )
-        intro_popup.wait_to_be_clickable()
-        intro_popup.click()
-        setup_alert.first_execution = False
-
-        # Splunk 8.2.x
-        intro_popup = Button(
-            ucc_smartx_selenium_helper.browser,
-            Selector(select='[data-test="label"]'),
-        )
-        intro_popup.wait_to_be_clickable()
-        intro_popup.click()
-
-        # Splunk 8.0.x
-        important_changes_coming = Button(
-            ucc_smartx_selenium_helper.browser,
-            Selector(
-                select='div[data-test-name="python3-notification-modal"] '
-                'button[data-test="button"][data-appearance="secondary"]'
-            ),
-        )
-        important_changes_coming.wait_to_be_clickable()
-        important_changes_coming.click()
-    except:  # noqa: E722
-        pass
-
-
-setup_alert.first_execution = True
+#
+#
+# @pytest.fixture(autouse=True)
+# def setup_alert(ucc_smartx_selenium_helper):
+#     """
+#     Skip the popups in Splunk before executing the tests
+#     """
+#     try:
+#         # Splunk 8.x
+#         if not setup_alert.first_execution:
+#             return
+#         AlertPage(ucc_smartx_selenium_helper, None, open_page=False)
+#         intro_popup = Button(
+#             ucc_smartx_selenium_helper.browser,
+#             Selector(select=".modal-footer .btn-save"),
+#         )
+#         intro_popup.wait_to_be_clickable()
+#         intro_popup.click()
+#         setup_alert.first_execution = False
+#
+#         # Splunk 8.2.x
+#         intro_popup = Button(
+#             ucc_smartx_selenium_helper.browser,
+#             Selector(select='[data-test="label"]'),
+#         )
+#         intro_popup.wait_to_be_clickable()
+#         intro_popup.click()
+#
+#         # Splunk 8.0.x
+#         important_changes_coming = Button(
+#             ucc_smartx_selenium_helper.browser,
+#             Selector(
+#                 select='div[data-test-name="python3-notification-modal"] '
+#                 'button[data-test="button"][data-appearance="secondary"]'
+#             ),
+#         )
+#         important_changes_coming.wait_to_be_clickable()
+#         important_changes_coming.click()
+#     except:  # noqa: E722
+#         pass
+#
+#
+# setup_alert.first_execution = True
 
 
 @pytest.fixture


### PR DESCRIPTION
Using `SPLUNK_DISABLE_POPUPS` env variable to control popups, setting it to `true` so we don't need to have workaround code to bypass those.

Check out docs here: https://github.com/splunk/splunk-ansible/blob/186c95b84d82f9201e036388c716d466d083ae37/docs/ADVANCED.md?plain=1#L101