### PR TITLE
chore: add basic info about wheel files into os-dependent doc

### DIFF
--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/docs/advanced/os-dependent_libraries.md
+++ b/docs/advanced/os-dependent_libraries.md
@@ -17,14 +17,13 @@ To do this, you need to expand the **meta** section in global config with the **
 Generally, the wheel name convention is <br>**{distribution}-{version}(-{build tag})?-{python tag}-{abi tag}-{platform tag}.whl**.<br>
 For example for this particular library: <br>**grpcio-1.54.2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl**<br> 
 your pip parameters are:
-<ul>
-<li>name = grpcio</li>
-<li>version = 1.54.2</li>
-<li>platform = manylinux_2_17_x86_64 or manylinux2014_x86_64</li>
-<li>python_version = 37</li>
-<li>target = your/path/to/target</li>
-<li>os = linux</li>
-</ul>
+
+* name = **grpcio**
+* version = **1.54.2**
+* platform = **manylinux_2_17_x86_64** or **manylinux2014_x86_64**
+* python_version = **37**
+* target = **your/path/to/target**
+* os = **linux**
 
 and your pip command should look like this:<br>
 `pip install --no-deps --platform manylinux_2_17_x86_64 --python-version 37 --target your/path/to/target --only-binary=:all: grpcio==1.54.2`

--- a/docs/advanced/os-dependent_libraries.md
+++ b/docs/advanced/os-dependent_libraries.md
@@ -12,6 +12,30 @@ To do this, you need to expand the **meta** section in global config with the **
 | target<span class="required-asterisk">*</span>         | string  | Path where the selected library will be unpacked.                                                                                                                                                                                                                        | -             |
 | os<span class="required-asterisk">*</span>             | string  | The name of the operating system for which the library is intended. Using this parameter, an appropriate insert into sys.path will be created. It takes 3 values **windows**, **linux** and **darwin**.                                                                  | -             |
 
+### About wheels files
+
+Generally, the wheel name convention is <br>**{distribution}-{version}(-{build tag})?-{python tag}-{abi tag}-{platform tag}.whl**.<br>
+For example for this particular library: <br>**grpcio-1.54.2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl**<br> 
+your pip parameters are:
+<ul>
+<li>name = grpcio</li>
+<li>version = 1.54.2</li>
+<li>platform = manylinux_2_17_x86_64 or manylinux2014_x86_64</li>
+<li>python_version = 37</li>
+<li>target = your/path/to/target</li>
+<li>os = linux</li>
+</ul>
+
+and your pip command should look like this:<br>
+`pip install --no-deps --platform manylinux_2_17_x86_64 --python-version 37 --target your/path/to/target --only-binary=:all: grpcio==1.54.2`
+
+A dot in the platform part indicates that a given distribution supports several platforms.
+In this case "**.**" in **manylinux_2_17_x86_64.manylinux2014_x86_64** means this distribution supports both **manylinux_2_17_x86_64** and **manylinux2014_x86_64**.
+
+
+for more informations, we recommend watching [.whl](https://www.youtube.com/watch?v=4L0Jb3Ku81s) and [manylinux platform](https://www.youtube.com/watch?v=80j-MRtHMek)
+
+
 ### Usage
 
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 # you may not use this file except in compliance with the License.
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/run_splunk.sh
+++ b/run_splunk.sh
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunk_add_on_ucc_framework/__init__.py
+++ b/splunk_add_on_ucc_framework/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunk_add_on_ucc_framework/__main__.py
+++ b/splunk_add_on_ucc_framework/__main__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunk_add_on_ucc_framework/app_conf.py
+++ b/splunk_add_on_ucc_framework/app_conf.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunk_add_on_ucc_framework/app_manifest.py
+++ b/splunk_add_on_ucc_framework/app_manifest.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunk_add_on_ucc_framework/commands/__init__.py
+++ b/splunk_add_on_ucc_framework/commands/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunk_add_on_ucc_framework/commands/build.py
+++ b/splunk_add_on_ucc_framework/commands/build.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunk_add_on_ucc_framework/commands/import_from_aob.py
+++ b/splunk_add_on_ucc_framework/commands/import_from_aob.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunk_add_on_ucc_framework/commands/init.py
+++ b/splunk_add_on_ucc_framework/commands/init.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunk_add_on_ucc_framework/commands/modular_alert_builder/__init__.py
+++ b/splunk_add_on_ucc_framework/commands/modular_alert_builder/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunk_add_on_ucc_framework/commands/modular_alert_builder/alert_actions_conf_gen.py
+++ b/splunk_add_on_ucc_framework/commands/modular_alert_builder/alert_actions_conf_gen.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunk_add_on_ucc_framework/commands/modular_alert_builder/alert_actions_exceptions.py
+++ b/splunk_add_on_ucc_framework/commands/modular_alert_builder/alert_actions_exceptions.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunk_add_on_ucc_framework/commands/modular_alert_builder/alert_actions_helper.py
+++ b/splunk_add_on_ucc_framework/commands/modular_alert_builder/alert_actions_helper.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunk_add_on_ucc_framework/commands/modular_alert_builder/alert_actions_html_gen.py
+++ b/splunk_add_on_ucc_framework/commands/modular_alert_builder/alert_actions_html_gen.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunk_add_on_ucc_framework/commands/modular_alert_builder/alert_actions_merge.py
+++ b/splunk_add_on_ucc_framework/commands/modular_alert_builder/alert_actions_merge.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunk_add_on_ucc_framework/commands/modular_alert_builder/alert_actions_py_gen.py
+++ b/splunk_add_on_ucc_framework/commands/modular_alert_builder/alert_actions_py_gen.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunk_add_on_ucc_framework/commands/modular_alert_builder/arf_consts.py
+++ b/splunk_add_on_ucc_framework/commands/modular_alert_builder/arf_consts.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunk_add_on_ucc_framework/commands/modular_alert_builder/builder.py
+++ b/splunk_add_on_ucc_framework/commands/modular_alert_builder/builder.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunk_add_on_ucc_framework/commands/modular_alert_builder/normalize.py
+++ b/splunk_add_on_ucc_framework/commands/modular_alert_builder/normalize.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunk_add_on_ucc_framework/commands/openapi_generator/__init__.py
+++ b/splunk_add_on_ucc_framework/commands/openapi_generator/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunk_add_on_ucc_framework/commands/openapi_generator/json_to_object.py
+++ b/splunk_add_on_ucc_framework/commands/openapi_generator/json_to_object.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunk_add_on_ucc_framework/commands/openapi_generator/oas.py
+++ b/splunk_add_on_ucc_framework/commands/openapi_generator/oas.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunk_add_on_ucc_framework/commands/openapi_generator/object_to_json.py
+++ b/splunk_add_on_ucc_framework/commands/openapi_generator/object_to_json.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunk_add_on_ucc_framework/commands/openapi_generator/ucc_to_oas.py
+++ b/splunk_add_on_ucc_framework/commands/openapi_generator/ucc_to_oas.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunk_add_on_ucc_framework/commands/package.py
+++ b/splunk_add_on_ucc_framework/commands/package.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunk_add_on_ucc_framework/commands/rest_builder/__init__.py
+++ b/splunk_add_on_ucc_framework/commands/rest_builder/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunk_add_on_ucc_framework/commands/rest_builder/builder.py
+++ b/splunk_add_on_ucc_framework/commands/rest_builder/builder.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunk_add_on_ucc_framework/commands/rest_builder/endpoint/__init__.py
+++ b/splunk_add_on_ucc_framework/commands/rest_builder/endpoint/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunk_add_on_ucc_framework/commands/rest_builder/endpoint/base.py
+++ b/splunk_add_on_ucc_framework/commands/rest_builder/endpoint/base.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunk_add_on_ucc_framework/commands/rest_builder/endpoint/datainput.py
+++ b/splunk_add_on_ucc_framework/commands/rest_builder/endpoint/datainput.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunk_add_on_ucc_framework/commands/rest_builder/endpoint/field.py
+++ b/splunk_add_on_ucc_framework/commands/rest_builder/endpoint/field.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunk_add_on_ucc_framework/commands/rest_builder/endpoint/multiple_model.py
+++ b/splunk_add_on_ucc_framework/commands/rest_builder/endpoint/multiple_model.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunk_add_on_ucc_framework/commands/rest_builder/endpoint/oauth_model.py
+++ b/splunk_add_on_ucc_framework/commands/rest_builder/endpoint/oauth_model.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunk_add_on_ucc_framework/commands/rest_builder/endpoint/single_model.py
+++ b/splunk_add_on_ucc_framework/commands/rest_builder/endpoint/single_model.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunk_add_on_ucc_framework/commands/rest_builder/global_config_builder_schema.py
+++ b/splunk_add_on_ucc_framework/commands/rest_builder/global_config_builder_schema.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunk_add_on_ucc_framework/commands/rest_builder/validator_builder.py
+++ b/splunk_add_on_ucc_framework/commands/rest_builder/validator_builder.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunk_add_on_ucc_framework/dashboard.py
+++ b/splunk_add_on_ucc_framework/dashboard.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunk_add_on_ucc_framework/data_ui_generator.py
+++ b/splunk_add_on_ucc_framework/data_ui_generator.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunk_add_on_ucc_framework/exceptions.py
+++ b/splunk_add_on_ucc_framework/exceptions.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunk_add_on_ucc_framework/global_config.py
+++ b/splunk_add_on_ucc_framework/global_config.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunk_add_on_ucc_framework/global_config_update.py
+++ b/splunk_add_on_ucc_framework/global_config_update.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunk_add_on_ucc_framework/global_config_validator.py
+++ b/splunk_add_on_ucc_framework/global_config_validator.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunk_add_on_ucc_framework/install_python_libraries.py
+++ b/splunk_add_on_ucc_framework/install_python_libraries.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunk_add_on_ucc_framework/main.py
+++ b/splunk_add_on_ucc_framework/main.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunk_add_on_ucc_framework/meta_conf.py
+++ b/splunk_add_on_ucc_framework/meta_conf.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunk_add_on_ucc_framework/package/appserver/templates/base.html
+++ b/splunk_add_on_ucc_framework/package/appserver/templates/base.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2023 Splunk Inc.
+  ~ Copyright 2024 Splunk Inc.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/splunk_add_on_ucc_framework/package/appserver/templates/redirect.html
+++ b/splunk_add_on_ucc_framework/package/appserver/templates/redirect.html
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright 2023 Splunk Inc.
+  ~ Copyright 2024 Splunk Inc.
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.

--- a/splunk_add_on_ucc_framework/rest_map_conf.py
+++ b/splunk_add_on_ucc_framework/rest_map_conf.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunk_add_on_ucc_framework/server_conf.py
+++ b/splunk_add_on_ucc_framework/server_conf.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunk_add_on_ucc_framework/utils.py
+++ b/splunk_add_on_ucc_framework/utils.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/splunk_add_on_ucc_framework/web_conf.py
+++ b/splunk_add_on_ucc_framework/web_conf.py
@@ -1,5 +1,5 @@
 #
-# Copyright 2023 Splunk Inc.
+# Copyright 2024 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/ui/src/pages/style.css
+++ b/ui/src/pages/style.css
@@ -1,5 +1,5 @@
 /*
- * Copyright 2023 Splunk Inc.
+ * Copyright 2024 Splunk Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
* added basic information about wheel files to the documentation in the OS-dependent libraries section
* updated license headers to 2024 