### PR TITLE
Automatically run yarn when poetry build runs

### DIFF
--- a/build.py
+++ b/build.py
@@ -1,4 +1,4 @@
-""" build script that ensures that yarn is run before install"""
+""" build script that ensures that yarn is run before poetry finishes building the package """
 
 import subprocess
 import shutil

--- a/build.py
+++ b/build.py
@@ -1,0 +1,16 @@
+""" build script that ensures that yarn is run before install"""
+
+import subprocess
+import shutil
+
+
+def run_yarn():
+    if shutil.which("yarn") is None:
+        print("yarn command not found, please install yarn to build the ui")
+        exit(1)
+    print("Running yarn to build the UI")
+    subprocess.run(["./build-ui.sh"])
+
+
+if __name__ == "__main__":
+    run_yarn()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,11 +32,15 @@ classifiers = [
     "Intended Audience :: Developers",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Software Development :: Code Generators",
-    "License :: OSI Approved :: Apache Software License"
+    "License :: OSI Approved :: Apache Software License",
 ]
 
 [tool.poetry.urls]
 "Bug Tracker" = "https://github.com/splunk/addonfactory-ucc-generator/issues"
+
+[tool.poetry.build]
+script = "build.py"
+generate-setup-file = false
 
 [tool.poetry.dependencies]
 python = "^3.7"
@@ -53,7 +57,7 @@ colorama = "^0.4.6"
 
 [tool.poetry.group.dev.dependencies]
 mkdocs = "^1.4.2"
-importlib-metadata = {version="*", python="<3.8"}
+importlib-metadata = { version = "*", python = "<3.8" }
 pytest = "^7.2.1"
 pytest-splunk-addon = "^5.0.0"
 pytest-splunk-addon-ui-smartx = "2.5.4"
@@ -63,7 +67,7 @@ pytest-cov = "^4.0.0"
 covdefaults = "^2.3.0"
 
 [tool.poetry.scripts]
-ucc-gen="splunk_add_on_ucc_framework.main:main"
+ucc-gen = "splunk_add_on_ucc_framework.main:main"
 
 [build-system]
 requires = ["poetry>=1.0.2"]


### PR DESCRIPTION
This build script uses PEP 517 functionality to run the yarn build script before install so that `poetry build` or `poetry install` works properly.

This avoids the trap of being able to `pip install` directly from the repo, but missing required files that are built outside the python build environment.

... the CI probably won't work now though without some tweaks?