### PR TITLE
fix(dashboard): adds splunk_server=local when getting add-on version

### DIFF
--- a/splunk_add_on_ucc_framework/dashboard.py
+++ b/splunk_add_on_ucc_framework/dashboard.py
@@ -54,7 +54,7 @@ PANEL_ADDON_VERSION_TEMPLATE = """  <row>
       <title>Add-on version</title>
       <single>
         <search>
-          <query>| rest services/apps/local/{addon_name} | fields version</query>
+          <query>| rest services/apps/local/{addon_name} splunk_server=local | fields version</query>
           <earliest>-15m</earliest>
           <latest>now</latest>
         </search>

--- a/tests/testdata/expected_addons/expected_output_global_config_everything/Splunk_TA_UCCExample/default/data/ui/views/dashboard.xml
+++ b/tests/testdata/expected_addons/expected_output_global_config_everything/Splunk_TA_UCCExample/default/data/ui/views/dashboard.xml
@@ -14,7 +14,7 @@
       <title>Add-on version</title>
       <single>
         <search>
-          <query>| rest services/apps/local/Splunk_TA_UCCExample | fields version</query>
+          <query>| rest services/apps/local/Splunk_TA_UCCExample splunk_server=local | fields version</query>
           <earliest>-15m</earliest>
           <latest>now</latest>
         </search>

--- a/tests/testdata/test_addons/package_global_config_everything/globalConfig.json
+++ b/tests/testdata/test_addons/package_global_config_everything/globalConfig.json
@@ -1291,7 +1291,7 @@
     "meta": {
         "name": "Splunk_TA_UCCExample",
         "restRoot": "splunk_ta_uccexample",
-        "version": "5.31.1Rcbdd058b",
+        "version": "5.31.1Rd908ea55",
         "displayName": "Splunk UCC test Add-on",
         "schemaVersion": "0.0.3"
     }

--- a/tests/unit/test_dashboard.py
+++ b/tests/unit/test_dashboard.py
@@ -28,7 +28,7 @@ def test_generate_dashboard_when_dashboard_does_not_exist(
       <title>Add-on version</title>
       <single>
         <search>
-          <query>| rest services/apps/local/Splunk_TA_UCCExample | fields version</query>
+          <query>| rest services/apps/local/Splunk_TA_UCCExample splunk_server=local | fields version</query>
           <earliest>-15m</earliest>
           <latest>now</latest>
         </search>


### PR DESCRIPTION
Related docs: https://docs.splunk.com/Documentation/Splunk/latest/SearchReference/Rest

Related PR: https://github.com/splunk/splunk-add-on-for-microsoft-365-defender/pull/314