### PR TITLE
feat: onboard Python 3.12

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -150,6 +150,7 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
+          - "3.12"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4
@@ -174,6 +175,7 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
+          - "3.12"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v4

--- a/.releaserc
+++ b/.releaserc
@@ -18,7 +18,6 @@
     [
       "+([0-9])?(.{+([0-9]),x}).x",
       "main",
-      { name: "develop", prerelease: "beta", channel: "beta" },
     ],
   plugins:
     [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,9 +24,17 @@ include = ["NOTICE"]
 readme = "README.md"
 repository = "https://github.com/splunk/addonfactory-ucc-generator"
 homepage = "https://github.com/splunk/addonfactory-ucc-generator"
-keywords = ["splunk"]
+keywords = ["splunk", "ucc"]
 classifiers = [
-    "Programming Language :: Python",
+    "Programming Language :: Python", 
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "Topic :: Software Development :: Libraries :: Python Modules",


### PR DESCRIPTION
This PR adds tests for Python 3.12 which was released recently, we are not ready to make any code changes because we need to support Python 3.7.