### PR TITLE
Fix: Add ":gz" flag to tarfile.open to add compression

### DIFF
--- a/splunk_add_on_ucc_framework/commands/package.py
+++ b/splunk_add_on_ucc_framework/commands/package.py
@@ -57,7 +57,7 @@ def package(path_to_built_addon: str, output_directory: Optional[str] = None) ->
     archive_path = os.path.join(
         output_directory, f"{addon_name}-{addon_version}.tar.gz"
     )
-    with tarfile.open(archive_path, mode="w", encoding="utf-8") as archive_file:
+    with tarfile.open(archive_path, mode="w:gz", encoding="utf-8") as archive_file:
         logger.info(path_to_built_addon)
         archive_file.add(path_to_built_addon, arcname=addon_name)
     logger.info(f"Package exported to {archive_path}")


### PR DESCRIPTION
Fixes #900 - Adding ":gz" flag to [tarfile.open](https://docs.python.org/3/library/tarfile.html#tarfile.open) adds gzip compression on write.