### PR TITLE
fix: return back div wrapper that shifts layout

### DIFF
--- a/ui/src/components/ControlWrapper/ControlWrapper.tsx
+++ b/ui/src/components/ControlWrapper/ControlWrapper.tsx
@@ -6,6 +6,8 @@ import CONTROL_TYPE_MAP, { ComponentTypes } from '../../constants/ControlTypeMap
 import { AnyEntity, UtilControlWrapper } from '../BaseFormTypes';
 import { AcceptableFormValueOrNullish } from '../../types/components/shareableTypes';
 
+const CustomElement = styled.div``;
+
 const ControlGroupWrapper = styled(ControlGroup).attrs((props: { dataName: string }) => ({
     'data-name': props.dataName,
 }))`
@@ -113,7 +115,7 @@ class ControlWrapper extends React.PureComponent<ControlWrapperProps> {
                     labelWidth={240}
                     {...this?.props?.entity}
                 >
-                    {rowView}
+                    <CustomElement>{rowView}</CustomElement>
                 </ControlGroupWrapper>
             )
         );


### PR DESCRIPTION
## The problem
introduced in #1055
<img width="811" alt="image" src="https://github.com/splunk/addonfactory-ucc-generator/assets/142901247/4bab24e4-0e60-4824-b022-c83ee463e1d2">

## The fix
<img width="809" alt="image" src="https://github.com/splunk/addonfactory-ucc-generator/assets/142901247/291a63c1-9022-4f6e-9071-a7d6b8ceeff8">
