### PR TITLE
chore(storybook): fix mock service worker path

### DIFF
--- a/ui/.storybook/preview.tsx
+++ b/ui/.storybook/preview.tsx
@@ -6,6 +6,9 @@ import { withSplunkThemeToolbar } from './withSplunkTheme';
 
 // Initialize MSW
 initialize({
+    serviceWorker: {
+        url: './mockServiceWorker.js',
+    },
     onUnhandledRequest(req) {
         const url = req.url;
         const skipList = ['bundle.js', 'hot-update.js', 'http://localhost:6006/index.json'];


### PR DESCRIPTION
## The problem
Storybook deployed on GH pages is down due to it is looking for a JS service worker at the root path (`https://splunk.github.io/mockServiceWorker.js`) instead of subpath `https://splunk.github.io/addonfactory-ucc-generator/storybook/mockServiceWorker.js

## The fix
The fix proposed in https://github.com/mswjs/msw-storybook-addon/issues/77 to add relative path instead of default absolute. I hope that would work