### PR TITLE
feat: add UCC version to globalConfig

### DIFF
--- a/splunk_add_on_ucc_framework/app_manifest.py
+++ b/splunk_add_on_ucc_framework/app_manifest.py
@@ -88,9 +88,6 @@ class AppManifest:
     def update_addon_version(self, version: str) -> None:
         self._manifest["info"]["id"]["version"] = version
 
-    def add_ucc_version(self, version: str) -> None:
-        self._manifest["info"]["ucc_framework"] = {"version": version}
-
     def validate(self) -> None:
         schema_version = self._get_schema_version()
         if schema_version != APP_MANIFEST_SCHEMA_VERSION:

--- a/splunk_add_on_ucc_framework/app_manifest.py
+++ b/splunk_add_on_ucc_framework/app_manifest.py
@@ -88,6 +88,9 @@ class AppManifest:
     def update_addon_version(self, version: str) -> None:
         self._manifest["info"]["id"]["version"] = version
 
+    def add_ucc_version(self, version: str) -> None:
+        self._manifest["info"]["ucc_framework"] = {"version": version}
+
     def validate(self) -> None:
         schema_version = self._get_schema_version()
         if schema_version != APP_MANIFEST_SCHEMA_VERSION:

--- a/splunk_add_on_ucc_framework/commands/build.py
+++ b/splunk_add_on_ucc_framework/commands/build.py
@@ -715,3 +715,10 @@ def generate(
         os.path.join(output_directory, ta_name),
         verbose_file_summary_report,
     )
+
+#TODO remove below
+if __name__ == "__main__":
+
+    path_package = '/Users/mmacalik/Documents/Ucc-Gen_webinar/repos/addonfactory-ucc-generator/tests/testdata/test_addons/package_global_config_everything/package'
+
+    generate(source=path_package)

--- a/splunk_add_on_ucc_framework/commands/build.py
+++ b/splunk_add_on_ucc_framework/commands/build.py
@@ -644,6 +644,7 @@ def generate(
         logger.info("Updated VERSION file")
 
     app_manifest.update_addon_version(addon_version)
+    app_manifest.add_ucc_version(__version__)
     output_manifest_path = os.path.abspath(
         os.path.join(output_directory, ta_name, app_manifest_lib.APP_MANIFEST_FILE_NAME)
     )
@@ -715,10 +716,3 @@ def generate(
         os.path.join(output_directory, ta_name),
         verbose_file_summary_report,
     )
-
-
-# TODO remove below
-if __name__ == "__main__":
-    path_package = "/Users/mmacalik/Documents/Ucc-Gen_webinar/repos/addonfactory-ucc-generator/tests/testdata/test_addons/package_global_config_everything/package"
-
-    generate(source=path_package)

--- a/splunk_add_on_ucc_framework/commands/build.py
+++ b/splunk_add_on_ucc_framework/commands/build.py
@@ -502,6 +502,7 @@ def generate(
             logger.error(f"globalConfig file is not valid. Error: {e}")
             sys.exit(1)
         global_config.update_addon_version(addon_version)
+        global_config.add_ucc_version(__version__)
         global_config.dump(global_config.original_path)
         logger.info(
             f"Updated and saved add-on version in the globalConfig file to {addon_version}"
@@ -714,3 +715,10 @@ def generate(
         os.path.join(output_directory, ta_name),
         verbose_file_summary_report,
     )
+
+#TODO remove below
+if __name__ == "__main__":
+
+    path_package = '/Users/mmacalik/Documents/Ucc-Gen_webinar/repos/addonfactory-ucc-generator/tests/testdata/test_addons/package_global_config_everything/package'
+
+    generate(source=path_package)

--- a/splunk_add_on_ucc_framework/commands/build.py
+++ b/splunk_add_on_ucc_framework/commands/build.py
@@ -644,7 +644,6 @@ def generate(
         logger.info("Updated VERSION file")
 
     app_manifest.update_addon_version(addon_version)
-    app_manifest.add_ucc_version(__version__)
     output_manifest_path = os.path.abspath(
         os.path.join(output_directory, ta_name, app_manifest_lib.APP_MANIFEST_FILE_NAME)
     )

--- a/splunk_add_on_ucc_framework/commands/build.py
+++ b/splunk_add_on_ucc_framework/commands/build.py
@@ -716,9 +716,9 @@ def generate(
         verbose_file_summary_report,
     )
 
-#TODO remove below
-if __name__ == "__main__":
 
-    path_package = '/Users/mmacalik/Documents/Ucc-Gen_webinar/repos/addonfactory-ucc-generator/tests/testdata/test_addons/package_global_config_everything/package'
+# TODO remove below
+if __name__ == "__main__":
+    path_package = "/Users/mmacalik/Documents/Ucc-Gen_webinar/repos/addonfactory-ucc-generator/tests/testdata/test_addons/package_global_config_everything/package"
 
     generate(source=path_package)

--- a/splunk_add_on_ucc_framework/global_config.py
+++ b/splunk_add_on_ucc_framework/global_config.py
@@ -128,6 +128,10 @@ class GlobalConfig:
         return self.meta["version"]
 
     @property
+    def ucc_version(self) -> str:
+        return self.meta["uccVersion"]
+
+    @property
     def original_path(self) -> str:
         return self._original_path
 
@@ -149,6 +153,9 @@ class GlobalConfig:
 
     def update_addon_version(self, version: str) -> None:
         self._content.setdefault("meta", {})["version"] = version
+
+    def add_ucc_version(self, version: str) -> None:
+        self.content.setdefault("meta", {})["uccVersion"] = version
 
     def has_inputs(self) -> bool:
         return bool(self.inputs)

--- a/splunk_add_on_ucc_framework/global_config.py
+++ b/splunk_add_on_ucc_framework/global_config.py
@@ -129,7 +129,7 @@ class GlobalConfig:
 
     @property
     def ucc_version(self) -> str:
-        return self.meta["uccVersion"]
+        return self.meta["_uccVersion"]
 
     @property
     def original_path(self) -> str:
@@ -155,7 +155,7 @@ class GlobalConfig:
         self._content.setdefault("meta", {})["version"] = version
 
     def add_ucc_version(self, version: str) -> None:
-        self.content.setdefault("meta", {})["uccVersion"] = version
+        self.content.setdefault("meta", {})["_uccVersion"] = version
 
     def has_inputs(self) -> bool:
         return bool(self.inputs)

--- a/splunk_add_on_ucc_framework/schema/schema.json
+++ b/splunk_add_on_ucc_framework/schema/schema.json
@@ -1628,7 +1628,7 @@
           "type": "string",
           "pattern": "^(?:\\d{1,3}\\.){2}\\d{1,3}$"
         },
-        "uccVersion": {
+        "_uccVersion": {
           "type": "string"
         },
         "checkForUpdates": {

--- a/splunk_add_on_ucc_framework/schema/schema.json
+++ b/splunk_add_on_ucc_framework/schema/schema.json
@@ -443,9 +443,6 @@
             },
             "enable": {
               "type": "boolean"
-            },
-            "requiredWhenVisible": {
-              "type": "boolean"
             }
           },
           "additionalProperties": false
@@ -520,9 +517,6 @@
               "type": "string"
             },
             "enable": {
-              "type": "boolean"
-            },
-            "requiredWhenVisible": {
               "type": "boolean"
             },
             "rowsMin": {
@@ -611,9 +605,6 @@
               "type": "string"
             },
             "enable": {
-              "type": "boolean"
-            },
-            "requiredWhenVisible": {
               "type": "boolean"
             },
             "disableSearch": {
@@ -728,9 +719,6 @@
             "enable": {
               "type": "boolean"
             },
-            "requiredWhenVisible": {
-              "type": "boolean"
-            },
             "disableSearch": {
               "type": "boolean"
             },
@@ -823,9 +811,6 @@
               "type": "boolean"
             },
             "enable": {
-              "type": "boolean"
-            },
-            "requiredWhenVisible": {
               "type": "boolean"
             }
           },
@@ -936,9 +921,6 @@
                 "additionalProperties": false
               },
               "minItems": 1
-            },
-            "disableonEdit": {
-              "type": "boolean"
             }
           },
           "required": ["rows"],
@@ -997,15 +979,13 @@
             "enable": {
               "type": "boolean"
             },
-            "requiredWhenVisible": {
-              "type": "boolean"
-            },
             "items": {
               "type": "array",
               "items": {
                 "$ref": "#/definitions/ValueLabelPair"
               }
             }
+
           },
           "required": ["items"],
           "additionalProperties": false
@@ -1066,9 +1046,6 @@
             "enable": {
               "type": "boolean"
             },
-            "requiredWhenVisible": {
-              "type": "boolean"
-            },
             "maxFileSize": {
               "type": "number"
             },
@@ -1120,9 +1097,6 @@
               "type": "boolean"
             },
             "disableonEdit": {
-              "type": "boolean"
-            },
-            "requiredWhenVisible": {
               "type": "boolean"
             },
             "enable": {
@@ -1310,8 +1284,7 @@
           },
           {
             "$ref": "#/definitions/CustomEntity"
-          }
-        ]
+          }]
       }
     },
     "AutoCompleteFields": {
@@ -1354,9 +1327,6 @@
             "description": {
               "type": "string",
               "maxLength": 200
-            },
-            "subDescription": {
-              "$ref": "#/definitions/SubDescription"
             },
             "menu": {
               "type": "object"
@@ -1660,26 +1630,19 @@
               },
               "os": {
                 "anyOf": [
-                  {
-                    "const": "linux"
-                  },
-                  {
-                    "const": "windows"
-                  },
-                  {
-                    "const": "darwin"
-                  }
-                ]
+                {
+                  "const": "linux"
+                },
+                {
+                  "const": "windows"
+                },
+                {
+                  "const": "darwin"
+                }
+              ]
               }
             },
-            "required": [
-              "name",
-              "version",
-              "platform",
-              "python_version",
-              "target",
-              "os"
-            ]
+            "required": ["name", "version", "platform", "python_version", "target", "os"]
           }
         }
       },
@@ -1994,37 +1957,6 @@
     "Field": {
       "type": "string",
       "pattern": "(?!^(?:persistentQueueSize|queueSize|start_by_shell|output_mode|output_field|owner|app|sharing)$)(?:^\\w+$)"
-    },
-    "SubDescription": {
-      "type": "object",
-      "properties": {
-        "text": {
-          "type": "string",
-          "maxLength": 1500
-        },
-        "links": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "slug": {
-                "type": "string",
-                "maxLength": 50,
-                "pattern": "^\\w+$"
-              },
-              "linkText": {
-                "type": "string",
-                "maxLength": 500
-              },
-              "link": {
-                "type": "string"
-              }
-            },
-            "required": ["slug", "linkText", "link"]
-          },
-          "required": ["text"]
-        }
-      }
     }
   },
   "type": "object",

--- a/splunk_add_on_ucc_framework/schema/schema.json
+++ b/splunk_add_on_ucc_framework/schema/schema.json
@@ -443,6 +443,9 @@
             },
             "enable": {
               "type": "boolean"
+            },
+            "requiredWhenVisible": {
+              "type": "boolean"
             }
           },
           "additionalProperties": false
@@ -517,6 +520,9 @@
               "type": "string"
             },
             "enable": {
+              "type": "boolean"
+            },
+            "requiredWhenVisible": {
               "type": "boolean"
             },
             "rowsMin": {
@@ -605,6 +611,9 @@
               "type": "string"
             },
             "enable": {
+              "type": "boolean"
+            },
+            "requiredWhenVisible": {
               "type": "boolean"
             },
             "disableSearch": {
@@ -719,6 +728,9 @@
             "enable": {
               "type": "boolean"
             },
+            "requiredWhenVisible": {
+              "type": "boolean"
+            },
             "disableSearch": {
               "type": "boolean"
             },
@@ -811,6 +823,9 @@
               "type": "boolean"
             },
             "enable": {
+              "type": "boolean"
+            },
+            "requiredWhenVisible": {
               "type": "boolean"
             }
           },
@@ -921,6 +936,9 @@
                 "additionalProperties": false
               },
               "minItems": 1
+            },
+            "disableonEdit": {
+              "type": "boolean"
             }
           },
           "required": ["rows"],
@@ -979,13 +997,15 @@
             "enable": {
               "type": "boolean"
             },
+            "requiredWhenVisible": {
+              "type": "boolean"
+            },
             "items": {
               "type": "array",
               "items": {
                 "$ref": "#/definitions/ValueLabelPair"
               }
             }
-
           },
           "required": ["items"],
           "additionalProperties": false
@@ -1046,6 +1066,9 @@
             "enable": {
               "type": "boolean"
             },
+            "requiredWhenVisible": {
+              "type": "boolean"
+            },
             "maxFileSize": {
               "type": "number"
             },
@@ -1097,6 +1120,9 @@
               "type": "boolean"
             },
             "disableonEdit": {
+              "type": "boolean"
+            },
+            "requiredWhenVisible": {
               "type": "boolean"
             },
             "enable": {
@@ -1284,7 +1310,8 @@
           },
           {
             "$ref": "#/definitions/CustomEntity"
-          }]
+          }
+        ]
       }
     },
     "AutoCompleteFields": {
@@ -1327,6 +1354,9 @@
             "description": {
               "type": "string",
               "maxLength": 200
+            },
+            "subDescription": {
+              "$ref": "#/definitions/SubDescription"
             },
             "menu": {
               "type": "object"
@@ -1630,19 +1660,26 @@
               },
               "os": {
                 "anyOf": [
-                {
-                  "const": "linux"
-                },
-                {
-                  "const": "windows"
-                },
-                {
-                  "const": "darwin"
-                }
-              ]
+                  {
+                    "const": "linux"
+                  },
+                  {
+                    "const": "windows"
+                  },
+                  {
+                    "const": "darwin"
+                  }
+                ]
               }
             },
-            "required": ["name", "version", "platform", "python_version", "target", "os"]
+            "required": [
+              "name",
+              "version",
+              "platform",
+              "python_version",
+              "target",
+              "os"
+            ]
           }
         }
       },
@@ -1957,6 +1994,37 @@
     "Field": {
       "type": "string",
       "pattern": "(?!^(?:persistentQueueSize|queueSize|start_by_shell|output_mode|output_field|owner|app|sharing)$)(?:^\\w+$)"
+    },
+    "SubDescription": {
+      "type": "object",
+      "properties": {
+        "text": {
+          "type": "string",
+          "maxLength": 1500
+        },
+        "links": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "slug": {
+                "type": "string",
+                "maxLength": 50,
+                "pattern": "^\\w+$"
+              },
+              "linkText": {
+                "type": "string",
+                "maxLength": 500
+              },
+              "link": {
+                "type": "string"
+              }
+            },
+            "required": ["slug", "linkText", "link"]
+          },
+          "required": ["text"]
+        }
+      }
     }
   },
   "type": "object",

--- a/splunk_add_on_ucc_framework/schema/schema.json
+++ b/splunk_add_on_ucc_framework/schema/schema.json
@@ -1629,8 +1629,7 @@
           "pattern": "^(?:\\d{1,3}\\.){2}\\d{1,3}$"
         },
         "uccVersion": {
-          "type": "string",
-          "pattern": "^(?:\\d{1,3}\\.){2}\\d{1,3}$"
+          "type": "string"
         },
         "checkForUpdates": {
           "type": "boolean",

--- a/splunk_add_on_ucc_framework/schema/schema.json
+++ b/splunk_add_on_ucc_framework/schema/schema.json
@@ -1628,6 +1628,10 @@
           "type": "string",
           "pattern": "^(?:\\d{1,3}\\.){2}\\d{1,3}$"
         },
+        "uccVersion": {
+          "type": "string",
+          "pattern": "^(?:\\d{1,3}\\.){2}\\d{1,3}$"
+        },
         "checkForUpdates": {
           "type": "boolean",
           "default": true

--- a/tests/smoke/test_ucc_build.py
+++ b/tests/smoke/test_ucc_build.py
@@ -63,10 +63,6 @@ def test_ucc_generate_with_config_param():
     Check if globalConfig and app.manifest contains current ucc version
     """
 
-    def get_file_content(path):
-        with open(path) as f:
-            return json.load(f)
-
     def check_ucc_versions():
         global_config_path = path.join(
             path.dirname(path.realpath(__file__)),
@@ -81,7 +77,8 @@ def test_ucc_generate_with_config_param():
             "globalConfig.json",
         )
 
-        global_config = get_file_content(global_config_path)
+        with open(global_config_path) as _f:
+            global_config = json.load(_f)
 
         assert global_config["meta"]["_uccVersion"] == __version__
 

--- a/tests/smoke/test_ucc_build.py
+++ b/tests/smoke/test_ucc_build.py
@@ -79,7 +79,6 @@ def test_ucc_generate_with_config_param():
             "globalConfig.json",
         )
 
-
         app_manifest_path = path.join(
             path.dirname(path.realpath(__file__)),
             "output",

--- a/tests/smoke/test_ucc_build.py
+++ b/tests/smoke/test_ucc_build.py
@@ -78,7 +78,7 @@ def test_ucc_generate_with_config_param():
             "build",
             "globalConfig.json",
         )
-        build.generate(source=package_folder, config_path=config_path)
+
 
         app_manifest_path = path.join(
             path.dirname(path.realpath(__file__)),
@@ -109,6 +109,8 @@ def test_ucc_generate_with_config_param():
         "package_global_config_everything",
         "globalConfig.json",
     )
+
+    build.generate(source=package_folder, config_path=config_path)
 
     check_ucc_versions()
 

--- a/tests/smoke/test_ucc_build.py
+++ b/tests/smoke/test_ucc_build.py
@@ -70,6 +70,8 @@ def test_ucc_generate_with_config_param():
     def check_ucc_versions():
         global_config_path = path.join(
             path.dirname(path.realpath(__file__)),
+            "..",
+            "..",
             "output",
             "Splunk_TA_UCCExample",
             "appserver",
@@ -81,6 +83,8 @@ def test_ucc_generate_with_config_param():
 
         app_manifest_path = path.join(
             path.dirname(path.realpath(__file__)),
+            "..",
+            "..",
             "output",
             "Splunk_TA_UCCExample",
             "app.manifest",

--- a/tests/smoke/test_ucc_build.py
+++ b/tests/smoke/test_ucc_build.py
@@ -83,7 +83,7 @@ def test_ucc_generate_with_config_param():
 
         global_config = get_file_content(global_config_path)
 
-        assert global_config["meta"]["uccVersion"] == __version__
+        assert global_config["meta"]["_uccVersion"] == __version__
 
     package_folder = path.join(
         path.dirname(path.realpath(__file__)),

--- a/tests/smoke/test_ucc_build.py
+++ b/tests/smoke/test_ucc_build.py
@@ -11,6 +11,7 @@ from tests.smoke import helpers
 import addonfactory_splunk_conf_parser_lib as conf_parser
 
 from splunk_add_on_ucc_framework.commands import build
+from splunk_add_on_ucc_framework import __version__
 
 PYTEST_SKIP_REASON = """Python 3.8 and higher preserves the order of the attrib
 fields when `tostring` function is used.
@@ -59,7 +60,9 @@ def test_ucc_generate():
 def test_ucc_generate_with_config_param():
     """
     Checks whether the package is build when the `config` flag is provided in the CLI.
+    Check if globalConfig contains current ucc version
     """
+
     package_folder = path.join(
         path.dirname(path.realpath(__file__)),
         "..",
@@ -76,7 +79,24 @@ def test_ucc_generate_with_config_param():
         "package_global_config_everything",
         "globalConfig.json",
     )
+    global_config_path = path.join(
+        path.dirname(path.realpath(__file__)),
+        "output",
+        "Splunk_TA_UCCExample",
+        "appserver",
+        "static",
+        "js",
+        "build",
+        "globalConfig.json"
+    )
     build.generate(source=package_folder, config_path=config_path)
+
+    with open(global_config_path, 'r') as f:
+        global_config = json.load(f)
+
+    assert global_config['meta']['uccVersion'] == __version__
+
+
 
 
 @pytest.mark.skipif(sys.version_info >= (3, 8), reason=PYTEST_SKIP_REASON)

--- a/tests/smoke/test_ucc_build.py
+++ b/tests/smoke/test_ucc_build.py
@@ -60,8 +60,38 @@ def test_ucc_generate():
 def test_ucc_generate_with_config_param():
     """
     Checks whether the package is build when the `config` flag is provided in the CLI.
-    Check if globalConfig contains current ucc version
+    Check if globalConfig and app.manifest contains current ucc version
     """
+
+    def get_file_content(path):
+        with open(path) as f:
+            return json.load(f)
+
+    def check_ucc_versions():
+        global_config_path = path.join(
+            path.dirname(path.realpath(__file__)),
+            "output",
+            "Splunk_TA_UCCExample",
+            "appserver",
+            "static",
+            "js",
+            "build",
+            "globalConfig.json",
+        )
+        build.generate(source=package_folder, config_path=config_path)
+
+        app_manifest_path = path.join(
+            path.dirname(path.realpath(__file__)),
+            "output",
+            "Splunk_TA_UCCExample",
+            "app.manifest",
+        )
+
+        global_config = get_file_content(global_config_path)
+        app_manifest = get_file_content(app_manifest_path)
+
+        assert global_config["meta"]["uccVersion"] == __version__
+        assert app_manifest["info"]["ucc_framework"]["version"] == __version__
 
     package_folder = path.join(
         path.dirname(path.realpath(__file__)),
@@ -79,22 +109,8 @@ def test_ucc_generate_with_config_param():
         "package_global_config_everything",
         "globalConfig.json",
     )
-    global_config_path = path.join(
-        path.dirname(path.realpath(__file__)),
-        "output",
-        "Splunk_TA_UCCExample",
-        "appserver",
-        "static",
-        "js",
-        "build",
-        "globalConfig.json",
-    )
-    build.generate(source=package_folder, config_path=config_path)
 
-    with open(global_config_path) as f:
-        global_config = json.load(f)
-
-    assert global_config["meta"]["uccVersion"] == __version__
+    check_ucc_versions()
 
 
 @pytest.mark.skipif(sys.version_info >= (3, 8), reason=PYTEST_SKIP_REASON)

--- a/tests/smoke/test_ucc_build.py
+++ b/tests/smoke/test_ucc_build.py
@@ -81,20 +81,9 @@ def test_ucc_generate_with_config_param():
             "globalConfig.json",
         )
 
-        app_manifest_path = path.join(
-            path.dirname(path.realpath(__file__)),
-            "..",
-            "..",
-            "output",
-            "Splunk_TA_UCCExample",
-            "app.manifest",
-        )
-
         global_config = get_file_content(global_config_path)
-        app_manifest = get_file_content(app_manifest_path)
 
         assert global_config["meta"]["uccVersion"] == __version__
-        assert app_manifest["info"]["ucc_framework"]["version"] == __version__
 
     package_folder = path.join(
         path.dirname(path.realpath(__file__)),

--- a/tests/smoke/test_ucc_build.py
+++ b/tests/smoke/test_ucc_build.py
@@ -60,30 +60,8 @@ def test_ucc_generate():
 def test_ucc_generate_with_config_param():
     """
     Checks whether the package is build when the `config` flag is provided in the CLI.
-    Check if globalConfig and app.manifest contains current ucc version
+    Check if globalConfig contains current ucc version
     """
-
-    def get_file_content(path):
-        with open(path) as f:
-            return json.load(f)
-
-    def check_ucc_versions():
-        global_config_path = path.join(
-            path.dirname(path.realpath(__file__)),
-            "..",
-            "..",
-            "output",
-            "Splunk_TA_UCCExample",
-            "appserver",
-            "static",
-            "js",
-            "build",
-            "globalConfig.json",
-        )
-
-        global_config = get_file_content(global_config_path)
-
-        assert global_config["meta"]["_uccVersion"] == __version__
 
     package_folder = path.join(
         path.dirname(path.realpath(__file__)),
@@ -101,10 +79,24 @@ def test_ucc_generate_with_config_param():
         "package_global_config_everything",
         "globalConfig.json",
     )
-
+    global_config_path = path.join(
+        path.dirname(path.realpath(__file__)),
+        "output",
+        "Splunk_TA_UCCExample",
+        "appserver",
+        "static",
+        "js",
+        "build",
+        "globalConfig.json"
+    )
     build.generate(source=package_folder, config_path=config_path)
 
-    check_ucc_versions()
+    with open(global_config_path, 'r') as f:
+        global_config = json.load(f)
+
+    assert global_config['meta']['uccVersion'] == __version__
+
+
 
 
 @pytest.mark.skipif(sys.version_info >= (3, 8), reason=PYTEST_SKIP_REASON)

--- a/tests/smoke/test_ucc_build.py
+++ b/tests/smoke/test_ucc_build.py
@@ -87,16 +87,14 @@ def test_ucc_generate_with_config_param():
         "static",
         "js",
         "build",
-        "globalConfig.json"
+        "globalConfig.json",
     )
     build.generate(source=package_folder, config_path=config_path)
 
-    with open(global_config_path, 'r') as f:
+    with open(global_config_path) as f:
         global_config = json.load(f)
 
-    assert global_config['meta']['uccVersion'] == __version__
-
-
+    assert global_config["meta"]["uccVersion"] == __version__
 
 
 @pytest.mark.skipif(sys.version_info >= (3, 8), reason=PYTEST_SKIP_REASON)

--- a/tests/testdata/test_addons/package_files_conflict_test/globalConfig.json
+++ b/tests/testdata/test_addons/package_files_conflict_test/globalConfig.json
@@ -212,8 +212,9 @@
     "meta": {
         "name": "test_addon",
         "restRoot": "test_addon",
-        "version": "5.34.1Racdcfb2e",
+        "version": "5.36.2Ref7d7543",
         "displayName": "This is my add-on",
-        "schemaVersion": "0.0.3"
+        "schemaVersion": "0.0.3",
+        "_uccVersion": "5.36.2"
     }
 }

--- a/tests/testdata/test_addons/package_global_config_configuration/globalConfig.json
+++ b/tests/testdata/test_addons/package_global_config_configuration/globalConfig.json
@@ -420,6 +420,7 @@
         "restRoot": "splunk_ta_uccexample",
         "version": "1.1.1",
         "displayName": "Splunk UCC test Add-on",
-        "schemaVersion": "0.0.3"
+        "schemaVersion": "0.0.3",
+        "_uccVersion": "5.36.2"
     }
 }

--- a/tests/testdata/test_addons/package_global_config_everything/globalConfig.json
+++ b/tests/testdata/test_addons/package_global_config_everything/globalConfig.json
@@ -1388,8 +1388,9 @@
     "meta": {
         "name": "Splunk_TA_UCCExample",
         "restRoot": "splunk_ta_uccexample",
-        "version": "5.35.1R537d4508",
+        "version": "5.36.2Ref7d7543",
         "displayName": "Splunk UCC test Add-on",
-        "schemaVersion": "0.0.3"
+        "schemaVersion": "0.0.3",
+        "_uccVersion": "5.36.2"
     }
 }

--- a/tests/testdata/test_addons/package_global_config_multi_input/globalConfig.json
+++ b/tests/testdata/test_addons/package_global_config_multi_input/globalConfig.json
@@ -465,8 +465,9 @@
     "meta": {
         "name": "Splunk_TA_UCCExample",
         "restRoot": "splunk_ta_uccexample",
-        "version": "0.0.1",
+        "version": "5.36.2Ref7d7543",
         "displayName": "Splunk UCC test Add-on",
-        "schemaVersion": "0.0.3"
+        "schemaVersion": "0.0.3",
+        "_uccVersion": "5.36.2"
     }
 }


### PR DESCRIPTION
This PR adds versions of used UCC framework to TA internal files for traceability.

see: [issue 983](https://github.com/splunk/addonfactory-ucc-generator/issues/983)