### PR TITLE
chore: add linter for UI on pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,3 +41,21 @@ repos:
     hooks:
     -   id: flake8
         exclude: (^splunk_add_on_ucc_framework/commands/init_template/|^splunk_add_on_ucc_framework/commands/imports.py)
+-   repo: local
+    hooks:
+    -   id: ui-prettify
+        name: UI code prettifier
+        entry: bash -c 'cd ui && exec node code-checks.js prettify --write "$@"'
+        language: system
+        files: ^ui/.*\.(js|ts|jsx|tsx|css)$
+    -   id: ui-linting
+        name: UI linting
+        entry: bash -c 'cd ui && exec node code-checks.js eslint --fix "$@"'
+        language: system
+        files: ^ui/.*\.(js|ts|jsx|tsx)$
+    -   id: ui-typecheck
+        name: UI typecheck
+        entry: bash -c 'cd ui && exec yarn tsc --noEmit'
+        language: system
+        pass_filenames: false
+        files: ^ui/.*\.(js|ts|jsx|tsx)$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,7 +55,7 @@ repos:
         files: ^ui/.*\.(js|ts|jsx|tsx)$
     -   id: ui-typecheck
         name: UI typecheck
-        entry: bash -c 'cd ui && exec yarn tsc --noEmit'
+        entry: bash -c 'cd ui && exec yarn run --binaries-only tsc --noEmit'
         language: system
         pass_filenames: false
         files: ^ui/.*\.(js|ts|jsx|tsx)$

--- a/ui/code-checks.js
+++ b/ui/code-checks.js
@@ -9,7 +9,7 @@ const files = process.argv
 const command = process.argv[2];
 
 // Construct the command
-const commandWithFiles = `yarn ${command} ${files}`;
+const commandWithFiles = `yarn run --binaries-only ${command} ${files}`;
 
 // Execute the command
 exec(commandWithFiles, (error, stdout, stderr) => {

--- a/ui/code-checks.js
+++ b/ui/code-checks.js
@@ -1,0 +1,25 @@
+const { exec } = require('child_process');
+
+// Get list of files from the command line arguments
+const files = process.argv
+    .slice(3)
+    .map((file) => file.replace(/^ui\//, '')) // Remove the 'ui/' prefix from each file path
+    .join(' ');
+
+const command = process.argv[2];
+
+// Construct the command
+const commandWithFiles = `yarn ${command} ${files}`;
+
+// Execute the command
+exec(commandWithFiles, (error, stdout, stderr) => {
+    if (error) {
+        console.error(`Error: ${error.message}`);
+        return 1;
+    }
+
+    if (stderr) {
+        console.error(`Stderr: ${stderr}`);
+        return 1;
+    }
+});


### PR DESCRIPTION
We can't use `language: node` because it looks for package.json in the root folder.

The custom nodejs script is required to cut `ui` prefix. The problem is discussed here: https://github.com/pre-commit/pre-commit/issues/1417 