### PR TITLE
fix: revert to static width of modal

### DIFF
--- a/ui/src/components/ControlWrapper.tsx
+++ b/ui/src/components/ControlWrapper.tsx
@@ -5,32 +5,11 @@ import styled from 'styled-components';
 import MarkdownMessage from './MarkdownMessage';
 import CONTROL_TYPE_MAP, { ComponentTypes } from '../constants/ControlTypeMap';
 
-const CustomElement = styled.div`
-    padding-left: 10px;
-`;
+const CustomElement = styled.div``;
 
-/* 
-    1st child is title, 3rd is help message
-    their width is fixed to not increase size of modal 
-    or page unintentionally due to long text
- */
 const ControlGroupWrapper = styled(ControlGroup).attrs((props: { dataName: string }) => ({
     'data-name': props.dataName,
 }))`
-    width: 100%;
-    max-width: 100%;
-    padding: 0 30px;
-
-    > * {
-        &:first-child {
-            width: 240px !important;
-        }
-        &:nth-child(3) {
-            margin-left: 250px !important;
-            width: 320px;
-        }
-    }
-
     span[class*='ControlGroupStyles__StyledAsterisk-'] {
         color: red;
     }
@@ -163,6 +142,7 @@ class ControlWrapper extends React.PureComponent<ControlWrapperProps> {
                     // @ts-ignore property should be data-name, but is mapped in obj ControlGroupWrapper
                     dataName={field}
                     required={required}
+                    labelWidth={240}
                 >
                     <CustomElement>{rowView}</CustomElement>
                 </ControlGroupWrapper>

--- a/ui/src/components/EntityModal.tsx
+++ b/ui/src/components/EntityModal.tsx
@@ -9,7 +9,7 @@ import { StyledButton } from '../pages/EntryPageStyle';
 import BaseFormView from './BaseFormView';
 
 const ModalWrapper = styled(Modal)`
-    width: fit-content;
+    width: 800px;
 `;
 
 interface EntityModalProps {

--- a/ui/src/components/EntityPage.tsx
+++ b/ui/src/components/EntityPage.tsx
@@ -83,7 +83,7 @@ function EntityPage({
             </ColumnLayout.Row>
             <ColumnLayout.Row>
                 <ColumnLayout.Column span={2} />
-                <ColumnLayout.Column span={8} style={{ maxWidth: 'fit-content' }}>
+                <ColumnLayout.Column span={8} style={{ maxWidth: '800px' }}>
                     <ShadowedDiv>
                         <Heading style={{ paddingLeft: '30px' }} level={3}>
                             {_(formLabel)}


### PR DESCRIPTION
reverting the dynamic width of model, and moving to static width of 800px,
when the size is dynamic the model content is moved to right.

removing other styles as 
they can be replace with `labelWidth={240}`

dynamic current view: 
![Screenshot 2023-11-17 at 18 32 05](https://github.com/splunk/addonfactory-ucc-generator/assets/143183665/8367c7f1-3d04-4710-a1c8-3f32a44b87b2)
![Screenshot 2023-11-17 at 18 31 41](https://github.com/splunk/addonfactory-ucc-generator/assets/143183665/2e88ef33-92a8-4027-bf70-95a80b568047)

static new new/old view 800px: 
![Screenshot 2023-11-17 at 18 35 11](https://github.com/splunk/addonfactory-ucc-generator/assets/143183665/f6aea0b1-1689-4b21-a089-06ef155f3a69)
![Screenshot 2023-11-17 at 18 35 00](https://github.com/splunk/addonfactory-ucc-generator/assets/143183665/d600644a-72d6-4de4-8292-24e96290ce5f)
