### PR TITLE
test: add more ui tests for account page

### DIFF
--- a/tests/testdata/expected_addons/expected_output_global_config_everything/Splunk_TA_UCCExample/README/splunk_ta_uccexample_account.conf.spec
+++ b/tests/testdata/expected_addons/expected_output_global_config_everything/Splunk_TA_UCCExample/README/splunk_ta_uccexample_account.conf.spec
@@ -1,7 +1,7 @@
 [<name>]
 custom_endpoint = 
-endpoint =
-url =
+endpoint = 
+url = 
 account_checkbox = 
 account_radio = 
 account_multiple_select = 

--- a/tests/testdata/expected_addons/expected_output_global_config_everything/Splunk_TA_UCCExample/README/splunk_ta_uccexample_account.conf.spec
+++ b/tests/testdata/expected_addons/expected_output_global_config_everything/Splunk_TA_UCCExample/README/splunk_ta_uccexample_account.conf.spec
@@ -1,6 +1,7 @@
 [<name>]
 custom_endpoint = 
-endpoint = 
+endpoint =
+url =
 account_checkbox = 
 account_radio = 
 account_multiple_select = 

--- a/tests/testdata/expected_addons/expected_output_global_config_everything/Splunk_TA_UCCExample/bin/splunk_ta_uccexample_rh_account.py
+++ b/tests/testdata/expected_addons/expected_output_global_config_everything/Splunk_TA_UCCExample/bin/splunk_ta_uccexample_rh_account.py
@@ -30,6 +30,15 @@ fields = [
         validator=None
     ), 
     field.RestField(
+        'url',
+        required=False,
+        encrypted=False,
+        default=None,
+        validator=validator.Pattern(
+            regex=r"""^(https://)[^/]+/?$""", 
+        )
+    ), 
+    field.RestField(
         'account_checkbox',
         required=False,
         encrypted=False,

--- a/tests/testdata/test_addons/package_global_config_everything/globalConfig.json
+++ b/tests/testdata/test_addons/package_global_config_everything/globalConfig.json
@@ -91,6 +91,23 @@
                             }
                         },
                         {
+                            "field": "url",
+                            "label": "URL",
+                            "type": "text",
+                            "help": "Enter the URL, for example",
+                            "required": false,
+                            "options": {
+                                "placeholder": "Required"
+                            },
+                            "validators": [
+                                {
+                                    "errorMsg": "Invalid URL provided. URL should start with 'https' as only secure URLs are supported. Provide URL in this format",
+                                    "type": "regex",
+                                    "pattern": "^(https://)[^/]+/?$"
+                                }
+                            ]
+                        },
+                        {
                             "type": "checkbox",
                             "label": "Example Checkbox",
                             "field": "account_checkbox",
@@ -1561,9 +1578,9 @@
     "meta": {
         "name": "Splunk_TA_UCCExample",
         "restRoot": "splunk_ta_uccexample",
-        "version": "5.40.0Rfd67bf22a",
+        "version": "5.41.0R629ac8f1",
         "displayName": "Splunk UCC test Add-on",
         "schemaVersion": "0.0.3",
-        "_uccVersion": "5.40.0"
+        "_uccVersion": "5.41.0"
     }
 }

--- a/tests/testdata/test_addons/package_global_config_everything_uccignore/globalConfig.json
+++ b/tests/testdata/test_addons/package_global_config_everything_uccignore/globalConfig.json
@@ -91,6 +91,23 @@
                             }
                         },
                         {
+                            "field": "url",
+                            "label": "URL",
+                            "type": "text",
+                            "help": "Enter the URL, for example",
+                            "required": false,
+                            "options": {
+                                "placeholder": "Required"
+                            },
+                            "validators": [
+                                {
+                                    "errorMsg": "Invalid URL provided. URL should start with 'https' as only secure URLs are supported. Provide URL in this format",
+                                    "type": "regex",
+                                    "pattern": "^(https://)[^/]+/?$"
+                                }
+                            ]
+                        },
+                        {
                             "type": "checkbox",
                             "label": "Example Checkbox",
                             "field": "account_checkbox",
@@ -1410,9 +1427,9 @@
     "meta": {
         "name": "Splunk_TA_UCCExample",
         "restRoot": "splunk_ta_uccexample",
-        "version": "5.40.0R84ad898f",
+        "version": "5.41.0Rc98e158c",
         "displayName": "Splunk UCC test Add-on",
         "schemaVersion": "0.0.3",
-        "_uccVersion": "5.40.0"
+        "_uccVersion": "5.41.0"
     }
 }

--- a/tests/ui/pages/account_page.py
+++ b/tests/ui/pages/account_page.py
@@ -11,8 +11,10 @@ from pytest_splunk_addon_ui_smartx.components.controls.checkbox import Checkbox
 from pytest_splunk_addon_ui_smartx.components.controls.textbox import TextBox
 from pytest_splunk_addon_ui_smartx.components.controls.learn_more import LearnMore
 from pytest_splunk_addon_ui_smartx.components.controls.toggle import Toggle
+from pytest_splunk_addon_ui_smartx.components.controls.message import Message
 from pytest_splunk_addon_ui_smartx.components.conf_table import ConfigurationTable
 from pytest_splunk_addon_ui_smartx.backend_confs import ListBackendConf
+
 
 from tests.ui import constants as C
 
@@ -36,6 +38,9 @@ class AccountEntity(Entity):
         # Controls
         self.name = TextBox(
             browser, Selector(select='[data-test="control-group"][data-name="name"]')
+        )
+        self.URL = TextBox(
+            browser, Selector(select='[data-test="control-group"][data-name="url"]')
         )
         self.environment = SingleSelect(
             browser,
@@ -96,6 +101,10 @@ class AccountEntity(Entity):
             ),
         )
         self.title = BaseComponent(browser, Selector(select='[data-test="title"]'))
+        self.auth_type = OAuthSelect(
+            browser,
+            Selector(select='[data-test="control-group"][data-name="auth_type"]'),
+        )
 
 
 class AccountPage(Page):
@@ -121,6 +130,14 @@ class AccountPage(Page):
             )
             self.entity = AccountEntity(
                 ucc_smartx_selenium_helper.browser, account_container
+            )
+            self.title = Message(
+                ucc_smartx_selenium_helper.browser,
+                Selector(select=' [data-test="column"] .pageTitle'),
+            )
+            self.description = Message(
+                ucc_smartx_selenium_helper.browser,
+                Selector(select=' [data-test="column"] .pageSubtitle'),
             )
 
         if ucc_smartx_rest_helper:

--- a/tests/ui/test_configuration_page_account_tab.py
+++ b/tests/ui/test_configuration_page_account_tab.py
@@ -573,6 +573,12 @@ class TestAccount(UccTester):
             "Name must begin with a letter and consist exclusively of alphanumeric characters and underscores.",
             left_args={"expect_error": True},
         )
+        account.entity.name.set_value("a" * 51)
+        self.assert_util(
+            account.entity.save,
+            "Length of ID should be between 1 and 50",
+            left_args={"expect_error": True},
+        )
 
     @pytest.mark.execute_enterprise_cloud_true
     @pytest.mark.forwarder
@@ -787,7 +793,7 @@ class TestAccount(UccTester):
             "disabled": False,
             "password": "******",
             "token": "******",
-            'url': 'https://test.example.com'
+            "url": "https://test.example.com",
         }
 
     @pytest.mark.execute_enterprise_cloud_true
@@ -965,7 +971,7 @@ class TestAccount(UccTester):
             "disabled": False,
             "password": "TestEditPassword",
             "token": "TestEditToken",
-            'url': 'https://test.example.com'
+            "url": "https://test.example.com",
         }
 
     @pytest.mark.execute_enterprise_cloud_true
@@ -997,7 +1003,7 @@ class TestAccount(UccTester):
             "disabled": False,
             "password": "TestEditPassword",
             "token": "TestEditToken",
-            'url': 'https://test.example.com'
+            "url": "https://test.example.com",
         }
 
     @pytest.mark.execute_enterprise_cloud_true
@@ -1091,7 +1097,6 @@ class TestAccount(UccTester):
         self.assert_util(account.entity.password.get_value, "")
         self.assert_util(account.entity.security_token.get_value, "")
 
-
     @pytest.mark.execute_enterprise_cloud_true
     @pytest.mark.account
     @pytest.mark.forwarder
@@ -1105,7 +1110,6 @@ class TestAccount(UccTester):
             account.description.wait_to_display,
             "Set up your add-on",
         )
-
 
     @pytest.mark.execute_enterprise_cloud_true
     @pytest.mark.account
@@ -1128,29 +1132,6 @@ class TestAccount(UccTester):
             left_args={"expect_error": True},
         )
 
-
-    @pytest.mark.execute_enterprise_cloud_true
-    @pytest.mark.account
-    @pytest.mark.forwarder
-    def test_account_valid_length_account_name(
-        self, ucc_smartx_selenium_helper, ucc_smartx_rest_helper
-    ):
-        """Verifies character lenth of field account_name"""
-        account = AccountPage(ucc_smartx_selenium_helper, ucc_smartx_rest_helper)
-        account.entity.open()
-        account.entity.name.set_value(ACCOUNT_CONFIG.get("name") * 10)
-        account.entity.URL.set_value(ACCOUNT_CONFIG.get("url"))
-        if account.entity.auth_type.get_value() == "oauth":
-            account.entity.auth_type.select(ACCOUNT_CONFIG.get("auth_type"))
-        account.entity.username.set_value(ACCOUNT_CONFIG.get("username"))
-        account.entity.password.set_value(ACCOUNT_CONFIG.get("password"))
-        self.assert_util(
-            account.entity.save,
-            "Length of ID should be between 1 and 50",
-            left_args={"expect_error": True},
-        )
-
-
     @pytest.mark.execute_enterprise_cloud_true
     @pytest.mark.account
     @pytest.mark.forwarder
@@ -1168,7 +1149,6 @@ class TestAccount(UccTester):
             if account.entity.auth_type.get_value() != auth_type_value:
                 account.entity.auth_type.select(auth_type_name)
             self.assert_util(account.entity.auth_type.get_value, auth_type_value)
-
 
     @pytest.mark.execute_enterprise_cloud_true
     @pytest.mark.account
@@ -1193,11 +1173,15 @@ class TestAccount(UccTester):
     @pytest.mark.execute_enterprise_cloud_true
     @pytest.mark.account
     @pytest.mark.forwarder
-    def test_account_url_validation(self, ucc_smartx_selenium_helper,  ucc_smartx_rest_helper):
+    def test_account_url_validation(
+        self, ucc_smartx_selenium_helper, ucc_smartx_rest_helper
+    ):
         account = AccountPage(ucc_smartx_selenium_helper, ucc_smartx_rest_helper)
         account.entity.open()
         account.entity.name.set_value(ACCOUNT_CONFIG.get("name"))
         invalid_url = "invalid_url"
         account.entity.URL.set_value(invalid_url)
-        self.assert_util(account.entity.save(expect_error=True),
-                         "Invalid URL provided. URL should start with 'https' as only secure URLs are supported. Provide URL in this format")
+        self.assert_util(
+            account.entity.save(expect_error=True),
+            "Invalid URL provided. URL should start with 'https' as only secure URLs are supported. Provide URL in this format",  # noqa: E501
+        )

--- a/tests/ui/test_configuration_page_account_tab.py
+++ b/tests/ui/test_configuration_page_account_tab.py
@@ -20,6 +20,7 @@ ACCOUNT_CONFIG = {
     "redirect_url": "",
     "endpoint": "",
     "example_help_link": "",
+    "url": "https://test.example.com",
 }
 
 
@@ -786,6 +787,7 @@ class TestAccount(UccTester):
             "disabled": False,
             "password": "******",
             "token": "******",
+            'url': 'https://test.example.com'
         }
 
     @pytest.mark.execute_enterprise_cloud_true
@@ -963,6 +965,7 @@ class TestAccount(UccTester):
             "disabled": False,
             "password": "TestEditPassword",
             "token": "TestEditToken",
+            'url': 'https://test.example.com'
         }
 
     @pytest.mark.execute_enterprise_cloud_true
@@ -994,6 +997,7 @@ class TestAccount(UccTester):
             "disabled": False,
             "password": "TestEditPassword",
             "token": "TestEditToken",
+            'url': 'https://test.example.com'
         }
 
     @pytest.mark.execute_enterprise_cloud_true
@@ -1086,3 +1090,114 @@ class TestAccount(UccTester):
         self.assert_util(account.entity.username.get_value, ACCOUNT_CONFIG["username"])
         self.assert_util(account.entity.password.get_value, "")
         self.assert_util(account.entity.security_token.get_value, "")
+
+
+    @pytest.mark.execute_enterprise_cloud_true
+    @pytest.mark.account
+    @pytest.mark.forwarder
+    def test_account_title_and_description(
+        self, ucc_smartx_selenium_helper, ucc_smartx_rest_helper
+    ):
+        """Verifies title and discription"""
+        account = AccountPage(ucc_smartx_selenium_helper, ucc_smartx_rest_helper)
+        self.assert_util(account.title.wait_to_display, "Configuration")
+        self.assert_util(
+            account.description.wait_to_display,
+            "Set up your add-on",
+        )
+
+
+    @pytest.mark.execute_enterprise_cloud_true
+    @pytest.mark.account
+    @pytest.mark.forwarder
+    def test_account_valid_input_account_name(
+        self, ucc_smartx_selenium_helper, ucc_smartx_rest_helper
+    ):
+        """Verifies validation of field account_name"""
+        account = AccountPage(ucc_smartx_selenium_helper, ucc_smartx_rest_helper)
+        account.entity.open()
+        account.entity.name.set_value("1234")
+        account.entity.URL.set_value(ACCOUNT_CONFIG.get("url"))
+        if account.entity.auth_type.get_value() == "oauth":
+            account.entity.auth_type.select(ACCOUNT_CONFIG.get("auth_type"))
+        account.entity.username.set_value(ACCOUNT_CONFIG.get("username"))
+        account.entity.password.set_value(ACCOUNT_CONFIG.get("password"))
+        self.assert_util(
+            account.entity.save,
+            "Name must begin with a letter and consist exclusively of alphanumeric characters and underscores.",
+            left_args={"expect_error": True},
+        )
+
+
+    @pytest.mark.execute_enterprise_cloud_true
+    @pytest.mark.account
+    @pytest.mark.forwarder
+    def test_account_valid_length_account_name(
+        self, ucc_smartx_selenium_helper, ucc_smartx_rest_helper
+    ):
+        """Verifies character lenth of field account_name"""
+        account = AccountPage(ucc_smartx_selenium_helper, ucc_smartx_rest_helper)
+        account.entity.open()
+        account.entity.name.set_value(ACCOUNT_CONFIG.get("name") * 10)
+        account.entity.URL.set_value(ACCOUNT_CONFIG.get("url"))
+        if account.entity.auth_type.get_value() == "oauth":
+            account.entity.auth_type.select(ACCOUNT_CONFIG.get("auth_type"))
+        account.entity.username.set_value(ACCOUNT_CONFIG.get("username"))
+        account.entity.password.set_value(ACCOUNT_CONFIG.get("password"))
+        self.assert_util(
+            account.entity.save,
+            "Length of ID should be between 1 and 50",
+            left_args={"expect_error": True},
+        )
+
+
+    @pytest.mark.execute_enterprise_cloud_true
+    @pytest.mark.account
+    @pytest.mark.forwarder
+    def test_account_select_value_auth_type(
+        self, ucc_smartx_selenium_helper, ucc_smartx_rest_helper
+    ):
+        """Select the all the values from single select and verifies the selected value"""
+        account = AccountPage(ucc_smartx_selenium_helper, ucc_smartx_rest_helper)
+        account.entity.open()
+        auth_value_dict = {
+            "basic": "Basic Authentication",
+            "oauth": "OAuth 2.0 Authentication",
+        }
+        for auth_type_value, auth_type_name in auth_value_dict.items():
+            if account.entity.auth_type.get_value() != auth_type_value:
+                account.entity.auth_type.select(auth_type_name)
+            self.assert_util(account.entity.auth_type.get_value, auth_type_value)
+
+
+    @pytest.mark.execute_enterprise_cloud_true
+    @pytest.mark.account
+    @pytest.mark.forwarder
+    def test_account_add_reserved_value_account_name(
+        self, ucc_smartx_selenium_helper, ucc_smartx_rest_helper
+    ):
+        """Select the all the values from single select and verifies the selected value"""
+        account = AccountPage(ucc_smartx_selenium_helper, ucc_smartx_rest_helper)
+        account.entity.open()
+        account.entity.name.set_value("default")
+        account.entity.URL.set_value(ACCOUNT_CONFIG.get("url"))
+        if account.entity.auth_type.get_value() == "oauth":
+            account.entity.auth_type.select(ACCOUNT_CONFIG.get("auth_type"))
+        account.entity.username.set_value(ACCOUNT_CONFIG.get("username"))
+        account.entity.password.set_value(ACCOUNT_CONFIG.get("password"))
+        self.assert_util(
+            account.entity.save(expect_error=True),
+            r'"default", ".", "..", string started with "_" and string including any one of ["*", "\", "[", "]", "(", ")", "?", ":"] are reserved value which cannot be used for field Name',  # noqa: E501
+        )
+
+    @pytest.mark.execute_enterprise_cloud_true
+    @pytest.mark.account
+    @pytest.mark.forwarder
+    def test_account_url_validation(self, ucc_smartx_selenium_helper,  ucc_smartx_rest_helper):
+        account = AccountPage(ucc_smartx_selenium_helper, ucc_smartx_rest_helper)
+        account.entity.open()
+        account.entity.name.set_value(ACCOUNT_CONFIG.get("name"))
+        invalid_url = "invalid_url"
+        account.entity.URL.set_value(invalid_url)
+        self.assert_util(account.entity.save(expect_error=True),
+                         "Invalid URL provided. URL should start with 'https' as only secure URLs are supported. Provide URL in this format")


### PR DESCRIPTION
Added UI tests that cover account page. These tests were [removed from ServiceNow add-on](https://github.com/splunk/splunk-add-on-for-servicenow/pull/710). 