### PR TITLE
fix(a11y): associate labels with inputs

### DIFF
--- a/ui/src/components/ControlWrapper.tsx
+++ b/ui/src/components/ControlWrapper.tsx
@@ -6,8 +6,6 @@ import CONTROL_TYPE_MAP, { ComponentTypes } from '../constants/ControlTypeMap';
 import { AnyEntity, UtilControlWrapper } from './BaseFormTypes';
 import { AcceptableFormValueOrNullish } from '../types/components/shareableTypes';
 
-const CustomElement = styled.div``;
-
 const ControlGroupWrapper = styled(ControlGroup).attrs((props: { dataName: string }) => ({
     'data-name': props.dataName,
 }))`
@@ -110,13 +108,12 @@ class ControlWrapper extends React.PureComponent<ControlWrapperProps> {
                 <ControlGroupWrapper
                     help={helpText}
                     error={this.props.error}
-                    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-                    // @ts-ignore property should be data-name, but is mapped in obj ControlGroupWrapper
+                    // @ts-expect-error property should be data-name, but is mapped in obj ControlGroupWrapper
                     dataName={this?.props?.entity.field}
                     labelWidth={240}
                     {...this?.props?.entity}
                 >
-                    <CustomElement>{rowView}</CustomElement>
+                    {rowView}
                 </ControlGroupWrapper>
             )
         );

--- a/ui/src/components/MultiInputComponent/MultiInputComponent.tsx
+++ b/ui/src/components/MultiInputComponent/MultiInputComponent.tsx
@@ -16,6 +16,7 @@ const WaitSpinnerWrapper = styled(WaitSpinner)`
 `;
 
 export interface MultiInputComponentProps {
+    id?: string;
     handleChange: (field: string, data: string) => void;
     field: string;
     controlOptions: {
@@ -40,6 +41,7 @@ export interface MultiInputComponentProps {
 
 function MultiInputComponent(props: MultiInputComponentProps) {
     const {
+        id,
         field,
         disabled = false,
         error = false,
@@ -135,6 +137,7 @@ function MultiInputComponent(props: MultiInputComponentProps) {
     return (
         <>
             <MultiSelectWrapper
+                inputId={id}
                 values={valueList}
                 error={error}
                 name={field}

--- a/ui/src/components/RadioComponent/RadioComponent.tsx
+++ b/ui/src/components/RadioComponent/RadioComponent.tsx
@@ -11,6 +11,7 @@ const RadioBarOption = styled(RadioBar.Option)`
 `;
 
 interface RadioComponentProps {
+    id?: string;
     value: string;
     handleChange: (field: string, value: string) => void;
     field: string;
@@ -31,6 +32,7 @@ class RadioComponent extends Component<RadioComponentProps> {
     render() {
         return (
             <RadioBarWrapper
+                id={this.props.id}
                 inline
                 onChange={this.handleChange}
                 value={this.props.value}

--- a/ui/src/components/SingleInputComponent.tsx
+++ b/ui/src/components/SingleInputComponent.tsx
@@ -31,6 +31,7 @@ interface FormItem {
 }
 
 interface SingleInputComponentProps {
+    id?: string;
     disabled?: boolean;
     value: string;
     error?: boolean;
@@ -181,6 +182,7 @@ function SingleInputComponent(props: SingleInputComponentProps) {
     ) : (
         <>
             <SelectWrapper
+                inputId={props.id}
                 className="dropdownBox"
                 data-test-loading={loading}
                 value={props.value}

--- a/ui/src/components/TextAreaComponent/TextAreaComponent.tsx
+++ b/ui/src/components/TextAreaComponent/TextAreaComponent.tsx
@@ -6,7 +6,8 @@ const TextWrapper = styled(TextArea)`
     width: 320px !important;
 `;
 
-interface TextAreadComponentProps {
+interface TextAreaComponentProps {
+    id?: string;
     value: string | number;
     handleChange: (field: string, value: string) => void;
     field: string;
@@ -15,13 +16,14 @@ interface TextAreadComponentProps {
     disabled?: boolean;
 }
 
-function TextAreaComponent(props: TextAreadComponentProps) {
+function TextAreaComponent(props: TextAreaComponentProps) {
     const handleChange = (e: unknown, { value }: { value: string }) => {
         props.handleChange(props.field, value);
     };
 
     return (
         <TextWrapper
+            inputId={props.id}
             inline
             canClear
             error={props.error}

--- a/ui/src/components/TextComponent/TextComponent.tsx
+++ b/ui/src/components/TextComponent/TextComponent.tsx
@@ -14,6 +14,7 @@ interface TextComponentProps {
     error?: boolean;
     encrypted?: boolean;
     disabled?: boolean;
+    id?: string;
 }
 
 class TextComponent extends Component<TextComponentProps> {
@@ -24,6 +25,7 @@ class TextComponent extends Component<TextComponentProps> {
     render() {
         return (
             <TextWrapper
+                inputId={this.props.id}
                 inline
                 error={this.props.error}
                 className={this.props.field}


### PR DESCRIPTION
## The problem
We use SUI components but a lot of wrappers for it. These wrappers don't pass all required props to the target component including id attribute. This causes lack of connection between `label`'s `for` attribute and `input`s `id`.
Instead the `id` is set on the wrapper:
<img width="540" alt="Screenshot 2024-02-06 at 15 15 14" src="https://github.com/splunk/addonfactory-ucc-generator/assets/142901247/ce7c4990-a627-4614-8632-4a7f80480cc8">

## The solution
Pass id from wrapper to input.

## References
- https://splunk.atlassian.net/browse/ADDON-68266
- closes #936