### PR TITLE
chore(webpack): disable throwing warnings about lack of licenses

### DIFF
--- a/ui/webpack.config.js
+++ b/ui/webpack.config.js
@@ -45,10 +45,9 @@ module.exports = merge(baseConfig, {
         hot: false,
         client: {
             overlay: {
-                warnings: (warning) =>
-                    !warning.message.includes(
-                        'license-webpack-plugin: could not find any license file for styled-components'
-                    ),
+                errors: true,
+                warnings: false, // it throws warnings about lack of package licenses
+                runtimeErrors: true,
             },
         },
         proxy: [

--- a/ui/webpack.config.js
+++ b/ui/webpack.config.js
@@ -36,20 +36,21 @@ module.exports = merge(baseConfig, {
             },
         ],
     },
-    plugins: [new LicenseWebpackPlugin(), new ForkTsCheckerWebpackPlugin()],
+    plugins: [
+        new LicenseWebpackPlugin({
+            stats: {
+                warnings: false,
+                errors: true,
+            },
+        }),
+        new ForkTsCheckerWebpackPlugin(),
+    ],
     devtool: 'source-map',
     resolve: {
         fallback: { querystring: require.resolve('querystring-es3') },
     },
     devServer: {
         hot: false,
-        client: {
-            overlay: {
-                errors: true,
-                warnings: false, // it throws warnings about lack of package licenses
-                runtimeErrors: true,
-            },
-        },
         proxy: [
             {
                 target: proxyTargetUrl,


### PR DESCRIPTION
disable warning about lack of licenses in packages:
```
WARNING in license-webpack-plugin: could not find any license file for styled-components. Use the licenseTextOverrides option to add the license text if desired.

WARNING in license-webpack-plugin: could not find any license file for @mdhnpm/rgb-hex-converter. Use the licenseTextOverrides option to add the license text if desired.

WARNING in license-webpack-plugin: could not find any license type for uuid-v4 in its package.json

WARNING in license-webpack-plugin: could not find any license file for uuid-v4. Use the licenseTextOverrides option to add the license text if desired.

WARNING in license-webpack-plugin: could not find any license type for maplibre-gl in its package.json
```