### PR TITLE
docs(entity): clarify options params

### DIFF
--- a/docs/entity/index.md
+++ b/docs/entity/index.md
@@ -24,6 +24,8 @@ title: Entity
 
 ## Common Options
 
+This section describes common options that can be used within the `options` object in entity properties.
+
 | Property            | Type    | Description                                                                            | Default Value |
 |---------------------|---------|----------------------------------------------------------------------------------------|---------------|
 | placeholder         | string  | (`Deprecated`) The grey text is shown when the input is empty.                         | -             |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,6 +14,7 @@ markdown_extensions:
   - fenced_code
   - sane_lists
   - codehilite
+  - pymdownx.superfences
 
 theme:
   name: "material"


### PR DESCRIPTION
- Add a bit of descriptions for common options
- pymdownx.superfences for enabling code highlighting 

Related to #1101
