### PR TITLE
fix: add control group wrapper max width to 750px

### DIFF
--- a/ui/src/components/ControlWrapper.tsx
+++ b/ui/src/components/ControlWrapper.tsx
@@ -10,9 +10,16 @@ const CustomElement = styled.div``;
 const ControlGroupWrapper = styled(ControlGroup).attrs((props: { dataName: string }) => ({
     'data-name': props.dataName,
 }))`
-    max-width: 750px;
+    max-width: 100%;
+
     span[class*='ControlGroupStyles__StyledAsterisk-'] {
         color: red;
+    }
+
+    > * {
+        &:nth-child(3) {
+            width: 320px;
+        }
     }
 `;
 

--- a/ui/src/components/ControlWrapper.tsx
+++ b/ui/src/components/ControlWrapper.tsx
@@ -10,6 +10,7 @@ const CustomElement = styled.div``;
 const ControlGroupWrapper = styled(ControlGroup).attrs((props: { dataName: string }) => ({
     'data-name': props.dataName,
 }))`
+    max-width: 750px;
     span[class*='ControlGroupStyles__StyledAsterisk-'] {
         color: red;
     }


### PR DESCRIPTION
fixing issue of too small width of component group

![image (1)](https://github.com/splunk/addonfactory-ucc-generator/assets/143183665/1f4210d3-b20c-4114-a698-d14d4f519d35)

setting control group max width to 100%, so component can be as long as parent element, along with limiting help message width to 320px (standard width of component)

![Screenshot 2023-12-05 at 18 00 02](https://github.com/splunk/addonfactory-ucc-generator/assets/143183665/d6acaa41-f6cc-4920-9b87-44913ab8c39b)
