### PR TITLE
fix: fix enable for entities and add it for oauth

### DIFF
--- a/docs/advanced/oauth_support.md
+++ b/docs/advanced/oauth_support.md
@@ -32,6 +32,7 @@ Auth can be used inside the entity tag. Use `type: "oauth"` in the entity list a
         - `help` : This can be changed if user wants to change the help text displayed below field.
         - `encrypted` : This should be true if user wants that particular field encrypted else no need to have this parameter.
         - `required`: To specify whether the field is required or not. The default value is true.
+        - `defaultValue`: The initial input value. (string, number or boolean)
         - `options`:
             - `placeholder`: The placeholder for the field.
             - `disableonEdit`: When the form is in edit mode, the field becomes uneditable. Default value: false

--- a/docs/advanced/oauth_support.md
+++ b/docs/advanced/oauth_support.md
@@ -35,6 +35,7 @@ Auth can be used inside the entity tag. Use `type: "oauth"` in the entity list a
         - `options`:
             - `placeholder`: The placeholder for the field.
             - `disableonEdit`: When the form is in edit mode, the field becomes uneditable. Default value: false
+            - `enable`: The enable property sets whether a field is enabled, or not. Default value: true
 
 
 > [!WARNING]

--- a/docs/advanced/oauth_support.md
+++ b/docs/advanced/oauth_support.md
@@ -35,7 +35,7 @@ Auth can be used inside the entity tag. Use `type: "oauth"` in the entity list a
         - `options`:
             - `placeholder`: The placeholder for the field.
             - `disableonEdit`: When the form is in edit mode, the field becomes uneditable. Default value: false
-            - `enable`: The enable property sets whether a field is enabled, or not. Default value: true
+            - `enable`: The enable property sets whether a field is enabled or not. Default value: true
 
 
 > [!WARNING]

--- a/ui/src/components/BaseFormView.jsx
+++ b/ui/src/components/BaseFormView.jsx
@@ -193,15 +193,13 @@ class BaseFormView extends PureComponent {
                                         : true;
                                 tempEntity.error = false;
 
-                                tempEntity.disabled =
-                                    typeof field?.options?.enable !== 'undefined' &&
-                                    !field.options.enable;
+                                tempEntity.disabled = !field.options.enable === false;
 
                                 if (props.mode === MODE_EDIT) {
+                                    // .disableonEdit = false do not overwrite .disabled = true
                                     tempEntity.disabled =
-                                        typeof field?.options?.disableonEdit !== 'undefined'
-                                            ? field?.options?.disableonEdit
-                                            : tempEntity.disabled;
+                                        field?.options?.disableonEdit === true ||
+                                        tempEntity.disabled;
                                 }
 
                                 temState[field.field] = tempEntity;
@@ -270,8 +268,7 @@ class BaseFormView extends PureComponent {
                     tempEntity.display =
                         typeof e?.options?.display !== 'undefined' ? e.options.display : true;
                     tempEntity.error = false;
-                    tempEntity.disabled =
-                        typeof e?.options?.enable !== 'undefined' && !e.options.enable;
+                    tempEntity.disabled = e?.options?.enable === false;
                     temState[e.field] = tempEntity;
                 } else if (props.mode === MODE_EDIT) {
                     tempEntity.value =
@@ -282,8 +279,7 @@ class BaseFormView extends PureComponent {
                     tempEntity.display =
                         typeof e?.options?.display !== 'undefined' ? e.options.display : true;
                     tempEntity.error = false;
-                    tempEntity.disabled =
-                        typeof e?.options?.enable !== 'undefined' && !e.options.enable;
+                    tempEntity.disabled = e?.options?.enable === false;
                     if (e.field === 'name') {
                         tempEntity.disabled = true;
                     } else if (typeof e?.options?.disableonEdit !== 'undefined') {
@@ -296,8 +292,7 @@ class BaseFormView extends PureComponent {
                     tempEntity.display =
                         typeof e?.options?.display !== 'undefined' ? e.options.display : true;
                     tempEntity.error = false;
-                    tempEntity.disabled =
-                        typeof e?.options?.enable !== 'undefined' && !e.options.enable;
+                    tempEntity.disabled = e?.options?.enable === false;
                     temState[e.field] = tempEntity;
                 } else if (props.mode === MODE_CONFIG) {
                     e.defaultValue = typeof e.defaultValue !== 'undefined' ? e.defaultValue : null;
@@ -309,8 +304,7 @@ class BaseFormView extends PureComponent {
                     tempEntity.display =
                         typeof e?.options?.display !== 'undefined' ? e.options.display : true;
                     tempEntity.error = false;
-                    tempEntity.disabled =
-                        typeof e?.options?.enable !== 'undefined' && !e.options.enable;
+                    tempEntity.disabled = e?.options?.enable === false;
                     if (e.field === 'name') {
                         tempEntity.disabled = true;
                     } else if (typeof e?.options?.disableonEdit !== 'undefined') {

--- a/ui/src/components/BaseFormView.jsx
+++ b/ui/src/components/BaseFormView.jsx
@@ -192,10 +192,16 @@ class BaseFormView extends PureComponent {
                                         ? type === temState.auth_type.value
                                         : true;
                                 tempEntity.error = false;
-                                tempEntity.disabled = false;
+
+                                tempEntity.disabled =
+                                    typeof field?.options?.enable !== 'undefined' &&
+                                    !field.options.enable;
 
                                 if (props.mode === MODE_EDIT) {
-                                    tempEntity.disabled = field?.options?.disableonEdit || false;
+                                    tempEntity.disabled =
+                                        typeof field?.options?.disableonEdit !== 'undefined'
+                                            ? field?.options?.disableonEdit
+                                            : tempEntity.disabled;
                                 }
 
                                 temState[field.field] = tempEntity;
@@ -264,7 +270,8 @@ class BaseFormView extends PureComponent {
                     tempEntity.display =
                         typeof e?.options?.display !== 'undefined' ? e.options.display : true;
                     tempEntity.error = false;
-                    tempEntity.disabled = false;
+                    tempEntity.disabled =
+                        typeof e?.options?.enable !== 'undefined' && !e.options.enable;
                     temState[e.field] = tempEntity;
                 } else if (props.mode === MODE_EDIT) {
                     tempEntity.value =
@@ -275,7 +282,8 @@ class BaseFormView extends PureComponent {
                     tempEntity.display =
                         typeof e?.options?.display !== 'undefined' ? e.options.display : true;
                     tempEntity.error = false;
-                    tempEntity.disabled = false;
+                    tempEntity.disabled =
+                        typeof e?.options?.enable !== 'undefined' && !e.options.enable;
                     if (e.field === 'name') {
                         tempEntity.disabled = true;
                     } else if (typeof e?.options?.disableonEdit !== 'undefined') {
@@ -288,7 +296,8 @@ class BaseFormView extends PureComponent {
                     tempEntity.display =
                         typeof e?.options?.display !== 'undefined' ? e.options.display : true;
                     tempEntity.error = false;
-                    tempEntity.disabled = false;
+                    tempEntity.disabled =
+                        typeof e?.options?.enable !== 'undefined' && !e.options.enable;
                     temState[e.field] = tempEntity;
                 } else if (props.mode === MODE_CONFIG) {
                     e.defaultValue = typeof e.defaultValue !== 'undefined' ? e.defaultValue : null;
@@ -300,7 +309,8 @@ class BaseFormView extends PureComponent {
                     tempEntity.display =
                         typeof e?.options?.display !== 'undefined' ? e.options.display : true;
                     tempEntity.error = false;
-                    tempEntity.disabled = false;
+                    tempEntity.disabled =
+                        typeof e?.options?.enable !== 'undefined' && !e.options.enable;
                     if (e.field === 'name') {
                         tempEntity.disabled = true;
                     } else if (typeof e?.options?.disableonEdit !== 'undefined') {

--- a/ui/src/components/BaseFormView.jsx
+++ b/ui/src/components/BaseFormView.jsx
@@ -193,7 +193,7 @@ class BaseFormView extends PureComponent {
                                         : true;
                                 tempEntity.error = false;
 
-                                tempEntity.disabled = field.options.enable === false;
+                                tempEntity.disabled = field?.options?.enable === false;
 
                                 if (props.mode === MODE_EDIT) {
                                     // .disableonEdit = false do not overwrite .disabled = true

--- a/ui/src/components/BaseFormView.jsx
+++ b/ui/src/components/BaseFormView.jsx
@@ -193,7 +193,7 @@ class BaseFormView extends PureComponent {
                                         : true;
                                 tempEntity.error = false;
 
-                                tempEntity.disabled = !field.options.enable === false;
+                                tempEntity.disabled = field.options.enable === false;
 
                                 if (props.mode === MODE_EDIT) {
                                     // .disableonEdit = false do not overwrite .disabled = true

--- a/ui/src/components/EntityModal/EntityModal.test.tsx
+++ b/ui/src/components/EntityModal/EntityModal.test.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event';
 import EntityModal, { EntityModalProps } from './EntityModal';
 import { setUnifiedConfig } from '../../util/util';
 import {
+    DEFAULT_VALUE,
     getConfigAccerssTokenMock,
     getConfigBasicOauthDisableonEdit,
     getConfigEnableFalseForOauth,
@@ -50,7 +51,7 @@ describe('Oauth field disabled on edit - diableonEdit property', () => {
         renderModalWithProps(props);
         const oauthTextBox = getDisabledOauthField();
         expect(oauthTextBox).toBeInTheDocument();
-        expect(oauthTextBox?.getAttribute('disabled')).toBeNull();
+        expect(oauthTextBox).not.toHaveAttribute('disabled');
     });
 
     it('Oauth Oauth - test if oauth field disabled on edit after disableonEdit', async () => {
@@ -70,10 +71,10 @@ describe('Oauth field disabled on edit - diableonEdit property', () => {
 
         const oauthTextBox = getDisabledOauthField();
         expect(oauthTextBox).toBeInTheDocument();
-        expect(oauthTextBox?.getAttribute('disabled')).toBe('');
+        expect(oauthTextBox).not.toHaveAttribute('disabled');
     });
 
-    it('test if oauth field disabled on edit after disableonEdit true', async () => {
+    it('Oauth Basic - Enable field equal false, so field disabled', async () => {
         setUpConfigWithDisabedBasicOauth();
         const props = {
             serviceName: 'account',
@@ -90,7 +91,7 @@ describe('Oauth field disabled on edit - diableonEdit property', () => {
 
         const oauthTextBox = getDisabledBasicField();
         expect(oauthTextBox).toBeInTheDocument();
-        expect(oauthTextBox?.getAttribute('disabled')).toBe('');
+        expect(oauthTextBox).toHaveAttribute('disabled');
     });
 
     it('if oauth field not disabled with create after disableonEdit true', async () => {
@@ -108,7 +109,7 @@ describe('Oauth field disabled on edit - diableonEdit property', () => {
         renderModalWithProps(props);
         const oauthTextBox = getDisabledBasicField();
         expect(oauthTextBox).toBeInTheDocument();
-        expect(oauthTextBox?.getAttribute('disabled')).toBeNull();
+        expect(oauthTextBox).not.toHaveAttribute('disabled');
     });
 });
 
@@ -188,7 +189,7 @@ describe('Options - Enable field property', () => {
         renderModalWithProps(props);
         const oauthTextBox = getDisabledOauthField();
         expect(oauthTextBox).toBeInTheDocument();
-        expect(oauthTextBox?.getAttribute('disabled')).toBeNull();
+        expect(oauthTextBox).not.toHaveAttribute('disabled');
     });
 });
 
@@ -252,5 +253,35 @@ describe('EntityModal - auth_endpoint_token_access_type', () => {
         // we return only { closed: true } and do not trigger message on window obj
         const errorMessage = screen.getByText(ERROR_AUTH_PROCESS_TERMINATED_TRY_AGAIN);
         expect(errorMessage).toBeInTheDocument();
+    });
+});
+
+describe('Default value', () => {
+    const handleRequestClose = jest.fn();
+    const setUpConfigWithDefaultValue = () => {
+        const newConfig = getConfigWithOauthDefaultValue();
+        setUnifiedConfig(newConfig);
+    };
+
+    const renderModalWithProps = (props: EntityModalProps) => {
+        render(<EntityModal {...props} handleRequestClose={handleRequestClose} />);
+    };
+
+    it('render modal with correct default value', async () => {
+        setUpConfigWithDefaultValue();
+        const props = {
+            serviceName: 'account',
+            mode: 'create',
+            stanzaName: undefined,
+            formLabel: 'formLabel',
+            page: 'configuration',
+            groupName: '',
+            open: true,
+            handleRequestClose: () => {},
+        } satisfies EntityModalProps;
+        renderModalWithProps(props);
+        const component = screen.getByRole('textbox');
+        expect(component).toBeInTheDocument();
+        expect(component).toHaveValue(DEFAULT_VALUE);
     });
 });

--- a/ui/src/components/EntityModal/EntityModal.test.tsx
+++ b/ui/src/components/EntityModal/EntityModal.test.tsx
@@ -153,7 +153,7 @@ describe('Options - Enable field property', () => {
         renderModalWithProps(props);
         const oauthTextBox = getDisabledOauthField();
         expect(oauthTextBox).toBeInTheDocument();
-        expect(oauthTextBox?.getAttribute('disabled')).toBe('');
+        expect(oauthTextBox).toHaveAttribute('disabled');
     });
 
     it('Oauth Basic - Enable field equal false, so field disabled', async () => {
@@ -171,7 +171,7 @@ describe('Options - Enable field property', () => {
         renderModalWithProps(props);
         const oauthTextBox = getDisabledOauthField();
         expect(oauthTextBox).toBeInTheDocument();
-        expect(oauthTextBox?.getAttribute('disabled')).toBe('');
+        expect(oauthTextBox).toHaveAttribute('disabled');
     });
 
     it('Oauth Basic - Fully enabled field, enabled: true, disableonEdit: false', async () => {

--- a/ui/src/components/EntityModal/EntityModal.test.tsx
+++ b/ui/src/components/EntityModal/EntityModal.test.tsx
@@ -36,7 +36,7 @@ describe('Oauth field disabled on edit - diableonEdit property', () => {
     const getDisabledBasicField = () =>
         document.getElementsByClassName('basic_oauth_text_jest_test')[1];
 
-    it('Oauth Oauth - test if oauth field not disabled on create after disableonEdit', async () => {
+    it('Oauth Oauth - disableonEdit = true, oauth field not disabled on create', async () => {
         setUpConfigWithDisabedOauth();
         const props = {
             serviceName: 'account',
@@ -54,7 +54,7 @@ describe('Oauth field disabled on edit - diableonEdit property', () => {
         expect(oauthTextBox).not.toHaveAttribute('disabled');
     });
 
-    it('Oauth Oauth - test if oauth field disabled on edit after disableonEdit', async () => {
+    it('Oauth Oauth - disableonEdit = true, oauth field disabled on edit', async () => {
         setUpConfigWithDisabedOauth();
         const props = {
             serviceName: 'account',
@@ -71,7 +71,7 @@ describe('Oauth field disabled on edit - diableonEdit property', () => {
 
         const oauthTextBox = getDisabledOauthField();
         expect(oauthTextBox).toBeInTheDocument();
-        expect(oauthTextBox).not.toHaveAttribute('disabled');
+        expect(oauthTextBox).toHaveAttribute('disabled');
     });
 
     it('Oauth Basic - Enable field equal false, so field disabled', async () => {

--- a/ui/src/components/EntityModal/EntityModal.test.tsx
+++ b/ui/src/components/EntityModal/EntityModal.test.tsx
@@ -6,12 +6,19 @@ import { setUnifiedConfig } from '../../util/util';
 import {
     getConfigAccerssTokenMock,
     getConfigBasicOauthDisableonEdit,
+    getConfigEnableFalseForOauth,
+    getConfigFullyEnabledField,
     getConfigOauthOauthDisableonEdit,
 } from './TestConfig';
 import { ERROR_AUTH_PROCESS_TERMINATED_TRY_AGAIN } from '../../constants/oAuthErrorMessage';
 
-describe('EntityModal - Basic oauth', () => {
+describe('Oauth field disabled on edit - diableonEdit property', () => {
     const handleRequestClose = jest.fn();
+
+    const setUpConfigWithDisabedOauth = () => {
+        const newConfig = getConfigOauthOauthDisableonEdit();
+        setUnifiedConfig(newConfig);
+    };
 
     const setUpConfigWithDisabedBasicOauth = () => {
         setUnifiedConfig(getConfigBasicOauthDisableonEdit());
@@ -21,62 +28,11 @@ describe('EntityModal - Basic oauth', () => {
         render(<EntityModal {...props} handleRequestClose={handleRequestClose} />);
     };
 
-    const getDisabledBasicField = () =>
-        document.getElementsByClassName('basic_oauth_text_jest_test')[1];
-
-    it('if oauth field not disabled with create after disableonEdit true', async () => {
-        setUpConfigWithDisabedBasicOauth();
-        const props = {
-            serviceName: 'account',
-            mode: 'create',
-            stanzaName: undefined,
-            formLabel: 'formLabel',
-            page: 'configuration',
-            groupName: '',
-            open: true,
-            handleRequestClose: () => {},
-        } satisfies EntityModalProps;
-        renderModalWithProps(props);
-        const oauthTextBox = getDisabledBasicField();
-        expect(oauthTextBox).toBeInTheDocument();
-        expect(oauthTextBox?.getAttribute('disabled')).toBeNull();
-    });
-
-    it('test if oauth field disabled on edit after disableonEdit true', async () => {
-        setUpConfigWithDisabedBasicOauth();
-        const props = {
-            serviceName: 'account',
-            mode: 'edit',
-            stanzaName: undefined,
-            formLabel: 'formLabel',
-            page: 'configuration',
-            groupName: '',
-            open: true,
-            handleRequestClose: () => {},
-        } satisfies EntityModalProps;
-
-        renderModalWithProps(props);
-
-        const oauthTextBox = getDisabledBasicField();
-        expect(oauthTextBox).toBeInTheDocument();
-        expect(oauthTextBox?.getAttribute('disabled')).toBe('');
-    });
-});
-
-describe('EntityModal - Oauth oauth', () => {
-    const handleRequestClose = jest.fn();
-
-    const setUpConfigWithDisabedOauth = () => {
-        const newConfig = getConfigOauthOauthDisableonEdit();
-        setUnifiedConfig(newConfig);
-    };
-
-    const renderModalWithProps = (props: EntityModalProps) => {
-        render(<EntityModal {...props} handleRequestClose={handleRequestClose} />);
-    };
-
     const getDisabledOauthField = () =>
         document.getElementsByClassName('oauth_oauth_text_jest_test')[1];
+
+    const getDisabledBasicField = () =>
+        document.getElementsByClassName('basic_oauth_text_jest_test')[1];
 
     it('Oauth Oauth - test if oauth field not disabled on create after disableonEdit', async () => {
         setUpConfigWithDisabedOauth();
@@ -114,6 +70,124 @@ describe('EntityModal - Oauth oauth', () => {
         const oauthTextBox = getDisabledOauthField();
         expect(oauthTextBox).toBeInTheDocument();
         expect(oauthTextBox?.getAttribute('disabled')).toBe('');
+    });
+
+    it('test if oauth field disabled on edit after disableonEdit true', async () => {
+        setUpConfigWithDisabedBasicOauth();
+        const props = {
+            serviceName: 'account',
+            mode: 'edit',
+            stanzaName: undefined,
+            formLabel: 'formLabel',
+            page: 'configuration',
+            groupName: '',
+            open: true,
+            handleRequestClose: () => {},
+        } satisfies EntityModalProps;
+
+        renderModalWithProps(props);
+
+        const oauthTextBox = getDisabledBasicField();
+        expect(oauthTextBox).toBeInTheDocument();
+        expect(oauthTextBox?.getAttribute('disabled')).toBe('');
+    });
+
+    it('if oauth field not disabled with create after disableonEdit true', async () => {
+        setUpConfigWithDisabedBasicOauth();
+        const props = {
+            serviceName: 'account',
+            mode: 'create',
+            stanzaName: undefined,
+            formLabel: 'formLabel',
+            page: 'configuration',
+            groupName: '',
+            open: true,
+            handleRequestClose: () => {},
+        } satisfies EntityModalProps;
+        renderModalWithProps(props);
+        const oauthTextBox = getDisabledBasicField();
+        expect(oauthTextBox).toBeInTheDocument();
+        expect(oauthTextBox?.getAttribute('disabled')).toBeNull();
+    });
+});
+
+describe('Options - Enable field property', () => {
+    const handleRequestClose = jest.fn();
+
+    const setUpConfigWithDisabledComplitelyOauthField = () => {
+        const newConfig = getConfigEnableFalseForOauth();
+        setUnifiedConfig(newConfig);
+    };
+
+    const setUpConfigWithFullyEnabledField = () => {
+        const newConfig = getConfigFullyEnabledField();
+        setUnifiedConfig(newConfig);
+    };
+
+    const setUpConfigWithDisabledComplitelyOauthBasicField = () => {
+        const newConfig = getConfigEnableFalseForOauth();
+        setUnifiedConfig(newConfig);
+    };
+
+    const renderModalWithProps = (props: EntityModalProps) => {
+        render(<EntityModal {...props} handleRequestClose={handleRequestClose} />);
+    };
+
+    const getDisabledOauthField = () =>
+        document.getElementsByClassName('oauth_oauth_text_jest_test')[1];
+
+    it('Oauth Oauth - Enable field equal false, so field disabled', async () => {
+        setUpConfigWithDisabledComplitelyOauthField();
+        const props = {
+            serviceName: 'account',
+            mode: 'create',
+            stanzaName: undefined,
+            formLabel: 'formLabel',
+            page: 'configuration',
+            groupName: '',
+            open: true,
+            handleRequestClose: () => {},
+        } satisfies EntityModalProps;
+        renderModalWithProps(props);
+        const oauthTextBox = getDisabledOauthField();
+        expect(oauthTextBox).toBeInTheDocument();
+        expect(oauthTextBox?.getAttribute('disabled')).toBe('');
+    });
+
+    it('Oauth Basic - Enable field equal false, so field disabled', async () => {
+        setUpConfigWithDisabledComplitelyOauthBasicField();
+        const props = {
+            serviceName: 'account',
+            mode: 'create',
+            stanzaName: undefined,
+            formLabel: 'formLabel',
+            page: 'configuration',
+            groupName: '',
+            open: true,
+            handleRequestClose: () => {},
+        } satisfies EntityModalProps;
+        renderModalWithProps(props);
+        const oauthTextBox = getDisabledOauthField();
+        expect(oauthTextBox).toBeInTheDocument();
+        expect(oauthTextBox?.getAttribute('disabled')).toBe('');
+    });
+
+    it('Oauth Basic - Fully enabled field, enabled: true, disableonEdit: false', async () => {
+        setUpConfigWithFullyEnabledField();
+        const props = {
+            serviceName: 'account',
+            mode: 'create',
+            stanzaName: undefined,
+            formLabel: 'formLabel',
+            page: 'configuration',
+            groupName: '',
+            open: true,
+            handleRequestClose: () => {},
+        } satisfies EntityModalProps;
+        renderModalWithProps(props);
+        const oauthTextBox = getDisabledOauthField();
+        expect(oauthTextBox).toBeInTheDocument();
+        expect(oauthTextBox?.getAttribute('disabled')).toBeNull();
     });
 });
 

--- a/ui/src/components/EntityModal/EntityModal.test.tsx
+++ b/ui/src/components/EntityModal/EntityModal.test.tsx
@@ -9,6 +9,7 @@ import {
     getConfigEnableFalseForOauth,
     getConfigFullyEnabledField,
     getConfigOauthOauthDisableonEdit,
+    getConfigWithOauthDefaultValue,
 } from './TestConfig';
 import { ERROR_AUTH_PROCESS_TERMINATED_TRY_AGAIN } from '../../constants/oAuthErrorMessage';
 

--- a/ui/src/components/EntityModal/TestConfig.ts
+++ b/ui/src/components/EntityModal/TestConfig.ts
@@ -30,28 +30,8 @@ const entityBasicOauthDisableonEdit = [
         required: true,
         encrypted: false,
         options: {
-            auth_type: ['basic', 'oauth'],
+            auth_type: ['basic'],
             basic: [
-                {
-                    oauth_field: 'username_jest_test',
-                    label: 'Username_jest_test',
-                    help: 'Enter the username for this account.',
-                    field: 'username_jest_test',
-                },
-                {
-                    oauth_field: 'password_jest_test',
-                    label: 'Password',
-                    encrypted: true,
-                    help: 'Enter the password for this account.',
-                    field: 'password_jest_test',
-                },
-                {
-                    oauth_field: 'security_token_jest_test',
-                    label: 'Security Token',
-                    encrypted: true,
-                    help: 'Enter the security token.',
-                    field: 'token_jest_test',
-                },
                 {
                     oauth_field: 'some_text_jest_test',
                     label: 'some_text Token',
@@ -59,6 +39,7 @@ const entityBasicOauthDisableonEdit = [
                     field: 'basic_oauth_text_jest_test',
                     options: {
                         disableonEdit: true,
+                        enable: true,
                     },
                 },
             ],
@@ -84,31 +65,13 @@ const entityOauthOauthDisableonEdit = [
             auth_type: ['oauth'],
             oauth: [
                 {
-                    oauth_field: 'client_id_jest_test',
-                    label: 'Client Id',
-                    field: 'client_id_jest_test',
-                    help: 'Enter the Client Id for this account.',
-                },
-                {
-                    oauth_field: 'client_secret_jest_test',
-                    label: 'Client Secret',
-                    field: 'client_secret_jest_test',
-                    encrypted: true,
-                    help: 'Enter the Client Secret key for this account.',
-                },
-                {
-                    oauth_field: 'redirect_url_jest_test',
-                    label: 'Redirect url',
-                    field: 'redirect_url_jest_test',
-                    help: 'Copy and paste this URL into your app.',
-                },
-                {
                     oauth_field: 'oauth_some_text_jest_test',
                     label: 'oauth some_text Token',
                     help: 'Enter some_text',
                     field: 'oauth_oauth_text_jest_test',
                     options: {
                         disableonEdit: true,
+                        enable: true,
                     },
                 },
             ],
@@ -206,6 +169,212 @@ export const getConfigAccerssTokenMock = () => {
             configuration: {
                 ...globalConfig.pages.configuration,
                 tabs: [{ entity: accessTokenMock, ...defaultTableProps }],
+            },
+        },
+    };
+    return newConfig satisfies z.infer<typeof GlobalConfigSchema>;
+};
+
+const entityEnableFalseForOauthField = [
+    {
+        type: 'oauth',
+        field: 'oauth_jest_test',
+        label: 'Not used',
+        required: true,
+        encrypted: false,
+        options: {
+            auth_type: ['oauth'],
+            oauth: [
+                {
+                    oauth_field: 'oauth_some_text_jest_test',
+                    label: 'oauth some_text Token',
+                    help: 'Enter some_text',
+                    field: 'oauth_oauth_text_jest_test',
+                    options: {
+                        disableonEdit: false,
+                        enable: false,
+                    },
+                },
+            ],
+            auth_code_endpoint: '/services/oauth2/authorize',
+            access_token_endpoint: '/services/oauth2/token',
+            oauth_timeout: 30,
+            oauth_state_enabled: false,
+            display: true,
+            disableonEdit: false,
+            enable: true,
+        },
+    } satisfies z.infer<typeof OAuthEntity>,
+];
+
+export const getConfigEnableFalseForOauth = () => {
+    const globalConfig = getGlobalConfigMock();
+    const newConfig = {
+        ...globalConfig,
+        pages: {
+            ...globalConfig.pages,
+            configuration: {
+                ...globalConfig.pages.configuration,
+                tabs: [{ entity: entityEnableFalseForOauthField, ...defaultTableProps }],
+            },
+        },
+    };
+    return newConfig satisfies z.infer<typeof GlobalConfigSchema>;
+};
+
+export const getConfigEnableFalseForOauthBasic = () => {
+    const globalConfig = getGlobalConfigMock();
+    const newConfig = {
+        ...globalConfig,
+        pages: {
+            ...globalConfig.pages,
+            configuration: {
+                ...globalConfig.pages.configuration,
+                tabs: [{ entity: entityEnableFalseForOauthField, ...defaultTableProps }],
+            },
+        },
+    };
+    return newConfig satisfies z.infer<typeof GlobalConfigSchema>;
+};
+
+const entityEnableFalseForBasicOauthField = [
+    {
+        type: 'oauth',
+        field: 'oauth_jest_test',
+        label: 'Not used',
+        required: true,
+        encrypted: false,
+        options: {
+            auth_type: ['basic'],
+            basic: [
+                {
+                    oauth_field: 'some_text_jest_test',
+                    label: 'some_text Token',
+                    help: 'Enter some_text',
+                    field: 'basic_oauth_text_jest_test',
+                    options: {
+                        disableonEdit: true,
+                        enable: false,
+                    },
+                },
+            ],
+            auth_code_endpoint: '/services/oauth2/authorize',
+            access_token_endpoint: '/services/oauth2/token',
+            oauth_timeout: 30,
+            oauth_state_enabled: false,
+            display: true,
+            disableonEdit: false,
+            enable: true,
+        },
+    } satisfies z.infer<typeof OAuthEntity>,
+];
+
+export const getConfigEnableTrueForOauthBasic = () => {
+    const globalConfig = getGlobalConfigMock();
+    const newConfig = {
+        ...globalConfig,
+        pages: {
+            ...globalConfig.pages,
+            configuration: {
+                ...globalConfig.pages.configuration,
+                tabs: [{ entity: entityEnableFalseForBasicOauthField, ...defaultTableProps }],
+            },
+        },
+    };
+    return newConfig satisfies z.infer<typeof GlobalConfigSchema>;
+};
+
+const entityBasicOauthFullyEnabledField = [
+    {
+        type: 'oauth',
+        field: 'oauth_jest_test',
+        label: 'Not used',
+        required: true,
+        encrypted: false,
+        options: {
+            auth_type: ['oauth'],
+            oauth: [
+                {
+                    oauth_field: 'some_text_jest_test',
+                    label: 'some_text Token',
+                    help: 'Enter some_text',
+                    field: 'oauth_oauth_text_jest_test',
+                    options: {
+                        disableonEdit: false,
+                        enable: true,
+                    },
+                },
+            ],
+            auth_code_endpoint: '/services/oauth2/authorize',
+            access_token_endpoint: '/services/oauth2/token',
+            oauth_timeout: 30,
+            oauth_state_enabled: false,
+            display: true,
+            disableonEdit: false,
+            enable: true,
+        },
+    } satisfies z.infer<typeof OAuthEntity>,
+];
+
+export const getConfigFullyEnabledField = () => {
+    const globalConfig = getGlobalConfigMock();
+    const newConfig = {
+        ...globalConfig,
+        pages: {
+            ...globalConfig.pages,
+            configuration: {
+                ...globalConfig.pages.configuration,
+                tabs: [{ entity: entityBasicOauthFullyEnabledField, ...defaultTableProps }],
+            },
+        },
+    };
+    return newConfig satisfies z.infer<typeof GlobalConfigSchema>;
+};
+
+export const DEFAULT_VALUE = 'some default value';
+
+const entityBasicOauthDefaultValue = [
+    {
+        type: 'oauth',
+        field: 'oauth_jest_test',
+        label: 'Not used',
+        required: true,
+        encrypted: false,
+        options: {
+            auth_type: ['oauth'],
+            oauth: [
+                {
+                    oauth_field: 'some_text_jest_test',
+                    label: 'some_text Token',
+                    help: 'Enter some_text',
+                    field: 'oauth_oauth_text_jest_test',
+                    defaultValue: DEFAULT_VALUE,
+                    options: {
+                        disableonEdit: false,
+                        enable: true,
+                    },
+                },
+            ],
+            auth_code_endpoint: '/services/oauth2/authorize',
+            access_token_endpoint: '/services/oauth2/token',
+            oauth_timeout: 30,
+            oauth_state_enabled: false,
+            display: true,
+            disableonEdit: false,
+            enable: true,
+        },
+    } satisfies z.infer<typeof OAuthEntity>,
+];
+
+export const getConfigWithOauthDefaultValue = () => {
+    const globalConfig = getGlobalConfigMock();
+    const newConfig = {
+        ...globalConfig,
+        pages: {
+            ...globalConfig.pages,
+            configuration: {
+                ...globalConfig.pages.configuration,
+                tabs: [{ entity: entityBasicOauthDefaultValue, ...defaultTableProps }],
             },
         },
     };

--- a/ui/src/mocks/globalConfigMock.ts
+++ b/ui/src/mocks/globalConfigMock.ts
@@ -137,6 +137,16 @@ const globalConfigMock: z.input<typeof GlobalConfigSchema> = {
                             required: true,
                         },
                         {
+                            type: 'text',
+                            label: 'Disabled Input',
+                            defaultValue: 'Disabled Input',
+                            field: 'disabled_input_field',
+                            help: 'This field should always be disabled',
+                            options: {
+                                enable: false,
+                            },
+                        },
+                        {
                             type: 'singleSelect',
                             label: 'Account to use',
                             options: {

--- a/ui/src/types/globalConfig/entities.ts
+++ b/ui/src/types/globalConfig/entities.ts
@@ -189,6 +189,7 @@ const OAuthFields = z
         options: z.object({
             placeholder: z.string().optional(),
             disableonEdit: z.boolean().optional(),
+            enable: z.boolean().optional().default(true),
         }),
     })
     .partial();

--- a/ui/src/types/globalConfig/entities.ts
+++ b/ui/src/types/globalConfig/entities.ts
@@ -186,6 +186,7 @@ const OAuthFields = z
         help: z.string(),
         encrypted: z.boolean().default(false),
         required: z.boolean().default(false),
+        defaultValue: z.union([z.string(), z.number(), z.boolean()]).optional(),
         options: z.object({
             placeholder: z.string().optional(),
             disableonEdit: z.boolean().optional(),


### PR DESCRIPTION
As a replacement for account_hook.js for repo https://github.com/splunk/splunk-add-on-for-okta-identity-cloud
parent ticket https://splunk.atlassian.net/browse/ADDON-65747

fix for enable property for every entity/field and adding support of it for oauth fields
https://splunk.github.io/addonfactory-ucc-generator/entity/ 

Adding tests for default value in oauth fields, logic existed there it was just not permitted in schema.