### PR TITLE
fix(EntityModal): prevent Enter from submitting the form in Modal window

### DIFF
--- a/ui/src/components/BaseFormView.tsx
+++ b/ui/src/components/BaseFormView.tsx
@@ -1,4 +1,4 @@
-import React, { FormEventHandler, PureComponent } from 'react';
+import React, { PureComponent } from 'react';
 import update from 'immutability-helper';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -522,7 +522,7 @@ class BaseFormView extends PureComponent<BaseFormProps, BaseFormState> {
         }
     };
 
-    handleSubmit: FormEventHandler = (event) => {
+    handleSubmit = (event: React.MouseEvent | React.FormEvent) => {
         event.preventDefault();
         this.clearErrorMsg();
         this.props.handleFormSubmit(/* isSubmitting */ true, /* closeEntity */ false);

--- a/ui/src/components/BaseFormView.tsx
+++ b/ui/src/components/BaseFormView.tsx
@@ -1,4 +1,4 @@
-import React, { PureComponent } from 'react';
+import React, { FormEventHandler, PureComponent } from 'react';
 import update from 'immutability-helper';
 import { v4 as uuidv4 } from 'uuid';
 
@@ -522,8 +522,8 @@ class BaseFormView extends PureComponent<BaseFormProps, BaseFormState> {
         }
     };
 
-    // eslint-disable-next-line react/no-unused-class-component-methods
-    handleSubmit = () => {
+    handleSubmit: FormEventHandler = (event) => {
+        event.preventDefault();
         this.clearErrorMsg();
         this.props.handleFormSubmit(/* isSubmitting */ true, /* closeEntity */ false);
 
@@ -1253,7 +1253,10 @@ class BaseFormView extends PureComponent<BaseFormProps, BaseFormState> {
         }
         return (
             <div>
-                <form style={this.props.mode === MODE_CONFIG ? { marginTop: '25px' } : {}}>
+                <form
+                    onSubmit={this.handleSubmit}
+                    style={this.props.mode === MODE_CONFIG ? { marginTop: '25px' } : {}}
+                >
                     {this.generateWarningMessage()}
                     {this.generateErrorMessage()}
                     {this.entities?.map((e) => {

--- a/ui/src/components/ConfigurationFormView.jsx
+++ b/ui/src/components/ConfigurationFormView.jsx
@@ -37,8 +37,11 @@ function ConfigurationFormView({ serviceName }) {
         });
     }, [serviceName]);
 
-    const handleSubmit = () => {
-        form.current.handleSubmit();
+    /**
+     * @param event {React.MouseEvent<HTMLButtonElement>}
+     */
+    const handleSubmit = (event) => {
+        form.current.handleSubmit(event);
     };
 
     const handleFormSubmit = (set) => {

--- a/ui/src/components/EntityModal/EntityModal.tsx
+++ b/ui/src/components/EntityModal/EntityModal.tsx
@@ -4,7 +4,8 @@ import styled from 'styled-components';
 import WaitSpinner from '@splunk/react-ui/WaitSpinner';
 import { _ } from '@splunk/ui-utils/i18n';
 
-import { MODE_CLONE, MODE_CREATE, MODE_EDIT, Mode } from '../../constants/modes';
+import { ButtonClickHandler } from '@splunk/react-ui/Button';
+import { Mode, MODE_CLONE, MODE_CREATE, MODE_EDIT } from '../../constants/modes';
 import { StyledButton } from '../../pages/EntryPageStyle';
 import BaseFormView from '../BaseFormView';
 
@@ -53,8 +54,8 @@ class EntityModal extends Component<EntityModalProps, EntityModalState> {
         this.props.handleRequestClose();
     };
 
-    handleSubmit = () => {
-        const result = this.form.current?.handleSubmit();
+    handleSubmit: ButtonClickHandler = (e) => {
+        const result = this.form.current?.handleSubmit(e);
         if (result) {
             this.handleRequestClose();
         }

--- a/ui/src/components/EntityPage.tsx
+++ b/ui/src/components/EntityPage.tsx
@@ -8,6 +8,7 @@ import { variables } from '@splunk/themes';
 
 import Heading from '@splunk/react-ui/Heading';
 import styled from 'styled-components';
+import { ButtonClickHandler } from '@splunk/react-ui/Button';
 import { MODE_CLONE, MODE_CREATE, MODE_EDIT, Mode } from '../constants/modes';
 import BaseFormView from './BaseFormView';
 import { SubTitleComponent } from '../pages/Input/InputPageStyle';
@@ -55,8 +56,8 @@ function EntityPage({
         buttonText = _('Update');
     }
 
-    const handleSubmit = () => {
-        const result = form.current?.handleSubmit();
+    const handleSubmit: ButtonClickHandler = (e) => {
+        const result = form.current?.handleSubmit(e);
         if (result) {
             handleRequestClose();
         }
@@ -107,6 +108,7 @@ function EntityPage({
                             style={{ width: '80px' }}
                         />
                         <StyledButton
+                            type="Submit"
                             appearance="primary"
                             label={isSubmitting ? <WaitSpinner /> : buttonText}
                             onClick={handleSubmit}


### PR DESCRIPTION
## The problem

Enter for a form with single input triggers the form submission. [The specification](https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#implicit-submission). The form submission was not properly handled.

## The fix
- hook up on form submission by adding callback onSubmit for `<form />` element
- prevent default behavior (sending GET with formdata in params and redirect) and proceed with our handlers (validation and sending as JSON with AJAX)

## References
- https://splunk.atlassian.net/browse/ADDON-61126
- https://splunk.atlassian.net/browse/ADDON-58706

Resolves #875