### PR TITLE
ci: returntocorp -> semgrep

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -59,7 +59,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - id: semgrep
-        uses: returntocorp/semgrep-action@v1
+        uses: semgrep/semgrep-action@v1
         with:
           publishToken: ${{ secrets.SEMGREP_PUBLISH_TOKEN }}
 


### PR DESCRIPTION
`returntocorp` organization name was changed to `semgrep`.