### PR TITLE
fix: no-compile missing from os-dependentLibraries packages

### DIFF
--- a/splunk_add_on_ucc_framework/install_python_libraries.py
+++ b/splunk_add_on_ucc_framework/install_python_libraries.py
@@ -233,6 +233,7 @@ Possible solutions, either:
 
         pip_download_command = (
             f"{os_lib.deps_flag} "
+            f"--no-compile "
             f"--platform {os_lib.platform} "
             f"--python-version {os_lib.python_version} "
             f"--target {target_path}"


### PR DESCRIPTION
The missing --no-compile flag on the os-dependentLibraries packages means that *.pyc files in __pycache__ are left by the installer, this causes Splunk AppInspect failures.

