### PR TITLE
feat: custom sub description for pages - ADDON-67014

### DIFF
--- a/docs/advanced/sub_description.md
+++ b/docs/advanced/sub_description.md
@@ -4,7 +4,7 @@ This feature allows us to pass broarder description on Input and Configuration p
 
 | Property                                      | Type   | Description                                                          |
 | --------------------------------------------- | ------ | -------------------------------------------------------------------- |
-| text<span class="required-asterisk">\*</span> | string | Text used for that description, you can put </br> to add a breakline |
+| text<span class="required-asterisk">\*</span> | string | Text used for that description, you can put \n to add a breakline |
 | links                                         | object | To enable including links inside description                         |
 
 ### Links
@@ -23,7 +23,7 @@ This feature allows us to pass broarder description on Input and Configuration p
   "title": "Example Input One",
   "entity": [],
   "subDescription": {
-    "text": "Ingesting data from to Splunk Cloud?</br>Read our [[blogPost]] to learn more about Data Manager and it's availability on your Splunk Cloud instance.",
+    "text": "Ingesting data from to Splunk Cloud?\nRead our [[blogPost]] to learn more about Data Manager and it's availability on your Splunk Cloud instance.",
     "links": [
       {
         "slug": "blogPost",

--- a/docs/advanced/sub_description.md
+++ b/docs/advanced/sub_description.md
@@ -1,0 +1,36 @@
+This feature allows us to pass broarder description on Input and Configuration page displayed under main description.
+
+### Sub Descritpion Properties
+
+| Property                                      | Type   | Description                                                          |
+| --------------------------------------------- | ------ | -------------------------------------------------------------------- |
+| text<span class="required-asterisk">\*</span> | string | Text used for that description, you can put </br> to add a breakline |
+| links                                         | object | To enable including links inside description                         |
+
+### Links
+
+| Property                                          | Type   | Description                                                                                  |
+| ------------------------------------------------- | ------ | -------------------------------------------------------------------------------------------- |
+| slug<span class="required-asterisk">\*</span>     | string | Used to identify place for link to appear, put inside text, surrounded by 2 squared brackets |
+| link<span class="required-asterisk">\*</span>     | string | Link to be used                                                                              |
+| linkText<span class="required-asterisk">\*</span> | string | Text to be inserted instead of slug                                                          |
+
+### Usage
+
+```json
+{
+  "name": "example_input_one",
+  "title": "Example Input One",
+  "entity": [],
+  "subDescription": {
+    "text": "Ingesting data from to Splunk Cloud?</br>Read our [[blogPost]] to learn more about Data Manager and it's availability on your Splunk Cloud instance.",
+    "links": [
+      {
+        "slug": "blogPost",
+        "link": "https://splk.it/31oy2b2",
+        "linkText": "blog post"
+      }
+    ]
+  }
+}
+```

--- a/docs/configurations.md
+++ b/docs/configurations.md
@@ -2,30 +2,30 @@
 
 ### Configuration Properties
 
-| Property                                                         | Type   | Description                                          |
-| ---------------------------------------------------------------- | ------ | ---------------------------------------------------- |
-| title<span class="required-asterisk">*</span>                    | string | -                                                    |
-| description                                                      | string | To provide a brief summary of an configuration page. |
-| [tabs](#tabs-properties)<span class="required-asterisk">*</span> | array  | To specify a list of tab.                            |
-
+| Property                                                          | Type   | Description                                             |
+| ----------------------------------------------------------------- | ------ | ------------------------------------------------------- |
+| title<span class="required-asterisk">\*</span>                    | string | -                                                       |
+| description                                                       | string | To provide a brief summary of an configuration page.    |
+| subDescription(../advanced/sub_description)                        | object | To provide broader description of an configuration page |
+| [tabs](#tabs-properties)<span class="required-asterisk">\*</span> | array  | To specify a list of tab.                               |
 
 ### Tabs properties
 
-| Property                                       | Type   | Description                                                                                                                                                                                        |
-| ---------------------------------------------- | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| name<span class="required-asterisk">*</span>   | string | To define the particular tab name.                                                                                                                                                                 |
-| title<span class="required-asterisk">*</span>  | string | To show the title of the tab.                                                                                                                                                                      |
-| [entity](../entity)<span class="required-asterisk">*</span> | array  | A list of fields and their properties.                                                                                                                                                             |
-| [table](../table)                                          | object | To display accounts stanza in table                                                                                                                                                                |
-| style                                          | string | By specifying this property in the global config file, the forms can either be opened as a new page or in a dialog. <br>Supported values are "page" or "dialog". <br> Default value is **dialog**. |
-| options                                        | object | This property allows you to enable the [saveValidator](../advanced/save_validator) feature.                                                                                                        |
-| hook                                           | object | It is used to add custom behaviour to forms. Visit the [Custom Hook](../custom_ui_extensions/custom_hook) page to learn more.                                                                      |
-| warning                                        | object | It is used to add custom warning message for each of modes ('create', 'edit', 'config', 'clone'), message is displayed on form                                                                     |
-| conf                                           | string | TBD                                                                                                                                                                                                |
-| restHandlerName                                | string | TBD                                                                                                                                                                                                |
-| restHandlerModule                              | string | TBD                                                                                                                                                                                                |
-| restHandlerClass                               | string | TBD                                                                                                                                                                                                |
-| customTab                                      | Object | This property allows you to enable the [custom tab](../custom_ui_extensions/custom_tab) feature.                                                                                                   |
+| Property                                                     | Type   | Description                                                                                                                                                                                        |
+| ------------------------------------------------------------ | ------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| name<span class="required-asterisk">\*</span>                | string | To define the particular tab name.                                                                                                                                                                 |
+| title<span class="required-asterisk">\*</span>               | string | To show the title of the tab.                                                                                                                                                                      |
+| [entity](../entity)<span class="required-asterisk">\*</span> | array  | A list of fields and their properties.                                                                                                                                                             |
+| [table](../table)                                            | object | To display accounts stanza in table                                                                                                                                                                |
+| style                                                        | string | By specifying this property in the global config file, the forms can either be opened as a new page or in a dialog. <br>Supported values are "page" or "dialog". <br> Default value is **dialog**. |
+| options                                                      | object | This property allows you to enable the [saveValidator](../advanced/save_validator) feature.                                                                                                        |
+| hook                                                         | object | It is used to add custom behaviour to forms. Visit the [Custom Hook](../custom_ui_extensions/custom_hook) page to learn more.                                                                      |
+| warning                                                      | object | It is used to add custom warning message for each of modes ('create', 'edit', 'config', 'clone'), message is displayed on form                                                                     |
+| conf                                                         | string | TBD                                                                                                                                                                                                |
+| restHandlerName                                              | string | TBD                                                                                                                                                                                                |
+| restHandlerModule                                            | string | TBD                                                                                                                                                                                                |
+| restHandlerClass                                             | string | TBD                                                                                                                                                                                                |
+| customTab                                                    | Object | This property allows you to enable the [custom tab](../custom_ui_extensions/custom_tab) feature.                                                                                                   |
 
 ### Usage
 

--- a/splunk_add_on_ucc_framework/schema/schema.json
+++ b/splunk_add_on_ucc_framework/schema/schema.json
@@ -170,6 +170,9 @@
           "type": "string",
           "maxLength": 200
         },
+        "subDescription": {
+          "$ref": "#/definitions/SubDescription"
+        },
         "tabs": {
           "type": "array",
           "items": {
@@ -1000,7 +1003,6 @@
                 "$ref": "#/definitions/ValueLabelPair"
               }
             }
-
           },
           "required": ["items"],
           "additionalProperties": false
@@ -1305,7 +1307,8 @@
           },
           {
             "$ref": "#/definitions/CustomEntity"
-          }]
+          }
+        ]
       }
     },
     "AutoCompleteFields": {
@@ -1348,6 +1351,9 @@
             "description": {
               "type": "string",
               "maxLength": 200
+            },
+            "subDescription": {
+              "$ref": "#/definitions/SubDescription"
             },
             "menu": {
               "type": "object"
@@ -1648,19 +1654,26 @@
               },
               "os": {
                 "anyOf": [
-                {
-                  "const": "linux"
-                },
-                {
-                  "const": "windows"
-                },
-                {
-                  "const": "darwin"
-                }
-              ]
+                  {
+                    "const": "linux"
+                  },
+                  {
+                    "const": "windows"
+                  },
+                  {
+                    "const": "darwin"
+                  }
+                ]
               }
             },
-            "required": ["name", "version", "platform", "python_version", "target", "os"]
+            "required": [
+              "name",
+              "version",
+              "platform",
+              "python_version",
+              "target",
+              "os"
+            ]
           }
         }
       },
@@ -1969,6 +1982,36 @@
     "Field": {
       "type": "string",
       "pattern": "(?!^(?:persistentQueueSize|queueSize|start_by_shell|output_mode|output_field|owner|app|sharing)$)(?:^\\w+$)"
+    },
+    "SubDescription": {
+      "type": "object",
+      "properties": {
+        "text": {
+          "type": "string",
+          "maxLength": 1500
+        },
+        "links": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "slug": {
+                "type": "string",
+                "maxLength": 50,
+                "pattern": "^\\w+$"
+              },
+              "linkText": {
+                "type": "string",
+                "maxLength": 500
+              },
+              "link": {
+                "type": "string"
+              }
+            }
+          },
+          "required": ["text"]
+        }
+      }
     }
   },
   "type": "object",

--- a/splunk_add_on_ucc_framework/schema/schema.json
+++ b/splunk_add_on_ucc_framework/schema/schema.json
@@ -2007,7 +2007,8 @@
               "link": {
                 "type": "string"
               }
-            }
+            },
+            "required": ["slug", "linkText", "link"]
           },
           "required": ["text"]
         }

--- a/tests/testdata/test_addons/package_global_config_everything/globalConfig.json
+++ b/tests/testdata/test_addons/package_global_config_everything/globalConfig.json
@@ -465,7 +465,17 @@
                 }
             ],
             "title": "Configuration",
-            "description": "Set up your add-on"
+            "description": "Set up your add-on",
+            "subDescription": {
+                "text": "Configuration page - Ingesting data from to Splunk Cloud? Have you tried the new Splunk Data Manager yet?</br>Data Manager makes AWS data ingestion simpler, more automated and centrally managed for you, while co-existing with AWS and/or Kinesis TAs.</br>Read our [[blogPost]] to learn more about Data Manager and it's availability on your Splunk Cloud instance.",
+                "links": [
+                    {
+                        "slug": "blogPost",
+                        "link": "https://splk.it/31oy2b2",
+                        "linkText": "blog post"
+                    }
+                ]
+            }
         },
         "inputs": {
             "services": [
@@ -1149,6 +1159,16 @@
             ],
             "title": "Inputs",
             "description": "Manage your data inputs",
+            "subDescription": {
+                "text": "Input page - Ingesting data from to Splunk Cloud? Have you tried the new Splunk Data Manager yet?</br>Data Manager makes AWS data ingestion simpler, more automated and centrally managed for you, while co-existing with AWS and/or Kinesis TAs.</br>Read our [[blogPost]] to learn more about Data Manager and it's availability on your Splunk Cloud instance.",
+                "links": [
+                    {
+                        "slug": "blogPost",
+                        "link": "https://splk.it/31oy2b2",
+                        "linkText": "blog post"
+                    }
+                ]
+            },
             "table": {
                 "actions": [
                     "edit",

--- a/tests/testdata/test_addons/package_global_config_everything/globalConfig.json
+++ b/tests/testdata/test_addons/package_global_config_everything/globalConfig.json
@@ -467,7 +467,7 @@
             "title": "Configuration",
             "description": "Set up your add-on",
             "subDescription": {
-                "text": "Configuration page - Ingesting data from to Splunk Cloud? Have you tried the new Splunk Data Manager yet?</br>Data Manager makes AWS data ingestion simpler, more automated and centrally managed for you, while co-existing with AWS and/or Kinesis TAs.</br>Read our [[blogPost]] to learn more about Data Manager and it's availability on your Splunk Cloud instance.",
+                "text": "Configuration page - Ingesting data from to Splunk Cloud? Have you tried the new Splunk Data Manager yet?\nData Manager makes AWS data ingestion simpler, more automated and centrally managed for you, while co-existing with AWS and/or Kinesis TAs.\nRead our [[blogPost]] to learn more about Data Manager and it's availability on your Splunk Cloud instance.",
                 "links": [
                     {
                         "slug": "blogPost",
@@ -1160,7 +1160,7 @@
             "title": "Inputs",
             "description": "Manage your data inputs",
             "subDescription": {
-                "text": "Input page - Ingesting data from to Splunk Cloud? Have you tried the new Splunk Data Manager yet?</br>Data Manager makes AWS data ingestion simpler, more automated and centrally managed for you, while co-existing with AWS and/or Kinesis TAs.</br>Read our [[blogPost]] to learn more about Data Manager and it's availability on your Splunk Cloud instance.",
+                "text": "Input page - Ingesting data from to Splunk Cloud? Have you tried the new Splunk Data Manager yet?\nData Manager makes AWS data ingestion simpler, more automated and centrally managed for you, while co-existing with AWS and/or Kinesis TAs.\nRead our [[blogPost]] to learn more about Data Manager and it's availability on your Splunk Cloud instance.",
                 "links": [
                     {
                         "slug": "blogPost",
@@ -1375,7 +1375,7 @@
     "meta": {
         "name": "Splunk_TA_UCCExample",
         "restRoot": "splunk_ta_uccexample",
-        "version": "5.35.1R9330d2a9",
+        "version": "5.35.1Ree62a73b",
         "displayName": "Splunk UCC test Add-on",
         "schemaVersion": "0.0.3"
     }

--- a/ui/src/components/SubDescription/SubDescription.stories.tsx
+++ b/ui/src/components/SubDescription/SubDescription.stories.tsx
@@ -11,7 +11,7 @@ type Story = StoryObj<typeof meta>;
 
 export const Base: Story = {
     args: {
-        text: `Configuration page - Ingesting data from to Splunk Cloud? Have you tried the new Splunk Data Manager yet?</br>Data Manager makes AWS data ingestion simpler, more automated and centrally managed for you, while [blogPost2][[blogPost2]] co-existing with AWS and/or Kinesis TAs.</br>Read our [[blogPost]][blogPost2] to learn more about Data Manager and it's availability on your Splunk Cloud instance.`,
+        text: `Configuration page - Ingesting data from to Splunk Cloud? Have you tried the new Splunk Data Manager yet?\nData Manager makes AWS data ingestion simpler, more automated and centrally managed for you, while [blogPost2][[blogPost2]] co-existing with AWS and/or Kinesis TAs.\nRead our [[blogPost]][blogPost2] to learn more about Data Manager and it's availability on your Splunk Cloud instance.`,
         links: [
             {
                 slug: 'blogPost',

--- a/ui/src/components/SubDescription/SubDescription.stories.tsx
+++ b/ui/src/components/SubDescription/SubDescription.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import SubDescription from './SubDescription';
+
+const meta = {
+    component: SubDescription,
+    title: 'Components/SubDescription',
+} satisfies Meta<typeof SubDescription>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Base: Story = {
+    args: {
+        text: `Configuration page - Ingesting data from to Splunk Cloud? Have you tried the new Splunk Data Manager yet?</br>Data Manager makes AWS data ingestion simpler, more automated and centrally managed for you, while [blogPost2][[blogPost2]] co-existing with AWS and/or Kinesis TAs.</br>Read our [[blogPost]][blogPost2] to learn more about Data Manager and it's availability on your Splunk Cloud instance.`,
+        links: [
+            {
+                slug: 'blogPost',
+                link: 'https://splk.it/31oy2b2',
+                linkText: 'blog post',
+            },
+            {
+                slug: 'blogPost2',
+                link: 'https://splk.it/31oy2b2',
+                linkText: 'blog post 2',
+            },
+        ],
+    },
+};

--- a/ui/src/components/SubDescription/SubDescription.test.tsx
+++ b/ui/src/components/SubDescription/SubDescription.test.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+
+import { render, screen } from '@testing-library/react';
+import SubDescription from './SubDescription';
+
+it('Sub Description component - without links', async () => {
+    const props = {
+        text: `Some description without any break or changes`,
+    };
+    render(<SubDescription {...props} />);
+
+    const subDesc = await screen.findByText(props.text);
+    expect(subDesc).toBeInTheDocument();
+});
+
+it('Sub Description component - links', async () => {
+    const props = {
+        text: `Ingesting data from to Splunk Cloud?</br>Read our [[blogPost]] to learn more about Data Manager and it's availability on your Splunk Cloud instance.`,
+        links: [
+            {
+                slug: 'blogPost',
+                link: 'https://splk.it/31oy2b2',
+                linkText: 'blog post',
+            },
+        ],
+    };
+    render(<SubDescription {...props} />);
+
+    const firstParagraph = await screen.findByText('Ingesting data from to Splunk Cloud?');
+    expect(firstParagraph).toBeInTheDocument();
+    const wholeSubDescription = firstParagraph.parentNode;
+    expect(wholeSubDescription?.textContent).toEqual(
+        props.text.replaceAll('</br>', '').replaceAll('[[blogPost]]', 'blog post')
+    );
+
+    const linkInsideDescription = wholeSubDescription?.querySelector('a');
+    expect(linkInsideDescription).toBeInTheDocument();
+    expect(linkInsideDescription?.href).toEqual('https://splk.it/31oy2b2');
+});

--- a/ui/src/components/SubDescription/SubDescription.test.tsx
+++ b/ui/src/components/SubDescription/SubDescription.test.tsx
@@ -32,7 +32,7 @@ it('Sub Description component - links', async () => {
     expect(firstParagraph).toBeInTheDocument();
     const wholeSubDescription = firstParagraph.parentNode;
     expect(wholeSubDescription?.textContent).toEqual(
-        props.text.replaceAll('[[blogPost]]', 'blog post')
+        props.text.replaceAll('[[blogPost]]', 'blog post(Opens new window)')
     );
 
     const linkInsideDescription = wholeSubDescription?.querySelector('a');

--- a/ui/src/components/SubDescription/SubDescription.test.tsx
+++ b/ui/src/components/SubDescription/SubDescription.test.tsx
@@ -15,7 +15,7 @@ it('Sub Description component - without links', async () => {
 
 it('Sub Description component - links', async () => {
     const props = {
-        text: `Ingesting data from to Splunk Cloud?</br>Read our [[blogPost]] to learn more about Data Manager and it's availability on your Splunk Cloud instance.`,
+        text: `Ingesting data from to Splunk Cloud?\nRead our [[blogPost]] to learn more about Data Manager and it's availability on your Splunk Cloud instance.`,
         links: [
             {
                 slug: 'blogPost',
@@ -26,11 +26,13 @@ it('Sub Description component - links', async () => {
     };
     render(<SubDescription {...props} />);
 
-    const firstParagraph = await screen.findByText('Ingesting data from to Splunk Cloud?');
+    const firstParagraph = await screen.findByText((text) =>
+        text.startsWith('Ingesting data from to Splunk Cloud?')
+    );
     expect(firstParagraph).toBeInTheDocument();
     const wholeSubDescription = firstParagraph.parentNode;
     expect(wholeSubDescription?.textContent).toEqual(
-        props.text.replaceAll('</br>', '').replaceAll('[[blogPost]]', 'blog post')
+        props.text.replaceAll('[[blogPost]]', 'blog post')
     );
 
     const linkInsideDescription = wholeSubDescription?.querySelector('a');

--- a/ui/src/components/SubDescription/SubDescription.tsx
+++ b/ui/src/components/SubDescription/SubDescription.tsx
@@ -3,12 +3,11 @@ import React from 'react';
 import styled from 'styled-components';
 import { z } from 'zod';
 import { variables } from '@splunk/themes';
+import Link from '@splunk/react-ui/Link';
 import { SubDescriptionSchema } from '../../types/globalConfig/pages';
 
-export const SubTitleComponent = styled.div.attrs({
-    className: 'pageSubDescription',
-})`
-    &.pageSubDescription {
+export const SubTitleComponent = styled.p`
+    & {
         font-size: ${variables.fontSize};
         margin-bottom: 10px;
     }
@@ -25,14 +24,14 @@ const mapTextToElements = (props: SubDescriptionProps) => {
 
             if (linkToReplace) {
                 return (
-                    <a // using index as key for elements as they dont have unique values but are unique itself
+                    <Link // using index as key for elements as they dont have unique values but are unique itself
                         key={`subDesc${linkToReplace.slug}${i}`}
-                        href={linkToReplace.link}
+                        to={linkToReplace.link}
                         target="_blank"
                         rel="noreferrer"
                     >
                         {linkToReplace.linkText}
-                    </a>
+                    </Link>
                 );
             }
             return text.split('</br>').map((elem, ind) => (

--- a/ui/src/components/SubDescription/SubDescription.tsx
+++ b/ui/src/components/SubDescription/SubDescription.tsx
@@ -10,6 +10,7 @@ export const SubTitleComponent = styled.p`
     & {
         font-size: ${variables.fontSize};
         margin-bottom: 10px;
+        white-space: pre-line;
     }
 `;
 
@@ -19,28 +20,17 @@ const mapTextToElements = (props: SubDescriptionProps) => {
     const splitedtextBySlugs: string[] | undefined = props?.text.split(/\]\]|\[\[/);
 
     return splitedtextBySlugs
-        ?.map((text, i) => {
+        ?.map((text) => {
             const linkToReplace = props?.links?.find((link) => link.slug === text);
 
             if (linkToReplace) {
                 return (
-                    <Link // using index as key for elements as they dont have unique values but are unique itself
-                        key={`subDesc${linkToReplace.slug}${i}`}
-                        to={linkToReplace.link}
-                        target="_blank"
-                        rel="noreferrer"
-                    >
+                    <Link to={linkToReplace.link} target="_blank" rel="noreferrer">
                         {linkToReplace.linkText}
                     </Link>
                 );
             }
-            return text.split('</br>').map((elem, ind) => (
-                // using index as key for elements as they dont have unique values but are unique itself
-                <span key={`subDesc${i}${ind}`}>
-                    {ind > 0 && ind < text.length - 1 && <br />}
-                    {elem}
-                </span>
-            ));
+            return text;
         })
         .flat();
 };

--- a/ui/src/components/SubDescription/SubDescription.tsx
+++ b/ui/src/components/SubDescription/SubDescription.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react/no-array-index-key */
 import React from 'react';
 import styled from 'styled-components';
 import { z } from 'zod';
@@ -25,7 +24,11 @@ const mapTextToElements = (props: SubDescriptionProps) => {
 
             if (linkToReplace) {
                 return (
-                    <Link to={linkToReplace.link} openInNewContext>
+                    <Link
+                        to={linkToReplace.link}
+                        openInNewContext
+                        key={`subDescription${linkToReplace.slug}`}
+                    >
                         {linkToReplace.linkText}
                     </Link>
                 );

--- a/ui/src/components/SubDescription/SubDescription.tsx
+++ b/ui/src/components/SubDescription/SubDescription.tsx
@@ -25,7 +25,7 @@ const mapTextToElements = (props: SubDescriptionProps) => {
 
             if (linkToReplace) {
                 return (
-                    <a // using index as elements for not have unique values but are unique itself
+                    <a // using index as key for elements as they dont have unique values but are unique itself
                         key={`subDesc${linkToReplace.slug}${i}`}
                         href={linkToReplace.link}
                         target="_blank"
@@ -36,7 +36,7 @@ const mapTextToElements = (props: SubDescriptionProps) => {
                 );
             }
             return text.split('</br>').map((elem, ind) => (
-                // using index as elements for not have unique values but are unique itself
+                // using index as key for elements as they dont have unique values but are unique itself
                 <span key={`subDesc${i}${ind}`}>
                     {ind > 0 && ind < text.length - 1 && <br />}
                     {elem}

--- a/ui/src/components/SubDescription/SubDescription.tsx
+++ b/ui/src/components/SubDescription/SubDescription.tsx
@@ -1,0 +1,58 @@
+/* eslint-disable react/no-array-index-key */
+import React from 'react';
+import styled from 'styled-components';
+import { z } from 'zod';
+import { variables } from '@splunk/themes';
+import { SubDescriptionSchema } from '../../types/globalConfig/pages';
+
+export const SubTitleComponent = styled.div.attrs({
+    className: 'pageSubDescription',
+})`
+    &.pageSubDescription {
+        font-size: ${variables.fontSize};
+        margin-bottom: 10px;
+    }
+`;
+
+type SubDescriptionProps = z.TypeOf<typeof SubDescriptionSchema>;
+
+const mapTextToElements = (props: SubDescriptionProps) => {
+    const splitedtextBySlugs: string[] | undefined = props?.text.split(/\]\]|\[\[/);
+
+    return splitedtextBySlugs
+        ?.map((text, i) => {
+            const linkToReplace = props?.links?.find((link) => link.slug === text);
+
+            if (linkToReplace) {
+                return (
+                    <a // using index as elements for not have unique values but are unique itself
+                        key={`subDesc${linkToReplace.slug}${i}`}
+                        href={linkToReplace.link}
+                        target="_blank"
+                        rel="noreferrer"
+                    >
+                        {linkToReplace.linkText}
+                    </a>
+                );
+            }
+            return text.split('</br>').map((elem, ind) => (
+                // using index as elements for not have unique values but are unique itself
+                <span key={`subDesc${i}${ind}`}>
+                    {ind > 0 && ind < text.length - 1 && <br />}
+                    {elem}
+                </span>
+            ));
+        })
+        .flat();
+};
+
+function SubDescription(props: SubDescriptionProps) {
+    if (!props?.text) {
+        return <></>;
+    }
+
+    const mappedTextWithLinks = mapTextToElements(props);
+    return <SubTitleComponent>{mappedTextWithLinks}</SubTitleComponent>;
+}
+
+export default SubDescription;

--- a/ui/src/components/SubDescription/SubDescription.tsx
+++ b/ui/src/components/SubDescription/SubDescription.tsx
@@ -25,7 +25,7 @@ const mapTextToElements = (props: SubDescriptionProps) => {
 
             if (linkToReplace) {
                 return (
-                    <Link to={linkToReplace.link} target="_blank" rel="noreferrer">
+                    <Link to={linkToReplace.link} openInNewContext >
                         {linkToReplace.linkText}
                     </Link>
                 );

--- a/ui/src/components/SubDescription/SubDescription.tsx
+++ b/ui/src/components/SubDescription/SubDescription.tsx
@@ -25,7 +25,7 @@ const mapTextToElements = (props: SubDescriptionProps) => {
 
             if (linkToReplace) {
                 return (
-                    <Link to={linkToReplace.link} openInNewContext >
+                    <Link to={linkToReplace.link} openInNewContext>
                         {linkToReplace.linkText}
                     </Link>
                 );

--- a/ui/src/mocks/globalConfigMock.ts
+++ b/ui/src/mocks/globalConfigMock.ts
@@ -93,6 +93,16 @@ const globalConfigMock: z.input<typeof GlobalConfigSchema> = {
             ],
             title: 'Configuration',
             description: 'Set up your add-on',
+            subDescription: {
+                text: "Configuration page - Ingesting data from to Splunk Cloud?</br>Read our [[blogPost]] to learn more about Data Manager and it's availability on your Splunk Cloud instance.",
+                links: [
+                    {
+                        slug: 'blogPost',
+                        link: 'https://splk.it/31oy2b2',
+                        linkText: 'blog post',
+                    },
+                ],
+            },
         },
         inputs: {
             services: [
@@ -162,6 +172,16 @@ const globalConfigMock: z.input<typeof GlobalConfigSchema> = {
             ],
             title: 'Inputs',
             description: 'Manage your data inputs',
+            subDescription: {
+                text: "Inputs page - Ingesting data from to Splunk Cloud?</br>Read our [[blogPost]] to learn more about Data Manager and it's availability on your Splunk Cloud instance.",
+                links: [
+                    {
+                        slug: 'blogPost',
+                        link: 'https://splk.it/31oy2b2',
+                        linkText: 'blog post',
+                    },
+                ],
+            },
             table: {
                 actions: ['edit', 'enable', 'delete', 'clone'],
                 header: [

--- a/ui/src/pages/Configuration/ConfigurationPage.jsx
+++ b/ui/src/pages/Configuration/ConfigurationPage.jsx
@@ -14,6 +14,7 @@ import CustomTab from '../../components/CustomTab';
 import ConfigurationFormView from '../../components/ConfigurationFormView';
 import ConfigurationTable from '../../components/ConfigurationTable';
 import OpenApiDownloadButton from '../../components/DownloadButton/OpenApiDownloadBtn';
+import SubDescription from '../../components/SubDescription/SubDescription';
 
 const Row = styled(ColumnLayout.Row)`
     padding: 5px 0px;
@@ -30,7 +31,7 @@ const Row = styled(ColumnLayout.Row)`
 
 function ConfigurationPage() {
     const unifiedConfigs = getUnifiedConfigs();
-    const { title, description, tabs } = unifiedConfigs.pages.configuration;
+    const { title, description, subDescription, tabs } = unifiedConfigs.pages.configuration;
     const permittedTabNames = tabs.map((tab) => tab.name);
 
     const [activeTabId, setActiveTabId] = useState(tabs[0].name);
@@ -103,6 +104,7 @@ function ConfigurationPage() {
                         <ColumnLayout.Column span={9}>
                             <TitleComponent>{_(title)}</TitleComponent>
                             <SubTitleComponent>{_(description || '')}</SubTitleComponent>
+                            <SubDescription {...subDescription} />
                         </ColumnLayout.Column>
                         <ColumnLayout.Column span={1} style={{ textAlignLast: 'right' }}>
                             <OpenApiDownloadButton />

--- a/ui/src/pages/Input/InputPage.jsx
+++ b/ui/src/pages/Input/InputPage.jsx
@@ -17,6 +17,7 @@ import TableWrapper from '../../components/table/TableWrapper';
 import EntityModal from '../../components/EntityModal/EntityModal';
 import ErrorBoundary from '../../components/ErrorBoundary';
 import EntityPage from '../../components/EntityPage';
+import SubDescription from '../../components/SubDescription/SubDescription';
 import useQuery from '../../hooks/useQuery';
 
 const Row = styled(ColumnLayout.Row)`
@@ -38,7 +39,7 @@ const Row = styled(ColumnLayout.Row)`
 function InputPage() {
     const [entity, setEntity] = useState({ open: false });
     const unifiedConfigs = getUnifiedConfigs();
-    const { services, title, table, description } = unifiedConfigs.pages.inputs;
+    const { services, title, table, description, subDescription } = unifiedConfigs.pages.inputs;
 
     // check if the tabs feature is enabled or not.
     const isTabs = !table;
@@ -220,6 +221,7 @@ function InputPage() {
                                 <SubTitleComponent className={isTabs && 'page_subtitle'}>
                                     {isTabs ? _(selectedTab.description) : _(description || '')}
                                 </SubTitleComponent>
+                                <SubDescription {...subDescription} />
                             </ColumnLayout.Column>
                             <ColumnLayout.Column
                                 className={isTabs ? 'title_menu_column' : 'dropdown'}

--- a/ui/src/types/globalConfig/pages.ts
+++ b/ui/src/types/globalConfig/pages.ts
@@ -99,10 +99,26 @@ export const InputsPageRegular = z
     // The strict method disallows a table field to distinguish between to inputs
     .strict();
 
+export const SubDescriptionSchema = z
+    .object({
+        text: z.string(),
+        links: z
+            .array(
+                z.object({
+                    slug: z.string(),
+                    link: z.string(),
+                    linkText: z.string(),
+                })
+            )
+            .optional(),
+    })
+    .optional();
+
 export const InputsPageTableSchema = z
     .object({
         title: z.string(),
         description: z.string().optional(),
+        subDescription: SubDescriptionSchema,
         menu: z
             .object({
                 type: z.literal('external'),
@@ -129,6 +145,7 @@ export const pages = z.object({
     configuration: z.object({
         title: z.string(),
         description: z.string().optional(),
+        subDescription: SubDescriptionSchema,
         tabs: z.array(TabSchema).min(1),
     }),
     inputs: z.union([InputsPageRegular, InputsPageTableSchema]).optional(),

--- a/ui/src/types/modules.d.ts
+++ b/ui/src/types/modules.d.ts
@@ -3,3 +3,4 @@ declare module '@splunk/splunk-utils/url';
 // declaring modules as utils does not seem to have types
 
 declare module '@splunk/ui-utils/i18n';
+declare module '@splunk/react-page';

--- a/ui/src/types/modules.d.ts
+++ b/ui/src/types/modules.d.ts
@@ -3,4 +3,3 @@ declare module '@splunk/splunk-utils/url';
 // declaring modules as utils does not seem to have types
 
 declare module '@splunk/ui-utils/i18n';
-declare module '@splunk/react-page';


### PR DESCRIPTION
https://splunk.atlassian.net/browse/ADDON-67014
add possibility to create custom headers for inputs and configuration page.
Supports links and line breaks.



the idea for it is like that

```
  "subDescription": {
    "text": "Ingesting data from to Splunk Cloud?</br>Read our [[blogPost]] to learn more about Data Manager and it's availability on your Splunk Cloud instance.",
    "links": [
      {
        "slug": "blogPost",
        "link": "https://splk.it/31oy2b2",
        "linkText": "blog post"
      }
    ]
  }
```
so a whole description is put inside  `subDescription.text` variable, with support of `</br>` as break lines.

also if you use [[blogPost]] and slugs it will look for a matching link there, if it finds it puts anchor element with all data, if not it remvoes squared brackets and puts that string clear in text