### PR TITLE
fix(warning): added warning logger to display warnings

### DIFF
--- a/splunk_add_on_ucc_framework/__init__.py
+++ b/splunk_add_on_ucc_framework/__init__.py
@@ -24,3 +24,10 @@ stream_handler = logging.StreamHandler()
 stream_handler.setLevel(logging.INFO)
 stream_handler.setFormatter(formatter)
 logger.addHandler(stream_handler)
+
+import warnings
+warnings.filterwarnings("always", category=DeprecationWarning)
+
+logging.captureWarnings(True)
+warnings_logger = logging.getLogger("py.warnings")
+warnings_logger.addHandler(stream_handler)


### PR DESCRIPTION
Fixes GitHub Issue - #902 

Added warning logger in `__init__.py` file to display warnings to the console.

**Alternative Solution**:
Another approach for resolving the same issue is instead of using `warnings.warn`, use `logger` object. Below is the snippet for the alternative.
![warning_using_logger](https://github.com/splunk/addonfactory-ucc-generator/assets/77769935/aecb157e-889c-4d83-adb0-2eaec544240c)

I recommend using a warning logger and warnings module over the use of a simple logger. Please let me know if you think otherwise.
