### PR TITLE
ci: run UI tests when PR is created against develop branch as well

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -197,6 +197,7 @@ jobs:
     if: |
       github.base_ref == 'main' ||
       github.ref_name == 'main' ||
+      github.base_ref == 'develop' ||
       github.ref_name == 'develop' ||
       contains(github.event.pull_request.labels.*.name, 'run-ui-tests')
     runs-on: ubuntu-latest


### PR DESCRIPTION
Since develop is now our primary development branch - let's run all the tests when PR is created to develop.