### PR TITLE
fix: typo in the error message

### DIFF
--- a/splunk_add_on_ucc_framework/install_python_libraries.py
+++ b/splunk_add_on_ucc_framework/install_python_libraries.py
@@ -222,7 +222,7 @@ OS dependent library {os_lib.name} = {os_lib.version} SHOULD be defined in requi
 When the os dependent library is installed without its dependencies it has to be listed in requirements.txt.
 Possible solutions, either:
 1. os-dependentLibraries.name[{os_lib.name}].dependencies = True
-2. Add {os_lib.name}={os_lib.version} in requirements.txt
+2. Add {os_lib.name}=={os_lib.version} in requirements.txt
 """
             )
             raise CouldNotInstallRequirements

--- a/tests/unit/test_install_python_libraries.py
+++ b/tests/unit/test_install_python_libraries.py
@@ -400,7 +400,7 @@ OS dependent library cryptography = 41.0.5 SHOULD be defined in requirements.txt
 When the os dependent library is installed without its dependencies it has to be listed in requirements.txt.
 Possible solutions, either:
 1. os-dependentLibraries.name[cryptography].dependencies = True
-2. Add cryptography=41.0.5 in requirements.txt
+2. Add cryptography==41.0.5 in requirements.txt
 """
 
     assert version_mismatch_log in caplog.messages


### PR DESCRIPTION
The proper format in requirements.txt is `==`, not `=`.