### PR TITLE
feat: init with logging for config

### DIFF
--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -1,16 +1,19 @@
 # Dashboard
+
 UCC introduces a support for a dashboard page (available from v5.27.0).
 The dashboard page configuration is generated if `ucc-gen init` command is used.
 The dashboard page is optional, you can delete it from configuration if you
 don't need it in your add-on.
+
 The dashboard page provides some additional information about the add-on
 operations to increase the visibility into what is add-on is actually doing
 under the hood.
+
 As of now, 3 pre-built panels are supported:
+
 * Add-on version
 * Events ingested by sourcetype
 * Errors in the add-on
-
 > Note: if you change the dashboard page (Edit button) after the add-on is
 > installed, the changes go to `local` folder, and you will see your version
 > of the dashboard even if you update an add-on. 

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -1,99 +1,16 @@
 # Dashboard
-
 UCC introduces a support for a dashboard page (available from v5.27.0).
 The dashboard page configuration is generated if `ucc-gen init` command is used.
 The dashboard page is optional, you can delete it from configuration if you
 don't need it in your add-on.
-
 The dashboard page provides some additional information about the add-on
 operations to increase the visibility into what is add-on is actually doing
 under the hood.
-
 As of now, 3 pre-built panels are supported:
-
 * Add-on version
 * Events ingested by sourcetype
 * Errors in the add-on
 
 > Note: if you change the dashboard page (Edit button) after the add-on is
 > installed, the changes go to `local` folder, and you will see your version
-> of the dashboard even if you update an add-on.
-
-To be able to add a dashboard page to an existing add-on, you need to adjust your 
-globalConfig file and include a new page "dashboard" there. Here is an example:
-
-```json
-{
-    "pages": {
-        "configuration": {
-            "tabs": [
-                ...
-            ],
-            "title": "Configuration",
-            "description": "Set up your add-on"
-        },
-        "inputs": {
-            "services": [
-                ...
-            ],
-            "title": "Inputs",
-            "description": "Manage your data inputs",
-            "table": {
-                ...
-            }
-        },
-        "dashboard": {
-            "panels": [
-                {
-                    "name": "addon_version"
-                },
-                {
-                    "name": "events_ingested_by_sourcetype"
-                },
-                {
-                    "name": "errors_in_the_addon"
-                }
-            ]
-        }
-    },
-    "meta": {
-      ...
-    }
-}
-```
-
-### Add-on version
-
-Executes the following search:
-
-```
-| rest services/apps/local/<addon_name> splunk_server=local | fields version
-```
-
-> Note: <addon_name> is being replaced by the actual value during the build time.
-
-### Events ingested by sourcetype
-
-Executes the following search:
-
-```
-index=_internal source=*<addon_name>* action=events_ingested
-| timechart avg(n_events) by sourcetype_ingested
-```
-
-> Note: <addon_name> is being replaced by the actual value during the build time.
-
-This search assumes specific data format in the internal logs to fill the panel with
-data.
-
-It's recommended to utilize `solnlib.log`'s [`events_ingested` function](https://github.com/splunk/addonfactory-solutions-library-python/blob/3045f9d15398fac0bd6740645ba119250ead129b/solnlib/log.py#L253).
-
-### Errors in the add-on
-
-Executes the following search:
-
-```
-index=_internal source=*<addon_name>* ERROR
-```
-
-> Note: <addon_name> is being replaced by the actual value during the build time.
+> of the dashboard even if you update an add-on. 

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -14,6 +14,7 @@ As of now, 3 pre-built panels are supported:
 * Add-on version
 * Events ingested by sourcetype
 * Errors in the add-on
+
 > Note: if you change the dashboard page (Edit button) after the add-on is
 > installed, the changes go to `local` folder, and you will see your version
 > of the dashboard even if you update an add-on. 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@
 
 [tool.poetry]
 name = "splunk_add_on_ucc_framework"
-version = "5.33.0"
+version = "5.32.0"
 description = "Splunk Add-on SDK formerly UCC is a build and code generation framework"
 license = "Apache-2.0"
 authors = ["Splunk <addonfactory@splunk.com>"]

--- a/splunk_add_on_ucc_framework/__init__.py
+++ b/splunk_add_on_ucc_framework/__init__.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-__version__ = "5.33.0"
+__version__ = "5.32.0"
 
 import logging
 

--- a/splunk_add_on_ucc_framework/commands/init.py
+++ b/splunk_add_on_ucc_framework/commands/init.py
@@ -120,9 +120,9 @@ def _generate_addon(
     os.makedirs(package_bin_path)
 
     py_in_bin_from_template = {
-        'utils.name.init-template' : f"{addon_name}_utils.py",
-        'rh_endpoint.name.init-template' : f"{addon_name}_rh_endpoint.py",
-        'input.name.init-template' : f"{addon_input_name}.py"
+        "utils.name.init-template": f"{addon_name}_utils.py",
+        "rh_endpoint.name.init-template": f"{addon_name}_rh_endpoint.py",
+        "input.name.init-template": f"{addon_input_name}.py",
     }
     for template, py_in_bin in py_in_bin_from_template.items():
         package_bin_input_path = os.path.join(package_bin_path, py_in_bin)

--- a/tests/testdata/expected_addons/expected_addon_after_init/demo_addon_for_splunk/globalConfig.json
+++ b/tests/testdata/expected_addons/expected_addon_after_init/demo_addon_for_splunk/globalConfig.json
@@ -3,7 +3,7 @@
         "configuration": {
             "tabs": [
                 {
-                    "name": "account",
+                    "name": "endpoint",
                     "table": {
                         "actions": [
                             "edit",
@@ -24,7 +24,7 @@
                             "validators": [
                                 {
                                     "type": "regex",
-                                    "errorMsg": "Account Name must begin with a letter and consist exclusively of alphanumeric characters and underscores.",
+                                    "errorMsg": "Endpoint Name must begin with a letter and consist exclusively of alphanumeric characters and underscores.",
                                     "pattern": "^[a-zA-Z]\\w*$"
                                 },
                                 {
@@ -35,19 +35,19 @@
                                 }
                             ],
                             "field": "name",
-                            "help": "A unique name for the account.",
+                            "help": "A unique name for the endpoint.",
                             "required": true
                         },
                         {
                             "type": "text",
-                            "label": "API key",
-                            "field": "api_key",
-                            "help": "API key",
+                            "label": "URI",
+                            "field": "uri",
+                            "help": "URI",
                             "required": true,
-                            "encrypted": true
+                            "encrypted": false
                         }
                     ],
-                    "title": "Accounts"
+                    "title": "Endpoints"
                 },
                 {
                     "name": "logging",
@@ -132,12 +132,31 @@
                         },
                         {
                             "type": "singleSelect",
-                            "label": "Account to use",
+                            "label": "Endpoint to use",
                             "options": {
-                                "referenceName": "account"
+                                "referenceName": "endpoint"
                             },
-                            "help": "Account to use for this input.",
-                            "field": "account",
+                            "help": "Endpoint to use for this input.",
+                            "field": "endpoint",
+                            "required": true
+                        },
+                        {
+                            "type": "text",
+                            "label": "Source type",
+                            "validators": [
+                                {
+                                    "type": "regex",
+                                    "errorMsg": "Source type name must begin with a letter and consist exclusively of lowercase alphanumeric characters and colon.",
+                                    "pattern": "^(?!.*:$)[a-z][a-z0-9:]*$"
+                                },
+                                {
+                                    "type": "string",
+                                    "errorMsg": "Length of source type name should be between 1 and 100",
+                                    "minLength": 1,
+                                    "maxLength": 100
+                                }
+                            ],
+                            "field": "sourcetype",
                             "required": true
                         }
                     ],

--- a/tests/testdata/expected_addons/expected_addon_after_init/demo_addon_for_splunk/package/bin/demo_addon_for_splunk_rh_endpoint.py
+++ b/tests/testdata/expected_addons/expected_addon_after_init/demo_addon_for_splunk/package/bin/demo_addon_for_splunk_rh_endpoint.py
@@ -1,0 +1,60 @@
+
+import import_declare_test
+
+from demo_addon_for_splunk_utils import Validator
+from splunktaucclib.rest_handler.endpoint import (
+    field,
+    validator,
+    RestModel,
+    SingleModel,
+)
+from splunktaucclib.rest_handler import admin_external, util
+from splunktaucclib.rest_handler.admin_external import AdminExternalHandler
+import logging
+
+util.remove_http_proxy_env_vars()
+
+
+fields = [
+    field.RestField(
+        'uri',
+        required=True,
+        encrypted=False,
+        default=None,
+        validator=None
+    )
+]
+model = RestModel(fields, name=None)
+
+
+endpoint = SingleModel(
+    'demo_addon_for_splunk_endpoint',
+    model,
+    config_name='endpoint'
+)
+
+class demo_addon_for_splunkExternalHandler(AdminExternalHandler):
+    def __init__(self, *args, **kwargs):
+        AdminExternalHandler.__init__(self, *args, **kwargs)
+
+    def handleEdit(self, confInfo):
+        Validator(session_key=self.getSessionKey()).validate(
+            uri=self.payload.get("uri")
+        )
+        AdminExternalHandler.handleEdit(self, confInfo)
+
+    def handleCreate(self, confInfo):
+        Validator(session_key=self.getSessionKey()).validate(
+            uri=self.payload.get("uri")
+        )
+        AdminExternalHandler.handleCreate(self, confInfo)
+
+    def handleRemove(self, confInfo):
+        AdminExternalHandler.handleRemove(self, confInfo)
+
+if __name__ == '__main__':
+    logging.getLogger().addHandler(logging.NullHandler())
+    admin_external.handle(
+        endpoint,
+        handler=demo_addon_for_splunkExternalHandler,
+    )

--- a/tests/testdata/expected_addons/expected_addon_after_init/demo_addon_for_splunk/package/bin/demo_addon_for_splunk_utils.py
+++ b/tests/testdata/expected_addons/expected_addon_after_init/demo_addon_for_splunk/package/bin/demo_addon_for_splunk_utils.py
@@ -1,0 +1,71 @@
+#
+# SPDX-FileCopyrightText: 2021 Splunk, Inc. <sales@splunk.com>
+# SPDX-License-Identifier: LicenseRef-Splunk-8-2021
+#
+#
+import logging
+import traceback
+import requests
+from requests import Response
+
+from splunktaucclib.rest_handler.error import RestError
+from solnlib import conf_manager, log
+
+ADDON_NAME = "demo_addon_for_splunk"
+
+def set_logger(session_key, filename):
+    """
+    This function sets up a logger with configured log level.
+    :param filename: Name of the log file
+    :return logger: logger object
+    """
+    logger = log.Logs().get_logger(filename)
+    log_level = conf_manager.get_log_level(
+        logger=logger,
+        session_key=session_key,
+        app_name=ADDON_NAME,
+        conf_name=f"{ADDON_NAME.lower()}_settings",
+    )
+    logger.setLevel(log_level)
+    return logger
+
+def set_logger_for_input(session_key, input_name) -> logging.Logger:
+    return set_logger(session_key, f"{ADDON_NAME.lower()}_{input_name}")
+
+class Connect:
+    def __init__(self, *, logger) -> None:
+        self.logger = logger
+
+    @staticmethod
+    def status_code(response: Response) -> int:
+        return response.status_code if response and response.status_code else 400
+
+    def get(
+        self,
+        *,
+        uri,
+    ):
+        try:
+            r = requests.get(uri)
+            if r:
+                self.logger.debug(f"Successfully get {uri}")
+                return r
+            else:
+                msg = f"Failed to get {uri}"
+                self.logger.warning(msg + traceback.format_exc())
+                raise RestError(Connect.status_code(r), msg)
+        except Exception:
+            msg = f"Failed to connect to {uri} and get data"
+            self.logger.error(msg + traceback.format_exc())
+            raise RestError(400, msg)
+
+class Validator:
+    def __init__(self, *, session_key) -> None:
+        self.connect = Connect(
+            logger=set_logger(session_key, ADDON_NAME.lower())
+        )
+
+    def validate(self, *, uri):
+        self.connect.get(
+            uri=uri,
+        )

--- a/tests/testdata/expected_addons/expected_addon_after_init/demo_addon_for_splunk/package/bin/demo_input.py
+++ b/tests/testdata/expected_addons/expected_addon_after_init/demo_addon_for_splunk/package/bin/demo_input.py
@@ -7,35 +7,20 @@ import import_declare_test
 from solnlib import conf_manager, log
 from splunklib import modularinput as smi
 
-ADDON_NAME = "demo_addon_for_splunk"
+from demo_addon_for_splunk_utils import ADDON_NAME, Connect, set_logger_for_input
 
-
-def logger_for_input(input_name: str) -> logging.Logger:
-    return log.Logs().get_logger(f"{ADDON_NAME.lower()}_{input_name}")
-
-
-def get_account_api_key(session_key: str, account_name: str):
+def get_endpoint_uri(session_key: str, endpoint_name: str):
     cfm = conf_manager.ConfManager(
         session_key,
         ADDON_NAME,
-        realm=f"__REST_CREDENTIAL__#{ADDON_NAME}#configs/conf-demo_addon_for_splunk_account",
+        realm=f"__REST_CREDENTIAL__#{ADDON_NAME}#configs/conf-demo_addon_for_splunk_endpoint",
     )
-    account_conf_file = cfm.get_conf("demo_addon_for_splunk_account")
-    return account_conf_file.get(account_name).get("api_key")
+    endpoint_conf_file = cfm.get_conf("demo_addon_for_splunk_endpoint")
+    return endpoint_conf_file.get(endpoint_name).get("uri")
 
-
-def get_data_from_api(logger: logging.Logger, api_key: str):
-    logger.info("Getting data from an external API")
-    dummy_data = [
-        {
-            "line1": "hello",
-        },
-        {
-            "line2": "world",
-        },
-    ]
-    return dummy_data
-
+def get_data(logger: logging.Logger, uri: str):
+    logger.info(f"Getting data from an external URI {uri}")
+    return Connect(logger=logger).get(uri=uri)
 
 class Input(smi.Script):
     def __init__(self):
@@ -58,44 +43,34 @@ class Input(smi.Script):
         return
 
     def stream_events(self, inputs: smi.InputDefinition, event_writer: smi.EventWriter):
-        # inputs.inputs is a Python dictionary object like:
-        # {
-        #   "demo_input://<input_name>": {
-        #     "account": "<account_name>",
-        #     "disabled": "0",
-        #     "host": "$decideOnStartup",
-        #     "index": "<index_name>",
-        #     "interval": "<interval_value>",
-        #     "python.version": "python3",
-        #   },
-        # }
         for input_name, input_item in inputs.inputs.items():
             normalized_input_name = input_name.split("/")[-1]
-            logger = logger_for_input(normalized_input_name)
             try:
                 session_key = self._input_definition.metadata["session_key"]
-                log_level = conf_manager.get_log_level(
-                    logger=logger,
-                    session_key=session_key,
-                    app_name=ADDON_NAME,
-                    conf_name=f"{ADDON_NAME}_settings",
-                )
-                logger.setLevel(log_level)
+                logger = set_logger_for_input(session_key, normalized_input_name)
                 log.modular_input_start(logger, normalized_input_name)
-                api_key = get_account_api_key(session_key, input_item.get("account"))
-                data = get_data_from_api(logger, api_key)
-                sourcetype = "dummy-data"
-                for line in data:
+                uri = get_endpoint_uri(session_key, input_item.get("endpoint"))
+                response = get_data(logger, uri)
+                data=json.dumps(response.__dict__, ensure_ascii=False, default=str)
+                successul_or_not_successul = "successul" if response.ok else "not successul"
+                log_msg = f"""Request to {uri} was {successul_or_not_successul}
+Response details:
+{data}"""
+                if response.ok:
+                    logger.debug(log_msg)
                     event_writer.write_event(
                         smi.Event(
-                            data=json.dumps(line, ensure_ascii=False, default=str),
+                            data=data,
                             index=input_item.get("index"),
-                            sourcetype=sourcetype,
+                            sourcetype=input_item.get("sourcetype"),
+                            source=uri,
                         )
                     )
-                log.events_ingested(
-                    logger, normalized_input_name, sourcetype, len(data)
-                )
+                    logger.info(
+                        "Data was successfuly indexed"
+                    )
+                else:
+                    logger.error(log_msg)
                 log.modular_input_end(logger, normalized_input_name)
             except Exception as e:
                 logger.error(

--- a/tests/testdata/test_addons/package_global_config_everything/globalConfig.json
+++ b/tests/testdata/test_addons/package_global_config_everything/globalConfig.json
@@ -1291,7 +1291,7 @@
     "meta": {
         "name": "Splunk_TA_UCCExample",
         "restRoot": "splunk_ta_uccexample",
-        "version": "5.31.1Rdd3a1ca0",
+        "version": "5.32.0R3714f637",
         "displayName": "Splunk UCC test Add-on",
         "schemaVersion": "0.0.3"
     }


### PR DESCRIPTION
Modify ucc-gen init, to have default, out of the box, TA that allows to request given uri and index returned response. There is validation added for configuration that checks if given address exists and is available. Validation results are logged (available in Splunk internal index).