### PR TITLE
fix: add missing colorama dependency

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -177,7 +177,7 @@ jobs:
       - run: curl -sSL https://install.python-poetry.org | python3 - --version 1.5.1
       - run: |
           cp -R built-ui/. splunk_add_on_ucc_framework/package/appserver/static/js/
-          poetry install
+          poetry install --only main
       - run: poetry run ucc-gen build --source tests/testdata/test_addons/package_global_config_everything/package
       - run: ./scripts/include-rum.sh output/Splunk_TA_UCCExample/appserver/templates/base.html scripts/rum-script.html "$RUM_ACCESS_TOKEN"
         env:
@@ -233,7 +233,7 @@ jobs:
           path: output/
       - run: |
           curl -sSL https://install.python-poetry.org | python3 - --version 1.5.1
-          poetry install
+          poetry install --only dev
       - name: Link chromedriver
         # Use installed chromedriver https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md
         run: |

--- a/poetry.lock
+++ b/poetry.lock
@@ -1610,4 +1610,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "96f4c996ef1bacd86fab97fb299c117ad6c41bfb54f927dba9534b8efb05cb6b"
+content-hash = "5fe53871a9749934e62afc9a7dc2958a8811e977adeecce6adb27286331ffbcd"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ openapi3 = "^1.7.0"
 defusedxml = "^0.7.1"
 requests = "^2.31.0"
 urllib3 = "<2"
+colorama = "^0.4.6"
 
 [tool.poetry.group.dev.dependencies]
 mkdocs = "^1.4.2"


### PR DESCRIPTION
This PR adds missing `colorama` dependency.

This commit (https://github.com/splunk/addonfactory-ucc-generator/pull/973/commits/ff3dcd74e8536ba6ad206011eeb795826c8ffb40) exposes the issue in the pipeline and [fbb71bd](https://github.com/splunk/addonfactory-ucc-generator/pull/973/commits/fbb71bd59598e1c4b1fb70600730c4151f158846) fixes it.

This issue should have been caught in the CI before making a release.