### PR TITLE
chore(yarn): set npmjs.com as default registry

### DIFF
--- a/ui/.yarnrc.yml
+++ b/ui/.yarnrc.yml
@@ -1,0 +1,1 @@
+npmRegistryServer: "https://registry.npmjs.com"


### PR DESCRIPTION
fixes changes registry across for the whole yarn.lock by renovate. Renovate bot works correctly since it yarnpkg.com is a default registry for yarn. Source: https://yarnpkg.com/configuration/yarnrc#npmRegistryServer

for example in #893