### PR TITLE
ci: escape characters in PYPI_USERNAME and PYPI_TOKEN

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -337,4 +337,4 @@ jobs:
       - if: ${{ steps.semantic.outputs.new_release_published == 'true' }}
         run: |
           poetry build
-          poetry publish -n -u ${{ secrets.PYPI_USERNAME }} -p ${{ secrets.PYPI_TOKEN }}
+          poetry publish -n -u "${{ secrets.PYPI_USERNAME }}" -p "${{ secrets.PYPI_TOKEN }}"


### PR DESCRIPTION
The new password contains special characters which makes `poetry publish ...` step to fail.

I also manually remove new tag and release from GitHub so the new release can be created.