### PR TITLE
fix(warning): added warnings_logger to display warnings

### DIFF
--- a/splunk_add_on_ucc_framework/__init__.py
+++ b/splunk_add_on_ucc_framework/__init__.py
@@ -16,6 +16,7 @@
 __version__ = "5.31.1"
 
 import logging
+import warnings
 
 logger = logging.getLogger("ucc_gen")
 logger.setLevel(logging.INFO)
@@ -24,3 +25,9 @@ stream_handler = logging.StreamHandler()
 stream_handler.setLevel(logging.INFO)
 stream_handler.setFormatter(formatter)
 logger.addHandler(stream_handler)
+
+warnings.filterwarnings("always", category=DeprecationWarning)
+
+logging.captureWarnings(True)
+warnings_logger = logging.getLogger("py.warnings")
+warnings_logger.addHandler(stream_handler)


### PR DESCRIPTION
Fixes GitHub Issue - #902

Added warning logger in `__init__.py` file to display warnings to the console.

**Alternative Solution**:
Another approach for resolving the same issue is instead of using `warnings.warn`, use a `logger` object. Below is the snippet for the alternative.
![warning_using_logger](https://github.com/splunk/addonfactory-ucc-generator/assets/77769935/aecb157e-889c-4d83-adb0-2eaec544240c)

I recommend using a warnings_logger and `warnings` module over the use of a simple logger. Please let me know if you think otherwise.