### PR TITLE
feat(CheckboxGroup): ADDON-61556 add defaultValue for checkbox

### DIFF
--- a/docs/entity/components.md
+++ b/docs/entity/components.md
@@ -272,16 +272,17 @@ Example usage below:
       {
         "field": "rowUnderGroup1",
         "checkbox": {
-          "label": "Row under Group 1"
+          "label": "Row under Group 1",
+          "defaultValue": true
         },
-        "text": {
+        "input": {
           "defaultValue": 1200,
           "required": false
         }
       },
       {
         "field": "rowWithoutGroup",
-        "text": {
+        "input": {
           "defaultValue": 1,
           "required": true
         }
@@ -293,14 +294,14 @@ Example usage below:
             "enable": false
           }
         },
-        "text": {
+        "input": {
           "defaultValue": 1,
           "required": true
         }
       },
       {
         "field": "rowWithoutGroup_2",
-        "text": {
+        "input": {
           "defaultValue": 3600,
           "required": true
         }
@@ -310,7 +311,7 @@ Example usage below:
         "checkbox": {
           "label": "Required field"
         },
-        "text": {
+        "input": {
           "required": true
         }
       },
@@ -319,7 +320,7 @@ Example usage below:
         "checkbox": {
           "label": "from 1 to 60 validation"
         },
-        "text": {
+        "input": {
           "validators": [
             {
               "type": "number",

--- a/splunk_add_on_ucc_framework/schema/schema.json
+++ b/splunk_add_on_ucc_framework/schema/schema.json
@@ -858,7 +858,7 @@
                     },
                     "additionalProperties": false
                   },
-                  "text": {
+                  "input": {
                     "type": "object",
                     "properties": {
                       "defaultValue": {

--- a/splunk_add_on_ucc_framework/schema/schema.json
+++ b/splunk_add_on_ucc_framework/schema/schema.json
@@ -854,16 +854,6 @@
                       "label": {
                         "type": "string",
                         "maxLength": 30
-                      },
-                      "options": {
-                        "type": "object",
-                        "properties": {
-                          "enable": {
-                            "type": "boolean",
-                            "default": false
-                          }
-                        },
-                        "additionalProperties": false
                       }
                     },
                     "additionalProperties": false
@@ -872,14 +862,7 @@
                     "type": "object",
                     "properties": {
                       "defaultValue": {
-                        "oneOf": [
-                          {
-                            "type": "string"
-                          },
-                          {
-                            "type": "number"
-                          }
-                        ]
+                        "type": "number"
                       },
                       "required": {
                         "type": "boolean",
@@ -890,13 +873,7 @@
                         "items": {
                           "anyOf": [
                             {
-                              "$ref": "#/definitions/StringValidator"
-                            },
-                            {
                               "$ref": "#/definitions/NumberValidator"
-                            },
-                            {
-                              "$ref": "#/definitions/RegexValidator"
                             }
                           ]
                         }

--- a/splunk_add_on_ucc_framework/schema/schema.json
+++ b/splunk_add_on_ucc_framework/schema/schema.json
@@ -854,6 +854,9 @@
                       "label": {
                         "type": "string",
                         "maxLength": 30
+                      },
+                      "defaultValue": {
+                        "type": "boolean"
                       }
                     },
                     "additionalProperties": false

--- a/tests/testdata/test_addons/package_global_config_everything/globalConfig.json
+++ b/tests/testdata/test_addons/package_global_config_everything/globalConfig.json
@@ -1288,7 +1288,7 @@
     "meta": {
         "name": "Splunk_TA_UCCExample",
         "restRoot": "splunk_ta_uccexample",
-        "version": "5.31.1R2a2605a9",
+        "version": "5.31.1Rd908ea55",
         "displayName": "Splunk UCC test Add-on",
         "schemaVersion": "0.0.3"
     }

--- a/tests/testdata/test_addons/package_global_config_everything/globalConfig.json
+++ b/tests/testdata/test_addons/package_global_config_everything/globalConfig.json
@@ -1288,7 +1288,7 @@
     "meta": {
         "name": "Splunk_TA_UCCExample",
         "restRoot": "splunk_ta_uccexample",
-        "version": "5.31.1Rd908ea55",
+        "version": "5.31.1R2a2605a9",
         "displayName": "Splunk UCC test Add-on",
         "schemaVersion": "0.0.3"
     }

--- a/tests/testdata/test_addons/package_global_config_everything/globalConfig.json
+++ b/tests/testdata/test_addons/package_global_config_everything/globalConfig.json
@@ -887,105 +887,108 @@
                                 "rows": [
                                     {
                                         "field": "ec2_volumes",
-                                        "text": {
+                                        "checkbox": {
+                                            "defaultValue": true
+                                        },
+                                        "input": {
                                             "defaultValue": 3600,
                                             "required": true
                                         }
                                     },
                                     {
                                         "field": "ec2_instances",
-                                        "text": {
+                                        "input": {
                                             "defaultValue": 3600,
                                             "required": true
                                         }
                                     },
                                     {
                                         "field": "ec2_reserved_instances",
-                                        "text": {
+                                        "input": {
                                             "defaultValue": 3600,
                                             "required": true
                                         }
                                     },
                                     {
                                         "field": "ebs_snapshots",
-                                        "text": {
+                                        "input": {
                                             "defaultValue": 3600,
                                             "required": true
                                         }
                                     },
                                     {
                                         "field": "rds_instances",
-                                        "text": {
+                                        "input": {
                                             "defaultValue": 3600,
                                             "required": true
                                         }
                                     },
                                     {
                                         "field": "rds_reserved_instances",
-                                        "text": {
+                                        "input": {
                                             "defaultValue": 3600,
                                             "required": true
                                         }
                                     },
                                     {
                                         "field": "ec2_key_pairs",
-                                        "text": {
+                                        "input": {
                                             "defaultValue": 3600,
                                             "required": true
                                         }
                                     },
                                     {
                                         "field": "ec2_security_groups",
-                                        "text": {
+                                        "input": {
                                             "defaultValue": 3600,
                                             "required": true
                                         }
                                     },
                                     {
                                         "field": "ec2_images",
-                                        "text": {
+                                        "input": {
                                             "defaultValue": 3600,
                                             "required": true
                                         }
                                     },
                                     {
                                         "field": "ec2_addresses",
-                                        "text": {
+                                        "input": {
                                             "defaultValue": 3600,
                                             "required": true
                                         }
                                     },
                                     {
                                         "field": "classic_load_balancers",
-                                        "text": {
+                                        "input": {
                                             "defaultValue": 3600,
                                             "required": true
                                         }
                                     },
                                     {
                                         "field": "application_load_balancers",
-                                        "text": {
+                                        "input": {
                                             "defaultValue": 3600,
                                             "required": true
                                         }
                                     },
                                     {
                                         "field": "vpcs",
-                                        "text": {
+                                        "input": {
                                             "defaultValue": 3600,
                                             "required": true
                                         }
                                     },
                                     {
                                         "field": "vpc_network_acls",
-                                        "text": {
+                                        "input": {
                                             "defaultValue": 3600,
                                             "required": true
                                         }
                                     },
                                     {
                                         "field": "vpc_subnets",
-                                        "text": {
+                                        "input": {
                                             "defaultValue": 3600,
                                             "required": true
                                         }
@@ -1288,7 +1291,7 @@
     "meta": {
         "name": "Splunk_TA_UCCExample",
         "restRoot": "splunk_ta_uccexample",
-        "version": "5.31.1Rd908ea55",
+        "version": "5.31.1Rdd3a1ca0",
         "displayName": "Splunk UCC test Add-on",
         "schemaVersion": "0.0.3"
     }

--- a/tests/unit/testdata/invalid_config_checkbox_groups_duplicate_field_in_options_groups.json
+++ b/tests/unit/testdata/invalid_config_checkbox_groups_duplicate_field_in_options_groups.json
@@ -100,10 +100,7 @@
                                     {
                                         "field": "collectTasksAndComments",
                                         "checkbox": {
-                                            "label": "This is a very very long line",
-                                            "options": {
-                                                "enable": true
-                                            }
+                                            "label": "This is a very very long line"
                                         },
                                         "text": {
                                             "defaultValue": 1,
@@ -113,10 +110,7 @@
                                     {
                                         "field": "collectFolderMetadata",
                                         "checkbox": {
-                                            "label": "Collect folder metadata",
-                                            "options": {
-                                                "enable": true
-                                            }
+                                            "label": "Collect folder metadata"
                                         },
                                         "text": {
                                             "defaultValue": 3600,

--- a/tests/unit/testdata/invalid_config_checkbox_groups_duplicate_field_in_options_groups.json
+++ b/tests/unit/testdata/invalid_config_checkbox_groups_duplicate_field_in_options_groups.json
@@ -76,7 +76,7 @@
                                 "rows": [
                                     {
                                         "field": "collectFolderCollaboration",
-                                        "text": {
+                                        "input":{
                                             "defaultValue": 1200,
                                             "required": false,
                                             "validators": [
@@ -92,7 +92,7 @@
                                         "checkbox": {
                                             "label": "Collect file metadata"
                                         },
-                                        "text": {
+                                        "input":{
                                             "defaultValue": 1,
                                             "required": true
                                         }
@@ -102,7 +102,7 @@
                                         "checkbox": {
                                             "label": "This is a very very long line"
                                         },
-                                        "text": {
+                                        "input":{
                                             "defaultValue": 1,
                                             "required": true
                                         }
@@ -112,7 +112,7 @@
                                         "checkbox": {
                                             "label": "Collect folder metadata"
                                         },
-                                        "text": {
+                                        "input":{
                                             "defaultValue": 3600,
                                             "required": true
                                         }

--- a/tests/unit/testdata/invalid_config_checkbox_groups_duplicate_fields_in_options_rows.json
+++ b/tests/unit/testdata/invalid_config_checkbox_groups_duplicate_fields_in_options_rows.json
@@ -56,7 +56,7 @@
                                 "rows": [
                                     {
                                         "field": "collectFolderCollaboration",
-                                        "text": {
+                                        "input":{
                                             "defaultValue": 1200,
                                             "required": false,
                                             "validators": [
@@ -72,7 +72,7 @@
                                         "checkbox": {
                                             "label": "Collect file metadata"
                                         },
-                                        "text": {
+                                        "input":{
                                             "defaultValue": 1,
                                             "required": true
                                         }
@@ -82,7 +82,7 @@
                                         "checkbox": {
                                             "label": "This is a very very long line"
                                         },
-                                        "text": {
+                                        "input":{
                                             "defaultValue": 1,
                                             "required": true
                                         }
@@ -92,7 +92,7 @@
                                         "checkbox": {
                                             "label": "Collect folder metadata"
                                         },
-                                        "text": {
+                                        "input":{
                                             "defaultValue": 3600,
                                             "required": true
                                         }

--- a/tests/unit/testdata/invalid_config_checkbox_groups_duplicate_fields_in_options_rows.json
+++ b/tests/unit/testdata/invalid_config_checkbox_groups_duplicate_fields_in_options_rows.json
@@ -80,10 +80,7 @@
                                     {
                                         "field": "collectTasksAndComments",
                                         "checkbox": {
-                                            "label": "This is a very very long line",
-                                            "options": {
-                                                "enable": true
-                                            }
+                                            "label": "This is a very very long line"
                                         },
                                         "text": {
                                             "defaultValue": 1,
@@ -93,10 +90,7 @@
                                     {
                                         "field": "collectFolderCollaboration",
                                         "checkbox": {
-                                            "label": "Collect folder metadata",
-                                            "options": {
-                                                "enable": true
-                                            }
+                                            "label": "Collect folder metadata"
                                         },
                                         "text": {
                                             "defaultValue": 3600,

--- a/tests/unit/testdata/invalid_config_checkbox_groups_undefined_field_used_in_groups.json
+++ b/tests/unit/testdata/invalid_config_checkbox_groups_undefined_field_used_in_groups.json
@@ -76,7 +76,7 @@
                                 "rows": [
                                     {
                                         "field": "collectFolderCollaboration",
-                                        "text": {
+                                        "input": {
                                             "defaultValue": 1200,
                                             "required": false,
                                             "validators": [
@@ -92,7 +92,7 @@
                                         "checkbox": {
                                             "label": "Collect file metadata"
                                         },
-                                        "text": {
+                                        "input": {
                                             "defaultValue": 1,
                                             "required": true
                                         }
@@ -100,12 +100,9 @@
                                     {
                                         "field": "collectTasksAndComments",
                                         "checkbox": {
-                                            "label": "This is a very very long line",
-                                            "options": {
-                                                "enable": true
-                                            }
+                                            "label": "This is a very very long line"
                                         },
-                                        "text": {
+                                        "input": {
                                             "defaultValue": 1,
                                             "required": true
                                         }
@@ -113,12 +110,9 @@
                                     {
                                         "field": "collectFolderMetadata",
                                         "checkbox": {
-                                            "label": "Collect folder metadata",
-                                            "options": {
-                                                "enable": true
-                                            }
+                                            "label": "Collect folder metadata"
                                         },
-                                        "text": {
+                                        "input": {
                                             "defaultValue": 3600,
                                             "required": true
                                         }

--- a/tests/unit/testdata/valid_config.json
+++ b/tests/unit/testdata/valid_config.json
@@ -947,7 +947,8 @@
                                     {
                                         "field": "collectFolderMetadata",
                                         "checkbox": {
-                                            "label": "Collect folder metadata"
+                                            "label": "Collect folder metadata",
+                                            "defaultValue": true
                                         },
                                         "input": {
                                             "defaultValue": 3600,
@@ -1074,14 +1075,7 @@
                                             "label": "No more 2 characters"
                                         },
                                         "input": {
-                                            "validators": [
-                                                {
-                                                    "type": "string",
-                                                    "minLength": 0,
-                                                    "maxLength": 2
-                                                }
-                                            ],
-                                            "defaultValue": "aa"
+                                            "defaultValue": 123
                                         }
                                     },
                                     {

--- a/tests/unit/testdata/valid_config.json
+++ b/tests/unit/testdata/valid_config.json
@@ -894,7 +894,7 @@
                                 "rows": [
                                     {
                                         "field": "collectFolderCollaboration",
-                                        "text": {
+                                        "input": {
                                             "defaultValue": 1200,
                                             "required": false,
                                             "validators": [
@@ -910,7 +910,7 @@
                                         "checkbox": {
                                             "label": "Collect file metadata"
                                         },
-                                        "text": {
+                                        "input": {
                                             "defaultValue": 1,
                                             "required": true
                                         }
@@ -918,12 +918,9 @@
                                     {
                                         "field": "collectTasksAndComments",
                                         "checkbox": {
-                                            "label": "This is a very very long line",
-                                            "options": {
-                                                "enable": true
-                                            }
+                                            "label": "This is a very very long line"
                                         },
-                                        "text": {
+                                        "input": {
                                             "defaultValue": 1,
                                             "required": true
                                         }
@@ -931,12 +928,9 @@
                                     {
                                         "field": "collectFolderMetadata",
                                         "checkbox": {
-                                            "label": "Collect folder metadata",
-                                            "options": {
-                                                "enable": true
-                                            }
+                                            "label": "Collect folder metadata"
                                         },
-                                        "text": {
+                                        "input": {
                                             "defaultValue": 3600,
                                             "required": true
                                         }
@@ -953,12 +947,9 @@
                                     {
                                         "field": "collectFolderMetadata",
                                         "checkbox": {
-                                            "label": "Collect folder metadata",
-                                            "options": {
-                                                "enable": true
-                                            }
+                                            "label": "Collect folder metadata"
                                         },
-                                        "text": {
+                                        "input": {
                                             "defaultValue": 3600,
                                             "required": true
                                         }
@@ -968,7 +959,7 @@
                                         "checkbox": {
                                             "label": "Collect folder collaboration"
                                         },
-                                        "text": {
+                                        "input": {
                                             "defaultValue": 1200,
                                             "required": false,
                                             "validators": [
@@ -984,7 +975,7 @@
                                         "checkbox": {
                                             "label": "Collect file metadata"
                                         },
-                                        "text": {
+                                        "input": {
                                             "defaultValue": 1,
                                             "required": true
                                         }
@@ -994,7 +985,7 @@
                                         "checkbox": {
                                             "label": "Collect tasks and comments"
                                         },
-                                        "text": {
+                                        "input": {
                                             "defaultValue": 1,
                                             "required": true
                                         }
@@ -1030,11 +1021,9 @@
                                         "field": "collectFolderCollaboration",
                                         "checkbox": {
                                             "label": "Collect folder collaboration",
-                                            "options": {
-                                                "enable": true
-                                            }
+                                            "defaultValue": true
                                         },
-                                        "text": {
+                                        "input": {
                                             "defaultValue": 1200,
                                             "required": false
                                         }
@@ -1043,11 +1032,9 @@
                                         "field": "collectFileMetadata",
                                         "checkbox": {
                                             "label": "Collect file metadata",
-                                            "options": {
-                                                "enable": true
-                                            }
+                                            "defaultValue": false
                                         },
-                                        "text": {
+                                        "input": {
                                             "defaultValue": 1,
                                             "required": true
                                         }
@@ -1055,12 +1042,9 @@
                                     {
                                         "field": "collectTasksAndComments",
                                         "checkbox": {
-                                            "label": "Collect tasks and comments",
-                                            "options": {
-                                                "enable": true
-                                            }
+                                            "label": "Collect tasks and comments"
                                         },
-                                        "text": {
+                                        "input": {
                                             "defaultValue": 1,
                                             "required": true
                                         }
@@ -1068,12 +1052,9 @@
                                     {
                                         "field": "collectFolderMetadata",
                                         "checkbox": {
-                                            "label": "Collect folder metadata",
-                                            "options": {
-                                                "enable": true
-                                            }
+                                            "label": "Collect folder metadata"
                                         },
-                                        "text": {
+                                        "input": {
                                             "defaultValue": 3600,
                                             "required": true
                                         }
@@ -1081,24 +1062,18 @@
                                     {
                                         "field": "field223",
                                         "checkbox": {
-                                            "label": "Required field",
-                                            "options": {
-                                                "enable": true
-                                            }
+                                            "label": "Required field"
                                         },
-                                        "text": {
+                                        "input": {
                                             "required": true
                                         }
                                     },
                                     {
                                         "field": "field23",
                                         "checkbox": {
-                                            "label": "No more 2 characters",
-                                            "options": {
-                                                "enable": true
-                                            }
+                                            "label": "No more 2 characters"
                                         },
-                                        "text": {
+                                        "input": {
                                             "validators": [
                                                 {
                                                     "type": "string",
@@ -1114,7 +1089,7 @@
                                         "checkbox": {
                                             "label": "from 1 to 60 validation"
                                         },
-                                        "text": {
+                                        "input": {
                                             "validators": [
                                                 {
                                                     "type": "number",

--- a/ui/src/main/webapp/components/CheckboxGroup/CheckboxGroup.stories.tsx
+++ b/ui/src/main/webapp/components/CheckboxGroup/CheckboxGroup.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import BaseFormView from '../BaseFormView';
 import CheckboxGroup from './CheckboxGroup';
+import { MODE_CREATE, MODE_EDIT } from '../../constants/modes';
 
 const meta = {
     component: CheckboxGroup,
@@ -12,6 +13,7 @@ type Story = StoryObj<typeof meta>;
 
 export const Base: Story = {
     args: {
+        mode: MODE_EDIT,
         field: 'api',
         value: 'collect_collaboration/1200,collect_file/1,collect_task/1',
         controlOptions: {
@@ -20,11 +22,8 @@ export const Base: Story = {
                     field: 'collect_collaboration',
                     checkbox: {
                         label: 'Collect folder collaboration',
-                        options: {
-                            enable: true,
-                        },
                     },
-                    text: {
+                    input: {
                         defaultValue: 1200,
                         required: false,
                     },
@@ -33,11 +32,8 @@ export const Base: Story = {
                     field: 'collect_file',
                     checkbox: {
                         label: 'Collect file metadata',
-                        options: {
-                            enable: true,
-                        },
                     },
-                    text: {
+                    input: {
                         defaultValue: 1,
                         required: true,
                     },
@@ -46,25 +42,9 @@ export const Base: Story = {
                     field: 'collect_task',
                     checkbox: {
                         label: 'Collect tasks and comments',
-                        options: {
-                            enable: true,
-                        },
                     },
-                    text: {
+                    input: {
                         defaultValue: 1,
-                        required: true,
-                    },
-                },
-                {
-                    field: 'disabledField',
-                    checkbox: {
-                        label: 'Disabled',
-                        options: {
-                            enable: false,
-                        },
-                    },
-                    text: {
-                        defaultValue: 3600,
                         required: true,
                     },
                 },
@@ -89,11 +69,8 @@ export const WithSingleGroup: Story = {
                     field: 'collect_collaboration',
                     checkbox: {
                         label: 'Collect folder collaboration',
-                        options: {
-                            enable: true,
-                        },
                     },
-                    text: {
+                    input: {
                         defaultValue: 1200,
                         required: false,
                     },
@@ -102,11 +79,8 @@ export const WithSingleGroup: Story = {
                     field: 'collect_file',
                     checkbox: {
                         label: 'Collect file metadata',
-                        options: {
-                            enable: true,
-                        },
                     },
-                    text: {
+                    input: {
                         defaultValue: 1,
                         required: true,
                     },
@@ -138,11 +112,8 @@ export const MixedWithGroups: Story = {
                     field: 'collect_collaboration',
                     checkbox: {
                         label: 'Collect folder collaboration',
-                        options: {
-                            enable: true,
-                        },
                     },
-                    text: {
+                    input: {
                         defaultValue: 1200,
                         required: false,
                     },
@@ -151,11 +122,8 @@ export const MixedWithGroups: Story = {
                     field: 'collect_file',
                     checkbox: {
                         label: 'Collect file metadata',
-                        options: {
-                            enable: true,
-                        },
                     },
-                    text: {
+                    input: {
                         defaultValue: 1,
                         required: true,
                     },
@@ -164,11 +132,8 @@ export const MixedWithGroups: Story = {
                     field: 'collect_task',
                     checkbox: {
                         label: 'Collect tasks and comments',
-                        options: {
-                            enable: true,
-                        },
                     },
-                    text: {
+                    input: {
                         defaultValue: 1,
                         required: true,
                     },
@@ -177,12 +142,43 @@ export const MixedWithGroups: Story = {
                     field: 'collect_folder_metadata',
                     checkbox: {
                         label: 'Collect folder metadata',
-                        options: {
-                            enable: true,
-                        },
                     },
-                    text: {
+                    input: {
                         defaultValue: 3600,
+                        required: true,
+                    },
+                },
+            ],
+        },
+    },
+};
+
+export const CreateMode: Story = {
+    args: {
+        ...Base.args,
+        value: 'field1/1,field2/1', // should be disregarded
+        mode: MODE_CREATE,
+        controlOptions: {
+            rows: [
+                {
+                    field: 'field1',
+                    checkbox: {
+                        label: 'Default true',
+                        defaultValue: true,
+                    },
+                    input: {
+                        defaultValue: 1200,
+                        required: false,
+                    },
+                },
+                {
+                    field: 'field2',
+                    checkbox: {
+                        label: 'Default false',
+                        defaultValue: false,
+                    },
+                    input: {
+                        defaultValue: 2,
                         required: true,
                     },
                 },

--- a/ui/src/main/webapp/components/CheckboxGroup/CheckboxGroup.tsx
+++ b/ui/src/main/webapp/components/CheckboxGroup/CheckboxGroup.tsx
@@ -20,17 +20,17 @@ function CheckboxGroup(props: CheckboxGroupProps) {
     const { field, handleChange, controlOptions, addCustomValidator } = props;
 
     const flattenedRowsWithGroups = getFlattenRowsWithGroups(controlOptions);
-    const value =
-        props.mode === MODE_CREATE
-            ? getDefaultValues(controlOptions.rows)
-            : parseValue(props.value);
+    const shouldUseDefaultValue = props.mode === MODE_CREATE && props.value === null;
+    const value = shouldUseDefaultValue
+        ? getDefaultValues(controlOptions.rows)
+        : parseValue(props.value);
 
     // propagate defaults up if the component is not touched
     useEffect(() => {
-        if (props.mode === MODE_CREATE) {
+        if (shouldUseDefaultValue) {
             handleChange(field, packValue(value), 'checkboxGroup');
         }
-    }, [field, handleChange, props.mode, value]);
+    }, [field, handleChange, shouldUseDefaultValue, value]);
 
     const [values, setValues] = useState(value);
 

--- a/ui/src/main/webapp/components/CheckboxGroup/CheckboxGroup.tsx
+++ b/ui/src/main/webapp/components/CheckboxGroup/CheckboxGroup.tsx
@@ -30,7 +30,7 @@ function CheckboxGroup(props: CheckboxGroupProps) {
         if (props.mode === MODE_CREATE) {
             handleChange(field, packValue(value), 'checkboxGroup');
         }
-    }, []);
+    }, [field, handleChange, props.mode, value]);
 
     const [values, setValues] = useState(value);
 

--- a/ui/src/main/webapp/components/CheckboxGroup/CheckboxGroup.tsx
+++ b/ui/src/main/webapp/components/CheckboxGroup/CheckboxGroup.tsx
@@ -22,7 +22,7 @@ function CheckboxGroup(props: CheckboxGroupProps) {
     const flattenedRowsWithGroups = getFlattenRowsWithGroups(controlOptions);
     const value =
         props.mode === MODE_CREATE
-            ? getDefaultValues(flattenedRowsWithGroups)
+            ? getDefaultValues(controlOptions.rows)
             : parseValue(props.value);
 
     // propagate defaults up if the component is not touched

--- a/ui/src/main/webapp/components/CheckboxGroup/CheckboxRow.tsx
+++ b/ui/src/main/webapp/components/CheckboxGroup/CheckboxRow.tsx
@@ -1,16 +1,12 @@
 import React, { useState, useEffect } from 'react';
 import ColumnLayout from '@splunk/react-ui/ColumnLayout';
-import Text from '@splunk/react-ui/Text';
-import { TextChangeHandler } from '@splunk/react-ui/types/src/Text/Text';
+import NumberComponent, { NumberChangeHandler } from '@splunk/react-ui/Number';
 import styled from 'styled-components';
 import Switch from '@splunk/react-ui/Switch';
 import { StyledColumnLayout } from './StyledComponent';
 
 const StyledSwitch = styled(Switch)`
     padding-left: 3px;
-`;
-const StyledText = styled(Text)`
-    padding-right: 3px;
 `;
 
 interface CheckboxRowProps {
@@ -31,10 +27,8 @@ function CheckboxRow(props: CheckboxRowProps) {
         setIsTextDisabled(!checkbox || disabled);
     }, [checkbox, disabled]);
 
-    const handleChangeTextBox: TextChangeHandler = (event) => {
-        if (event?.target && 'value' in event.target) {
-            handleChange({ field, inputValue: Number(event.target.value), checkbox });
-        }
+    const handleChangeInput: NumberChangeHandler = (event: unknown, { value }) => {
+        handleChange({ field, inputValue: value, checkbox });
     };
 
     const handleChangeCheckbox = (event: unknown, data: { selected: boolean; value?: unknown }) => {
@@ -45,7 +39,7 @@ function CheckboxRow(props: CheckboxRowProps) {
     return (
         <StyledColumnLayout>
             <ColumnLayout.Row>
-                <ColumnLayout.Column span={5}>
+                <ColumnLayout.Column span={7}>
                     <StyledSwitch
                         key={field}
                         value={field}
@@ -57,14 +51,12 @@ function CheckboxRow(props: CheckboxRowProps) {
                         {label}
                     </StyledSwitch>
                 </ColumnLayout.Column>
-                <ColumnLayout.Column span={2}>
-                    <StyledText
+                <ColumnLayout.Column span={3}>
+                    <NumberComponent
                         inline
                         disabled={isTextDisabled}
-                        value={input?.toString()}
-                        onChange={handleChangeTextBox}
-                        type="number"
-                        required
+                        defaultValue={input}
+                        onChange={handleChangeInput}
                     />
                 </ColumnLayout.Column>
             </ColumnLayout.Row>

--- a/ui/src/main/webapp/components/CheckboxGroup/CheckboxRow.tsx
+++ b/ui/src/main/webapp/components/CheckboxGroup/CheckboxRow.tsx
@@ -17,13 +17,13 @@ interface CheckboxRowProps {
     field: string;
     label: string;
     checkbox: boolean;
-    text?: string;
+    input?: number;
     disabled?: boolean;
-    handleChange: (value: { field: string; checkbox: boolean; text?: string }) => void;
+    handleChange: (value: { field: string; checkbox: boolean; inputValue?: number }) => void;
 }
 
 function CheckboxRow(props: CheckboxRowProps) {
-    const { field, label, checkbox, text, disabled, handleChange } = props;
+    const { field, label, checkbox, input, disabled, handleChange } = props;
 
     const [isTextDisabled, setIsTextDisabled] = useState(!checkbox || disabled);
 
@@ -33,13 +33,13 @@ function CheckboxRow(props: CheckboxRowProps) {
 
     const handleChangeTextBox: TextChangeHandler = (event) => {
         if (event?.target && 'value' in event.target) {
-            handleChange({ field, text: event.target.value, checkbox });
+            handleChange({ field, inputValue: Number(event.target.value), checkbox });
         }
     };
 
     const handleChangeCheckbox = (event: unknown, data: { selected: boolean; value?: unknown }) => {
         const previousValue = data.selected;
-        handleChange({ field, text, checkbox: !previousValue });
+        handleChange({ field, inputValue: input, checkbox: !previousValue });
     };
 
     return (
@@ -61,9 +61,9 @@ function CheckboxRow(props: CheckboxRowProps) {
                     <StyledText
                         inline
                         disabled={isTextDisabled}
-                        value={text || ''}
+                        value={input?.toString()}
                         onChange={handleChangeTextBox}
-                        type="text"
+                        type="number"
                         required
                     />
                 </ColumnLayout.Column>

--- a/ui/src/main/webapp/components/CheckboxGroup/CheckboxRowWrapper.tsx
+++ b/ui/src/main/webapp/components/CheckboxGroup/CheckboxRowWrapper.tsx
@@ -17,8 +17,7 @@ function CheckboxRowWrapper({
             field={row.field}
             label={row.checkbox?.label || row.field}
             checkbox={!!valueForField?.checkbox}
-            disabled={row.checkbox?.options?.enable === false}
-            text={valueForField ? valueForField.text : row.text?.defaultValue?.toString()}
+            input={valueForField ? valueForField.inputValue : row.input?.defaultValue}
             handleChange={handleRowChange}
         />
     );

--- a/ui/src/main/webapp/components/CheckboxGroup/checkboxGroup.utils.test.ts
+++ b/ui/src/main/webapp/components/CheckboxGroup/checkboxGroup.utils.test.ts
@@ -1,4 +1,5 @@
 import {
+    getDefaultValues,
     getFlattenRowsWithGroups,
     getNewCheckboxValues,
     Group,
@@ -154,7 +155,7 @@ describe('getFlattenRowsWithGroups', () => {
     });
 });
 
-describe('getNewCheckboxValues function', () => {
+describe('getNewCheckboxValues', () => {
     it('should update the checkbox value for an existing field', () => {
         const initialValues: ValueByField = new Map([
             ['field1', { checkbox: true, inputValue: 1 }],
@@ -179,5 +180,54 @@ describe('getNewCheckboxValues function', () => {
 
         const result = getNewCheckboxValues(initialValues, newValue);
         expect(result.get('field3')).toEqual({ checkbox: true, inputValue: undefined });
+    });
+});
+
+describe('getDefaultValues', () => {
+    it('should return an empty map when provided with an empty array', () => {
+        const input: Row[] = [];
+        const expectedOutput = new Map();
+        expect(getDefaultValues(input)).toEqual(expectedOutput);
+    });
+
+    it('should correctly set default values for a single row with checkbox', () => {
+        const input: Row[] = [
+            {
+                field: 'testField',
+                checkbox: { label: 'testField', defaultValue: true },
+                input: { defaultValue: 42 },
+            },
+        ];
+        const expectedOutput: ValueByField = new Map();
+        expectedOutput.set('testField', { checkbox: true, inputValue: 42 });
+        expect(getDefaultValues(input)).toEqual(expectedOutput);
+    });
+
+    it('should ignore rows where isGroupWithRows is true', () => {
+        const input: Row[] = [
+            {
+                field: 'ignoredField',
+                // assuming isGroupWithRows would set some additional properties
+            },
+            {
+                field: 'testField',
+                checkbox: { label: 'testField', defaultValue: true },
+                input: { defaultValue: 42 },
+            },
+        ];
+        const expectedOutput: ValueByField = new Map();
+        expectedOutput.set('testField', { checkbox: true, inputValue: 42 });
+        expect(getDefaultValues(input)).toEqual(expectedOutput);
+    });
+
+    it('should handle rows without default checkbox values', () => {
+        const input: Row[] = [
+            {
+                field: 'testField',
+                input: { defaultValue: 42 },
+            },
+        ];
+        const expectedOutput: ValueByField = new Map();
+        expect(getDefaultValues(input)).toEqual(expectedOutput);
     });
 });

--- a/ui/src/main/webapp/components/CheckboxGroup/checkboxGroup.utils.test.ts
+++ b/ui/src/main/webapp/components/CheckboxGroup/checkboxGroup.utils.test.ts
@@ -17,10 +17,10 @@ describe('parseValue', () => {
         const resultMap = parseValue(collection);
 
         expect(resultMap.size).toBe(3);
-        expect(resultMap.get('collect_collaboration')?.text).toBe('1200');
+        expect(resultMap.get('collect_collaboration')?.inputValue).toBe(1200);
         expect(resultMap.get('collect_collaboration')?.checkbox).toBeTruthy();
-        expect(resultMap.get('collect_file')?.text).toBe('1');
-        expect(resultMap.get('collect_task')?.text).toBe('1');
+        expect(resultMap.get('collect_file')?.inputValue).toBe(1);
+        expect(resultMap.get('collect_task')?.inputValue).toBe(1);
     });
     it('should return an empty Map for undefined collection', () => {
         const resultMap = parseValue();
@@ -35,34 +35,34 @@ describe('parseValue', () => {
 
 describe('packValue', () => {
     it('should return a comma-separated string of field/text pairs where checkbox is true', () => {
-        const testMap = new Map();
-        testMap.set('collect_collaboration', { checkbox: true, text: '1200' });
-        testMap.set('collect_file', { checkbox: true, text: '1' });
-        testMap.set('collect_task', { checkbox: true, text: '1' });
-        testMap.set('field4', { checkbox: false, text: '1' });
+        const testMap: ValueByField = new Map();
+        testMap.set('collect_collaboration', { checkbox: true, inputValue: 1200 });
+        testMap.set('collect_file', { checkbox: true, inputValue: 1 });
+        testMap.set('collect_task', { checkbox: true, inputValue: 1 });
+        testMap.set('field4', { checkbox: false, inputValue: 1 });
 
         const result = packValue(testMap);
         expect(result).toBe('collect_collaboration/1200,collect_file/1,collect_task/1');
     });
 
     it('should return an empty string if no entries have checkbox set to true', () => {
-        const testMap = new Map();
-        testMap.set('field1', { checkbox: false, text: 'text1' });
-        testMap.set('field2', { checkbox: false, text: 'text2' });
+        const testMap: ValueByField = new Map();
+        testMap.set('field1', { checkbox: false, inputValue: 1 });
+        testMap.set('field2', { checkbox: false, inputValue: 1 });
 
         const result = packValue(testMap);
         expect(result).toBe('');
     });
 
     it('should return an empty string if the map is empty', () => {
-        const testMap = new Map();
+        const testMap: ValueByField = new Map();
         const result = packValue(testMap);
         expect(result).toBe('');
     });
 
     it('parsed value should be the same as packed value', () => {
         const packedValue =
-            'collect_collaboration/1200,collect_file/1,collect_task/1,fieldWithoutValue/';
+            'collect_collaboration/1200,collect_file/1,collect_task/1,fieldWithoutValue/0';
         expect(packValue(parseValue(packedValue))).toBe(packedValue);
     });
 });
@@ -95,8 +95,8 @@ describe('getFlattenRowsWithGroups', () => {
                 checkbox: {
                     label: 'Checkbox1',
                 },
-                text: {
-                    defaultValue: 'value1',
+                input: {
+                    defaultValue: 1,
                     required: true,
                 },
             },
@@ -105,8 +105,8 @@ describe('getFlattenRowsWithGroups', () => {
                 checkbox: {
                     label: 'Checkbox2',
                 },
-                text: {
-                    defaultValue: 'value2',
+                input: {
+                    defaultValue: 2,
                     required: false,
                 },
             },
@@ -115,8 +115,8 @@ describe('getFlattenRowsWithGroups', () => {
                 checkbox: {
                     label: 'Checkbox3',
                 },
-                text: {
-                    defaultValue: 'value3',
+                input: {
+                    defaultValue: 3,
                     required: true,
                 },
             },
@@ -125,8 +125,8 @@ describe('getFlattenRowsWithGroups', () => {
                 checkbox: {
                     label: 'Checkbox4',
                 },
-                text: {
-                    defaultValue: 'value4',
+                input: {
+                    defaultValue: 4,
                     required: false,
                 },
             },
@@ -157,20 +157,20 @@ describe('getFlattenRowsWithGroups', () => {
 describe('getNewCheckboxValues function', () => {
     it('should update the checkbox value for an existing field', () => {
         const initialValues: ValueByField = new Map([
-            ['field1', { checkbox: true, text: 'text1' }],
+            ['field1', { checkbox: true, inputValue: 1 }],
         ]);
-        const newValue = { field: 'field1', checkbox: false, text: 'newText1' };
+        const newValue = { field: 'field1', checkbox: false, inputValue: 2 };
 
         const result = getNewCheckboxValues(initialValues, newValue);
-        expect(result.get('field1')).toEqual({ checkbox: false, text: 'newText1' });
+        expect(result.get('field1')).toEqual({ checkbox: false, inputValue: 2 });
     });
 
     it('should add a new field with checkbox and text values', () => {
         const initialValues: ValueByField = new Map();
-        const newValue = { field: 'field2', checkbox: true, text: 'text2' };
+        const newValue = { field: 'field2', checkbox: true, inputValue: 2 };
 
         const result = getNewCheckboxValues(initialValues, newValue);
-        expect(result.get('field2')).toEqual({ checkbox: true, text: 'text2' });
+        expect(result.get('field2')).toEqual({ checkbox: true, inputValue: 2 });
     });
 
     it('should set text to an empty string if not provided', () => {
@@ -178,6 +178,6 @@ describe('getNewCheckboxValues function', () => {
         const newValue = { field: 'field3', checkbox: true };
 
         const result = getNewCheckboxValues(initialValues, newValue);
-        expect(result.get('field3')).toEqual({ checkbox: true, text: '' });
+        expect(result.get('field3')).toEqual({ checkbox: true, inputValue: undefined });
     });
 });

--- a/ui/src/main/webapp/components/CheckboxGroup/checkboxGroup.utils.ts
+++ b/ui/src/main/webapp/components/CheckboxGroup/checkboxGroup.utils.ts
@@ -40,7 +40,7 @@ export function parseValue(collection?: string): ValueByField {
 export function packValue(map: ValueByField) {
     return Array.from(map.entries())
         .filter(([, value]) => value.checkbox)
-        .map(([field, value]) => `${field}/${value.inputValue}`)
+        .map(([field, { inputValue = '' }]) => `${field}/${inputValue}`)
         .join(',');
 }
 

--- a/ui/src/main/webapp/components/CheckboxGroup/checkboxGroup.utils.ts
+++ b/ui/src/main/webapp/components/CheckboxGroup/checkboxGroup.utils.ts
@@ -24,7 +24,7 @@ export function parseValue(collection?: string): ValueByField {
     splitValues.forEach((rawValue) => {
         const [field, inputValue] = rawValue.split('/');
         const parsedInputValue = Number(inputValue);
-        if (!field || isNaN(parsedInputValue)) {
+        if (!field || Number.isNaN(parsedInputValue)) {
             throw new Error(`Value is not parsable: ${collection}`);
         }
 
@@ -32,24 +32,6 @@ export function parseValue(collection?: string): ValueByField {
             checkbox: true,
             inputValue: parsedInputValue,
         });
-    });
-
-    return resultMap;
-}
-
-export function getDefaultValues(rows: (GroupWithRows | Row)[]): ValueByField {
-    const resultMap = new Map<Field, Value>();
-
-    rows.forEach((row) => {
-        if (!isGroupWithRows(row)) {
-            const checkboxDefaultValue = row.checkbox?.defaultValue;
-            if (typeof checkboxDefaultValue === 'boolean') {
-                resultMap.set(row.field, {
-                    checkbox: checkboxDefaultValue,
-                    inputValue: row.input?.defaultValue,
-                });
-            }
-        }
     });
 
     return resultMap;
@@ -156,4 +138,22 @@ export function getCheckedCheckboxesCount(group: GroupWithRows, values: ValueByF
         }
     });
     return checkedCheckboxesCount;
+}
+
+export function getDefaultValues(rows: (GroupWithRows | Row)[]): ValueByField {
+    const resultMap = new Map<Field, Value>();
+
+    rows.forEach((row) => {
+        if (!isGroupWithRows(row)) {
+            const checkboxDefaultValue = row.checkbox?.defaultValue;
+            if (typeof checkboxDefaultValue === 'boolean') {
+                resultMap.set(row.field, {
+                    checkbox: checkboxDefaultValue,
+                    inputValue: row.input?.defaultValue,
+                });
+            }
+        }
+    });
+
+    return resultMap;
 }

--- a/ui/src/main/webapp/components/CheckboxGroup/checkboxGroup.utils.ts
+++ b/ui/src/main/webapp/components/CheckboxGroup/checkboxGroup.utils.ts
@@ -56,12 +56,12 @@ export interface Group {
 export interface Row {
     field: string;
     checkbox?: {
-        label: string;
+        label?: string;
         defaultValue?: boolean;
     };
     input?: {
         defaultValue?: number;
-        validators?: (StringValidator | RegexValidator | NumberValidator)[];
+        validators?: NumberValidator[];
         required?: boolean;
     };
 }
@@ -140,7 +140,7 @@ export function getCheckedCheckboxesCount(group: GroupWithRows, values: ValueByF
     return checkedCheckboxesCount;
 }
 
-export function getDefaultValues(rows: (GroupWithRows | Row)[]): ValueByField {
+export function getDefaultValues(rows: Row[]): ValueByField {
     const resultMap = new Map<Field, Value>();
 
     rows.forEach((row) => {

--- a/ui/src/main/webapp/components/CheckboxGroup/checkboxGroup.utils.ts
+++ b/ui/src/main/webapp/components/CheckboxGroup/checkboxGroup.utils.ts
@@ -1,4 +1,4 @@
-import { NumberValidator, RegexValidator, StringValidator } from '../../types/ValidatorsTypes';
+import { NumberValidator } from '../../types/ValidatorsTypes';
 import { Mode } from '../../constants/modes';
 
 type Field = string;

--- a/ui/src/main/webapp/components/CheckboxGroup/checkboxGroupMocks.json
+++ b/ui/src/main/webapp/components/CheckboxGroup/checkboxGroupMocks.json
@@ -237,22 +237,6 @@
                     }
                   },
                   {
-                    "field": "field23",
-                    "checkbox": {
-                      "label": "No more 2 characters"
-                    },
-                    "input": {
-                      "validators": [
-                        {
-                          "type": "string",
-                          "minLength": 0,
-                          "maxLength": 2
-                        }
-                      ],
-                      "defaultValue": "aa"
-                    }
-                  },
-                  {
                     "field": "160validation",
                     "checkbox": {
                       "label": "from 1 to 60 validation"

--- a/ui/src/main/webapp/components/CheckboxGroup/checkboxGroupMocks.json
+++ b/ui/src/main/webapp/components/CheckboxGroup/checkboxGroupMocks.json
@@ -64,6 +64,9 @@
                 "rows": [
                   {
                     "field": "collectFolderCollaboration",
+                    "checkbox": {
+                      "defaultValue": true
+                    },
                     "input": {
                       "defaultValue": 1200,
                       "required": false,

--- a/ui/src/main/webapp/components/CheckboxGroup/checkboxGroupMocks.json
+++ b/ui/src/main/webapp/components/CheckboxGroup/checkboxGroupMocks.json
@@ -64,7 +64,7 @@
                 "rows": [
                   {
                     "field": "collectFolderCollaboration",
-                    "text": {
+                    "input": {
                       "defaultValue": 1200,
                       "required": false,
                       "validators": [
@@ -80,7 +80,7 @@
                     "checkbox": {
                       "label": "Collect file metadata"
                     },
-                    "text": {
+                    "input": {
                       "defaultValue": 1,
                       "required": true
                     }
@@ -88,12 +88,9 @@
                   {
                     "field": "collectTasksAndComments",
                     "checkbox": {
-                      "label": "This is a very very long line",
-                      "options": {
-                        "enable": true
-                      }
+                      "label": "This is a very very long line"
                     },
-                    "text": {
+                    "input": {
                       "defaultValue": 1,
                       "required": true
                     }
@@ -101,12 +98,9 @@
                   {
                     "field": "collectFolderMetadata",
                     "checkbox": {
-                      "label": "Collect folder metadata",
-                      "options": {
-                        "enable": true
-                      }
+                      "label": "Collect folder metadata"
                     },
-                    "text": {
+                    "input": {
                       "defaultValue": 3600,
                       "required": true
                     }
@@ -123,12 +117,9 @@
                   {
                     "field": "collectFolderMetadata",
                     "checkbox": {
-                      "label": "Collect folder metadata",
-                      "options": {
-                        "enable": true
-                      }
+                      "label": "Collect folder metadata"
                     },
-                    "text": {
+                    "input": {
                       "defaultValue": 3600,
                       "required": true
                     }
@@ -138,7 +129,7 @@
                     "checkbox": {
                       "label": "Collect folder collaboration"
                     },
-                    "text": {
+                    "input": {
                       "defaultValue": 1200,
                       "required": false,
                       "validators": [
@@ -154,7 +145,7 @@
                     "checkbox": {
                       "label": "Collect file metadata"
                     },
-                    "text": {
+                    "input": {
                       "defaultValue": 1,
                       "required": true
                     }
@@ -164,7 +155,7 @@
                     "checkbox": {
                       "label": "Collect tasks and comments"
                     },
-                    "text": {
+                    "input": {
                       "defaultValue": 1,
                       "required": true
                     }
@@ -199,12 +190,9 @@
                   {
                     "field": "collectFolderCollaboration",
                     "checkbox": {
-                      "label": "Collect folder collaboration",
-                      "options": {
-                        "enable": true
-                      }
+                      "label": "Collect folder collaboration"
                     },
-                    "text": {
+                    "input": {
                       "defaultValue": 1200,
                       "required": false
                     }
@@ -212,12 +200,9 @@
                   {
                     "field": "collectFileMetadata",
                     "checkbox": {
-                      "label": "Collect file metadata",
-                      "options": {
-                        "enable": true
-                      }
+                      "label": "Collect file metadata"
                     },
-                    "text": {
+                    "input": {
                       "defaultValue": 1,
                       "required": true
                     }
@@ -225,12 +210,9 @@
                   {
                     "field": "collectTasksAndComments",
                     "checkbox": {
-                      "label": "Collect tasks and comments",
-                      "options": {
-                        "enable": true
-                      }
+                      "label": "Collect tasks and comments"
                     },
-                    "text": {
+                    "input": {
                       "defaultValue": 1,
                       "required": true
                     }
@@ -238,12 +220,9 @@
                   {
                     "field": "collectFolderMetadata",
                     "checkbox": {
-                      "label": "Collect folder metadata",
-                      "options": {
-                        "enable": true
-                      }
+                      "label": "Collect folder metadata"
                     },
-                    "text": {
+                    "input": {
                       "defaultValue": 3600,
                       "required": true
                     }
@@ -251,24 +230,18 @@
                   {
                     "field": "field223",
                     "checkbox": {
-                      "label": "Required field",
-                      "options": {
-                        "enable": true
-                      }
+                      "label": "Required field"
                     },
-                    "text": {
+                    "input": {
                       "required": true
                     }
                   },
                   {
                     "field": "field23",
                     "checkbox": {
-                      "label": "No more 2 characters",
-                      "options": {
-                        "enable": true
-                      }
+                      "label": "No more 2 characters"
                     },
-                    "text": {
+                    "input": {
                       "validators": [
                         {
                           "type": "string",
@@ -284,7 +257,7 @@
                     "checkbox": {
                       "label": "from 1 to 60 validation"
                     },
-                    "text": {
+                    "input": {
                       "validators": [
                         {
                           "type": "number",

--- a/ui/src/main/webapp/components/CheckboxGroup/checkboxGroupMocks.ts
+++ b/ui/src/main/webapp/components/CheckboxGroup/checkboxGroupMocks.ts
@@ -1,7 +1,7 @@
-import { rest } from 'msw';
+import { compose, rest } from 'msw';
 
 export const serverHandlers = [
-    rest.get(`/servicesNS/nobody/-/restRoot_example_input_four`, (req, res, ctx) =>
+    rest.get(`/servicesNS/:user/-/:serviceName`, (req, res, ctx) =>
         res(
             ctx.json({
                 entry: [
@@ -12,6 +12,16 @@ export const serverHandlers = [
                     },
                 ],
             })
+        )
+    ),
+    rest.post(`/servicesNS/:user/-/:serviceName`, async (req, res, ctx) =>
+        res(
+            compose(
+                ctx.json({
+                    messages: [{ text: `Submitted body: ${decodeURIComponent(await req.text())}` }],
+                }),
+                ctx.status(500)
+            )
         )
     ),
 ];

--- a/ui/src/main/webapp/components/CheckboxGroup/checkboxGroupValidation.test.ts
+++ b/ui/src/main/webapp/components/CheckboxGroup/checkboxGroupValidation.test.ts
@@ -10,49 +10,13 @@ describe('validateCheckboxGroup', () => {
             rows: [
                 {
                     field: 'field1',
-                    text: { required: true },
+                    input: { required: true },
                     checkbox: { label: 'Label 1' },
                 },
             ],
         });
 
         expect(mockRequiredValidator).toHaveBeenCalled();
-        expect(result).toBe(false);
-    });
-
-    it('should handle regex validation', () => {
-        const mockRegexValidator = jest.fn().mockReturnValue(false);
-        Validator.RegexValidator = mockRegexValidator;
-
-        const result = validateCheckboxGroup('field1', 'field1/123', {
-            rows: [
-                {
-                    field: 'field1',
-                    text: { validators: [{ type: 'regex', pattern: '' }] },
-                    checkbox: { label: 'Label 1' },
-                },
-            ],
-        });
-
-        expect(mockRegexValidator).toHaveBeenCalled();
-        expect(result).toBe(false);
-    });
-
-    it('should handle string validation', () => {
-        const mockStringValidator = jest.fn().mockReturnValue(false);
-        Validator.StringValidator = mockStringValidator;
-
-        const result = validateCheckboxGroup('field1', 'field1/123', {
-            rows: [
-                {
-                    field: 'field1',
-                    text: { validators: [{ type: 'string', minLength: 0, maxLength: 2 }] },
-                    checkbox: { label: 'Label 1' },
-                },
-            ],
-        });
-
-        expect(mockStringValidator).toHaveBeenCalled();
         expect(result).toBe(false);
     });
 
@@ -64,7 +28,7 @@ describe('validateCheckboxGroup', () => {
             rows: [
                 {
                     field: 'field1',
-                    text: { validators: [{ type: 'number', range: [1, 2] }] },
+                    input: { validators: [{ type: 'number', range: [1, 2] }] },
                     checkbox: { label: 'Label 1' },
                 },
             ],
@@ -81,7 +45,7 @@ describe('validateCheckboxGroup', () => {
                     {
                         field: 'field1',
                         // @ts-expect-error tests
-                        text: { validators: [{ type: 'unsupported' }] },
+                        input: { validators: [{ type: 'unsupported' }] },
                         checkbox: { label: 'Label 1' },
                     },
                 ],
@@ -94,7 +58,7 @@ describe('validateCheckboxGroup', () => {
             rows: [
                 {
                     field: 'field1',
-                    text: {},
+                    input: {},
                     checkbox: { label: 'Label 1' },
                 },
             ],
@@ -110,7 +74,7 @@ describe('validateCheckboxGroup', () => {
             rows: [
                 {
                     field: 'field1',
-                    text: { validators: [{ type: 'number', range: [1, 2] }] },
+                    input: { validators: [{ type: 'number', range: [1, 2] }] },
                     checkbox: { label: 'Label 1' },
                 },
             ],

--- a/ui/src/main/webapp/components/CheckboxGroup/checkboxGroupValidation.ts
+++ b/ui/src/main/webapp/components/CheckboxGroup/checkboxGroupValidation.ts
@@ -19,44 +19,26 @@ export function validateCheckboxGroup(
     options.rows.some((row) => {
         const rowSubmittedValue = parsedValue.get(row.field);
         if (rowSubmittedValue) {
-            if (row.text.required) {
+            if (row.input?.required) {
                 errorMessage = Validator.RequiredValidator(
                     field,
                     row.checkbox?.label || row.field,
-                    rowSubmittedValue?.text
+                    rowSubmittedValue.inputValue
                 );
                 // break loop
                 return errorMessage;
             }
 
-            const { validators } = row.text;
-            if (validators?.length) {
-                return validators.some((validator) => {
+            if (row.input?.validators?.length) {
+                return row.input?.validators.some((validator) => {
                     const { type } = validator;
                     switch (type) {
-                        case 'regex':
-                            errorMessage = Validator.RegexValidator(
-                                field,
-                                row.checkbox?.label || row.field,
-                                validator,
-                                rowSubmittedValue?.text
-                            );
-                            return errorMessage;
-                        case 'string':
-                            errorMessage = Validator.StringValidator(
-                                field,
-                                row.checkbox?.label || row.field,
-                                validator,
-                                rowSubmittedValue?.text
-                            );
-                            return errorMessage;
-
                         case 'number':
                             errorMessage = Validator.NumberValidator(
                                 field,
                                 row.checkbox?.label || row.field,
                                 validator,
-                                rowSubmittedValue?.text
+                                rowSubmittedValue.inputValue
                             );
 
                             return errorMessage;

--- a/ui/src/main/webapp/components/ControlWrapper.jsx
+++ b/ui/src/main/webapp/components/ControlWrapper.jsx
@@ -88,6 +88,7 @@ class ControlWrapper extends React.PureComponent {
                       required,
                       addCustomValidator,
                       fileNameToDisplay: this.props.fileNameToDisplay,
+                      mode: this.props.mode,
                   })
                 : `No View Found for ${type} type`;
         }

--- a/ui/src/main/webapp/constants/modes.ts
+++ b/ui/src/main/webapp/constants/modes.ts
@@ -3,3 +3,10 @@ export const MODE_CREATE = 'create';
 export const MODE_DELETE = 'delete';
 export const MODE_EDIT = 'edit';
 export const MODE_CONFIG = 'config';
+
+export type Mode =
+    | typeof MODE_CLONE
+    | typeof MODE_CREATE
+    | typeof MODE_DELETE
+    | typeof MODE_EDIT
+    | typeof MODE_CONFIG;

--- a/ui/src/main/webapp/util/Validator.js
+++ b/ui/src/main/webapp/util/Validator.js
@@ -81,7 +81,7 @@ class Validator {
      * Validate the required field has value
      * @param {string} field
      * @param {string|number} label
-     * @param {string|number} data
+     * @param {string|number} [data]
      * @returns {Error|false}
      */
     static RequiredValidator(field, label, data) {
@@ -135,7 +135,7 @@ class Validator {
      * @param {string} field
      * @param {string|number} label
      * @param {RegexValidatorOptions} validator
-     * @param {string} data
+     * @param {string} [data]
      * @returns {Error|false}
      */
     static RegexValidator(field, label, validator, data) {
@@ -190,7 +190,7 @@ class Validator {
      * @param {string} field
      * @param {string|number} label
      * @param {NumberValidatorOptions} validator
-     * @param {string} data
+     * @param {string|number} [data]
      * @returns {Error|false}
      */
     // Validate the range of numeric field

--- a/ui/src/main/webapp/util/messageUtil.js
+++ b/ui/src/main/webapp/util/messageUtil.js
@@ -19,6 +19,7 @@ export const getFormattedMessage = (code, msg /* , ... , args */) => {
 
 export const parseErrorMsg = (err) => {
     let errorMsg = '';
+    console.log(err);
     let regex;
     let matches;
     try {

--- a/ui/src/main/webapp/util/messageUtil.js
+++ b/ui/src/main/webapp/util/messageUtil.js
@@ -19,7 +19,6 @@ export const getFormattedMessage = (code, msg /* , ... , args */) => {
 
 export const parseErrorMsg = (err) => {
     let errorMsg = '';
-    console.log(err);
     let regex;
     let matches;
     try {


### PR DESCRIPTION
- input value restricted to numbers only to avoid handling encapsulation
- due to that, the only possible validation left - number. Regex and strings are removed.
- `text` field has renamed to `input`. Motivation: it is not a text anymore, rather number. Docs, tests, mocks are updated
- removed `options.enabled` property to disable fields because of perception that it sets defaultValue while it is used for disabling.
- for CREATE mode, checkbox group takes checkbox values from it's defaultValue. Value provided by form is ignored.
- for any mode, default value for `input` is taken from `input.defaultValue` if it is not provided as a form value `field1/value1`