### PR TITLE
chore(storybook): ADDON-65440 add theme switcher

### DIFF
--- a/ui/.storybook/preview.tsx
+++ b/ui/.storybook/preview.tsx
@@ -1,14 +1,8 @@
 import type { Preview } from '@storybook/react';
 import { initialize, mswDecorator, mswLoader } from 'msw-storybook-addon';
-import { SplunkThemeProvider } from '@splunk/themes';
-import { Suspense } from 'react';
-import { BrowserRouter as Router } from 'react-router-dom';
-import { StyledContainer, ThemeProviderSettings } from '../src/pages/EntryPageStyle';
-import { WaitSpinnerWrapper } from '../src/components/table/CustomTableStyle';
-
-import React from 'react';
 import { serverHandlers } from '../src/mocks/server-handlers';
 import { rest } from 'msw';
+import { withSplunkThemeToolbar } from './withSplunkTheme';
 
 // Initialize MSW
 initialize({
@@ -26,6 +20,9 @@ const preview: Preview = {
     parameters: {
         actions: { argTypesRegex: '^handle.*' },
         loaders: [mswLoader],
+        backgrounds: {
+            disable: true,
+        },
         msw: {
             handlers: [
                 ...serverHandlers,
@@ -39,23 +36,67 @@ const preview: Preview = {
                 ),
             ],
         },
+        controls: {
+            sort: 'requiredFirst',
+        },
     },
-    decorators: [
-        (story) => (
-            <SplunkThemeProvider // nosemgrep: typescript.react.best-practice.react-props-spreading.react-props-spreading
-                {...ThemeProviderSettings}
-            >
-                <StyledContainer>
-                    <Router>
-                        <Suspense fallback={<WaitSpinnerWrapper size="medium" />}>
-                            {story()}
-                        </Suspense>
-                    </Router>
-                </StyledContainer>
-            </SplunkThemeProvider>
-        ),
-        mswDecorator,
-    ],
+    decorators: [withSplunkThemeToolbar, mswDecorator],
+};
+
+export const globalTypes: Preview['globalTypes'] = {
+    family: {
+        name: 'Family',
+        description: 'Family',
+        defaultValue: 'enterprise',
+        toolbar: {
+            icon: 'circlehollow',
+            type: 'return',
+            items: [
+                { value: 'enterprise', icon: 'circlehollow', title: 'Enterprise' },
+                { value: 'prisma', icon: 'circle', title: 'Prisma' },
+            ],
+            showName: true,
+            dynamicTitle: true,
+        },
+    },
+    colorScheme: {
+        name: 'Color Scheme',
+        description: 'Color Scheme',
+        defaultValue: 'light',
+        toolbar: {
+            items: [
+                { value: 'light', left: 'left', icon: 'sun', title: 'Light' },
+                { value: 'dark', icon: 'moon', title: 'Dark' },
+            ],
+            showName: true,
+            dynamicTitle: true,
+        },
+    },
+    density: {
+        name: 'Density',
+        description: 'Density',
+        defaultValue: 'comfortable',
+        toolbar: {
+            items: [
+                { value: 'comfortable', icon: 'grid', title: 'Comfortable' },
+                { value: 'compact', icon: 'component', title: 'Compact' },
+            ],
+            dynamicTitle: true,
+        },
+    },
+    animation: {
+        name: 'Animation',
+        description: 'Animation',
+        defaultValue: true,
+        toolbar: {
+            icon: 'circlehollow',
+            items: [
+                { value: true, title: 'Animation on' },
+                { value: false, title: 'Animation off' },
+            ],
+            dynamicTitle: true,
+        },
+    },
 };
 
 export default preview;

--- a/ui/.storybook/withSplunkTheme.tsx
+++ b/ui/.storybook/withSplunkTheme.tsx
@@ -1,0 +1,47 @@
+import styled from 'styled-components';
+import variables from '@splunk/themes/variables';
+import { PartialStoryFn as StoryFunction, Renderer, StoryContext } from '@storybook/types';
+import { AnimationToggleProvider } from '@splunk/react-ui/AnimationToggle';
+import { SplunkThemeProvider } from '@splunk/themes';
+import { BrowserRouter as Router } from 'react-router-dom';
+import React, { Suspense } from 'react';
+import { StyledContainer } from '../src/pages/EntryPageStyle';
+import { WaitSpinnerWrapper } from '../src/components/table/CustomTableStyle';
+
+// https://storybook.js.org/blog/how-to-add-a-theme-switcher-to-storybook/
+// syncing storybook preview background with selected theme
+const BackgroundBlock = styled.div`
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    width: 100vw;
+    height: 100vh;
+    bottom: 0;
+    overflow: auto;
+    padding: 1rem;
+    background-color: ${variables.backgroundColorPage};
+`;
+
+export const withSplunkThemeToolbar = <TRenderer extends Renderer>(
+    StoryFn: StoryFunction<TRenderer>,
+    { globals }: StoryContext<TRenderer>
+) => {
+    // vars from globalTypes of preview.tsx
+    const { colorScheme, density, family, animation } = globals;
+    return (
+        <AnimationToggleProvider enabled={animation}>
+            <SplunkThemeProvider family={family} density={density} colorScheme={colorScheme}>
+                <BackgroundBlock>
+                    <StyledContainer>
+                        <Router>
+                            <Suspense fallback={<WaitSpinnerWrapper size="medium" />}>
+                                {StoryFn()}
+                            </Suspense>
+                        </Router>
+                    </StyledContainer>
+                </BackgroundBlock>
+            </SplunkThemeProvider>
+        </AnimationToggleProvider>
+    );
+};


### PR DESCRIPTION
SUI Storybook addon does not work with Storybook v7, so I created toolbar controls to control theme options. It is dropdowns, I tried but could not manage to make toggle. Seems like it is feasible only with addon (which I don't want to create).

I took parameters from [SUI docs](https://splunkui.splunk.com/Packages/react-ui). There is a settings icon in the right top corner to control theme variables.

<img width="840" alt="image" src="https://github.com/splunk/addonfactory-ucc-generator/assets/142901247/a55acdc6-08b1-4898-9ae8-355d5c843db1">
<img width="802" alt="image" src="https://github.com/splunk/addonfactory-ucc-generator/assets/142901247/84d0d015-0ad8-4199-93e5-d3976dee1575">
