### PR TITLE
ci: add all-checks to summarize tests

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -216,7 +216,6 @@ jobs:
       id-token: write
       contents: read
       checks: write
-    continue-on-error: true
     needs:
       - meta
       - build-test-addon
@@ -224,6 +223,7 @@ jobs:
       - test-unit
       - test-smoke
     strategy:
+      fail-fast: false
       matrix:
         splunk: ${{ fromJson(needs.meta.outputs.matrix_supportedSplunk) }}
         test-mark:

--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -9,7 +9,7 @@ on:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
   pull_request:
-    branches: [ main, develop, "release/**" ]
+    branches: [main, develop, "release/**"]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
@@ -299,6 +299,33 @@ jobs:
           included_tags: ${{ matrix.tags }}
           appinspect_manual_checks: tests/testdata/expected_addons/expected_output_global_config_everything/.appinspect.manualcheck.yaml
           appinspect_expected_failures: tests/testdata/expected_addons/expected_output_global_config_everything/.appinspect.expect.yaml
+
+  all-checks:
+    if: ${{ !cancelled() }}
+    needs:
+      - test-ui
+      - build-test-addon-openapi-client
+      - storybook-screenshots
+    runs-on: ubuntu-latest
+    env:
+      NEEDS: ${{ toJson(needs) }}
+    steps:
+      - name: check if tests have passed or skipped
+        id: check
+        shell: bash
+        run: |
+          RUN_PUBLISH=$(echo "$NEEDS" | jq ".[] |  select(  ( .result != \"skipped\" ) and .result != \"success\" ) | length == 0")
+          if [[ "$RUN_PUBLISH" != *'false'* ]]
+          then
+              echo "all-checks=true" >> "$GITHUB_OUTPUT"
+          else
+              echo "all-checks=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: exit without publish
+        if: ${{ steps.check.outputs.all-checks == 'false' || ( github.event.action == 'labeled' && github.event.label.name == 'preserve_infra' ) }}
+        run: |
+          echo "Some check failed or Workflow has triggered on preserve_infra label."
+          exit 1
 
   release:
     needs:

--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -314,14 +314,14 @@ jobs:
         id: check
         shell: bash
         run: |
-          RUN_PUBLISH=$(echo "$NEEDS" | jq ".[] |  select(  ( .result != \"skipped\" ) and .result != \"success\" ) | length == 0")
-          if [[ "$RUN_PUBLISH" != *'false'* ]]
+          ALL_JOBS_PASSED=$(echo "$NEEDS" | jq "all(.[]; .result == \"success\" or .result == \"skipped\")")
+          if [[ "$ALL_JOBS_PASSED" == "true" ]]
           then
               echo "all-checks=true" >> "$GITHUB_OUTPUT"
           else
               echo "all-checks=false" >> "$GITHUB_OUTPUT"
           fi
-      - name: Fail job is something failed
+      - name: Fail job if something failed
         if: ${{ steps.check.outputs.all-checks == 'false' }}
         run: |
           echo "Some check failed"
@@ -338,6 +338,7 @@ jobs:
       - appinspect-for-expected-outputs
       - semgrep
       - pre-commit
+      - all-checks
     runs-on: ubuntu-latest
     if: "! github.event.pull_request.head.repo.fork "
     steps:

--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -9,7 +9,7 @@ on:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
   pull_request:
-    branches: [main, develop, "release/**"]
+    branches: [main, develop]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
@@ -321,10 +321,10 @@ jobs:
           else
               echo "all-checks=false" >> "$GITHUB_OUTPUT"
           fi
-      - name: exit without publish
-        if: ${{ steps.check.outputs.all-checks == 'false' || ( github.event.action == 'labeled' && github.event.label.name == 'preserve_infra' ) }}
+      - name: Fail job is something failed
+        if: ${{ steps.check.outputs.all-checks == 'false' }}
         run: |
-          echo "Some check failed or Workflow has triggered on preserve_infra label."
+          echo "Some check failed"
           exit 1
 
   release:


### PR DESCRIPTION
It waits the following jobs
      - test-ui
      - build-test-addon-openapi-client
      - storybook-screenshots

and fails if something fails. It will be useful for setting required checks for PRs