### PR TITLE
chore(renovate): bump package.json only

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,7 +11,6 @@
       "schedule:weekends"
     ]
   },
-  "rangeStrategy": "bump",
   "schedule": [
     "every 2 weeks on Sunday"
   ],
@@ -45,6 +44,12 @@
         "replacement"
       ],
       "enabled": false
+    },
+    {
+      "matchManagers": [
+        "npm"
+      ],
+      "rangeStrategy": "bump"
     }
   ]
 }


### PR DESCRIPTION
This PR changes Renovate's `rangeStrategy` to `bump` only for npm packages.

We don't want Renovate to bump Python packages because this package acts as a library.