### PR TITLE
ui: pin splunk/addonfactory-test-matrix-action to 1.10

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - id: matrix
-        uses: splunk/addonfactory-test-matrix-action@v1
+        uses: splunk/addonfactory-test-matrix-action@v1.10
 
   fossa-scan:
     continue-on-error: true


### PR DESCRIPTION
Pinning to this version to avoid testing with unreleased Splunk version.