### PR TITLE
ci: rollback versions to trigger the release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@
 
 [tool.poetry]
 name = "splunk_add_on_ucc_framework"
-version = "5.31.1-beta.1"
+version = "5.31.0"
 description = "Splunk Add-on SDK formerly UCC is a build and code generation framework"
 license = "Apache-2.0"
 authors = ["Splunk <addonfactory@splunk.com>"]

--- a/splunk_add_on_ucc_framework/__init__.py
+++ b/splunk_add_on_ucc_framework/__init__.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "5.31.1-beta.1"
+__version__ = "5.31.0"
 
 import logging
 


### PR DESCRIPTION
Last time release did not go because of the `semantic-release-replace-plugin` could not match the versions to update (because we released a beta version).