### PR TITLE
fix(code): added type conversion for autoCompleteFields

### DIFF
--- a/splunk_add_on_ucc_framework/global_config_validator.py
+++ b/splunk_add_on_ucc_framework/global_config_validator.py
@@ -239,7 +239,7 @@ class GlobalConfigValidator:
         labels, values = [], []
         for child in children:
             labels.append(child["label"].lower())
-            values.append(child["value"].lower())
+            values.append(str(child["value"]).lower())
         if self._find_duplicates_in_list(values) or self._find_duplicates_in_list(
             labels
         ):
@@ -262,7 +262,7 @@ class GlobalConfigValidator:
             if children:
                 self._validate_children_duplicates(children, entity_label)
             else:
-                values.append(field.get("value").lower())
+                values.append(str(field.get("value")).lower())
         if self._find_duplicates_in_list(values) or self._find_duplicates_in_list(
             labels
         ):


### PR DESCRIPTION
Fixes GitHub issue #794 

According to the schema, in the `autoCompleteFields` option, `value` should support number/string/boolean. However, it is not working as expected.

Error `AttributeError: 'int' object has no attribute 'lower'` is raised due to the `lower()` method being used for the `value` field.

When the field `value` has type `str`, it would work perfectly fine.
As for types `number` and `boolean`, it would raise this error, due to number and boolean not having `lower()` method.

This can be resolved by adding type conversion to `str` before validation. After adding type conversion, `ucc-gen` works properly without any error.