### PR TITLE
ci: fix release

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -218,6 +218,7 @@ jobs:
     if: |
       github.base_ref == 'main' ||
       github.ref_name == 'main' ||
+      github.ref_name == 'develop' ||
       contains(github.event.pull_request.labels.*.name, 'run-ui-tests')
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -347,7 +347,7 @@ jobs:
           gpg_private_key: ${{ secrets.SA_GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.SA_GPG_PASSPHRASE }}
           extra_plugins: |
-            @google/semantic-release-replace-plugin
+            semantic-release-replace-plugin
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN_ADMIN }}
       - if: ${{ steps.semantic.outputs.new_release_published == 'true' }}

--- a/.releaserc
+++ b/.releaserc
@@ -24,7 +24,7 @@
     [
       "@semantic-release/commit-analyzer",
       [
-        "@google/semantic-release-replace-plugin",
+        "semantic-release-replace-plugin",
         {
           "replacements": [
             {
@@ -79,6 +79,12 @@
           "message": "chore(release): ${nextRelease.version}\n\n${nextRelease.notes}",
         },
       ],
-      ["@semantic-release/github", { "assets": ["NOTICE", "pyproject.toml"] }],
+      [
+        "@semantic-release/github",
+        {
+          "assets": ["NOTICE", "pyproject.toml"],
+          "successComment": false
+        }
+      ],
     ],
 }

--- a/docs/entity/validators.md
+++ b/docs/entity/validators.md
@@ -1,7 +1,7 @@
 ### Common Properties
 
 - `type`<span class="required-asterisk">*</span> - To specify which validator type to use.
-- `errorMsg`<span class="required-asterisk">*</span> - UCC provides [default error messages](https://github.com/splunk/addonfactory-ucc-base-ui/blob/main/src/main/webapp/constants/messageDict.js). Using this attribute, A custom error message can be displayed.
+- `errorMsg`<span class="required-asterisk">*</span> - UCC provides [default error messages](https://github.com/splunk/addonfactory-ucc-generator/blob/main/ui/src/main/webapp/constants/messageDict.ts). Using this attribute, A custom error message can be displayed.
 
 ### String
 
@@ -57,7 +57,7 @@ Example usage below:
 
 No parameters are needed.
 
-It's using a regexp internally this [regex](https://github.com/splunk/addonfactory-ucc-base-ui/blob/main/src/main/webapp/constants/preDefinedRegex.js) for checking whether a field value is a URL or not.
+It's using a regexp internally this [regex](https://github.com/splunk/addonfactory-ucc-generator/blob/main/ui/src/main/webapp/constants/preDefinedRegex.ts) for checking whether a field value is a URL or not.
 
 ### Email
 
@@ -69,11 +69,11 @@ It's using a regexp internally suggested by [WHATWG](https://html.spec.whatwg.or
 
 No parameters are needed.
 
-Internally, it checks the IPV4 address using this [regex](https://github.com/splunk/addonfactory-ucc-base-ui/blob/main/src/main/webapp/constants/preDefinedRegex.js).
+Internally, it checks the IPV4 address using this [regex](https://github.com/splunk/addonfactory-ucc-generator/blob/main/ui/src/main/webapp/constants/preDefinedRegex.ts).
 
 ### Date 
 
 No parameters are needed.
 
-It is validated whether or not the field's value is a date in [ISO 8601](https://www.w3.org/TR/1998/NOTE-datetime-19980827) format.
+It is validated whether the field's value is a date in [ISO 8601](https://www.w3.org/TR/1998/NOTE-datetime-19980827) format.
 It is using the regex from [moment.js](https://github.com/moment/moment/blob/2.17.1/moment.js#L1980).

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,8 +17,7 @@ as well.
 UCC stands for Universal Configuration Console. The purpose of having a
 framework for add-on generation is to simplify the process of add-on
 creation for the developers. UCC 5 uses [SplunkUI](https://splunkui.splunk.com/) 
-which is a new UI framework based on React. UCC UI repository can be found
-[here](https://github.com/splunk/addonfactory-ucc-base-ui).
+which is a new UI framework based on React. UCC UI repository can be found in the `ui` folder.
 
 UCC-based add-ons are being powered by another Splunk libraries:
 [`solnlib`](https://github.com/splunk/addonfactory-solutions-library-python) and

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -16,8 +16,7 @@ To be able to create an add-on using UCC framework, you need to have at least:
 
 > If both globalConfig.json and globalConfig.yaml files are present, then the globalConfig.json file will take precedence.
 
-The JSON schema for the `globalConfig` file can be found
-[here](https://github.com/splunk/addonfactory-ucc-base-ui/blob/main/src/main/webapp/schema/schema.json).
+The JSON schema for the `globalConfig` file can be found in `splunk_add_on_ucc_framework/schema/schema.json` file.
 
 ### Add-on naming convention
 

--- a/splunk_add_on_ucc_framework/global_config_validator.py
+++ b/splunk_add_on_ucc_framework/global_config_validator.py
@@ -33,8 +33,6 @@ class GlobalConfigValidatorException(Exception):
 class GlobalConfigValidator:
     """
     GlobalConfigValidator implements different validation for globalConfig file.
-    Simple validation should go to JSON schema in
-    https://github.com/splunk/addonfactory-ucc-base-ui repository.
     Custom validation should be implemented here.
     """
 


### PR DESCRIPTION
We merged 300+ commits as part of the migration of UCC UI into this repository and as a side effect we made a release because of the commit messages used in those 300+ commits. The entire release was not successful as we hit the GitHub's quota and we were not able to add a comment to each PR.

This PR sets `successComment` to false for "@semantic-release/github" which does not add a comment to every PR involved in the release (300+).

This PR also cleans up references to the UCC UI repository.