### PR TITLE
ci: use concurrency to cancel previous jobs [ci skip]

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -11,6 +11,10 @@ on:
   pull_request:
     branches: [main, develop, "release/**"]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   meta:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This way we will save some GitHub resources by not running a lot of jobs in the same time for the same PR.