### PR TITLE
feat: file input component, supports base64 encoding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ init_addon_for_ucc_package/
 # ignore everything except redirect_page.js
 splunk_add_on_ucc_framework/package/appserver/static/js/build/
 !splunk_add_on_ucc_framework/package/appserver/static/js/build/redirect_page.js
+ui/.cache

--- a/.gitignore
+++ b/.gitignore
@@ -46,4 +46,3 @@ init_addon_for_ucc_package/
 # ignore everything except redirect_page.js
 splunk_add_on_ucc_framework/package/appserver/static/js/build/
 !splunk_add_on_ucc_framework/package/appserver/static/js/build/redirect_page.js
-ui/.cache

--- a/docs/entity/components.md
+++ b/docs/entity/components.md
@@ -454,7 +454,7 @@ By default it supports files that can be opened in text mode or with a text edit
 
 It only sends file content to the server by reading it using the [readAsArrayBuffer](https://developer.mozilla.org/en-US/docs/Web/API/FileReader/readAsArrayBuffer) method of the FileReader class, and then decoding it into **UTF-8** format, using the [decode](https://developer.mozilla.org/en-US/docs/Web/API/TextDecoder/decode) method of the TextDecoder class.
 
-If `options` property contains useBase64Encoding is set up as true, then readAsArrayBuffer method is replaced with [readAsDataURL](https://developer.mozilla.org/en-US/docs/Web/API/FileReader/readAsDataURL) and proceeded correctly to pass only file content. With that approach any file is stored in **Base64** format.
+If `options` property contains useBase64Encoding is set up as true, then readAsArrayBuffer method is replaced with [readAsDataURL](https://developer.mozilla.org/en-US/docs/Web/API/FileReader/readAsDataURL) and obtained data are correctly proceeded to store only file content (beggining of result is removed, as it contains unwanted informations and pure encoded file content is saved). With that approach any file is stored in **Base64** format.
 
 The file content can be validated using in-built validators such as [string](validators.md#string) and [regex](validators.md#regex), and a custom validator can also be implemented using a [custom hook](../custom_ui_extensions/custom_hook.md) and [saveValidator](../advanced/save_validator.md).
 

--- a/docs/entity/components.md
+++ b/docs/entity/components.md
@@ -450,9 +450,11 @@ This is how it looks in the UI:
 
 See the underlying `@splunk/react-ui` component: [`File`](https://splunkui.splunk.com/Packages/react-ui/File).
 
-It supports files that can be opened in text mode or with a text editor, which are files with extensions such as txt, json, xml, yaml, pem, key, crt, etc.
+By default it supports files that can be opened in text mode or with a text editor, which are files with extensions such as txt, json, xml, yaml, pem, key, crt, etc.
 
 It only sends file content to the server by reading it using the [readAsArrayBuffer](https://developer.mozilla.org/en-US/docs/Web/API/FileReader/readAsArrayBuffer) method of the FileReader class, and then decoding it into **UTF-8** format, using the [decode](https://developer.mozilla.org/en-US/docs/Web/API/TextDecoder/decode) method of the TextDecoder class.
+
+If `options` property contains useBase64Encoding is set up as true, then readAsArrayBuffer method is replaced with [readAsDataURL](https://developer.mozilla.org/en-US/docs/Web/API/FileReader/readAsDataURL) and proceeded correctly to pass only file content. With that approach any file is stored in **Base64** format.
 
 The file content can be validated using in-built validators such as [string](validators.md#string) and [regex](validators.md#regex), and a custom validator can also be implemented using a [custom hook](../custom_ui_extensions/custom_hook.md) and [saveValidator](../advanced/save_validator.md).
 
@@ -460,11 +462,12 @@ This feature allows you to upload a single file.
 
 <h3> Options </h3>
 
-| Property                                                   | Type   | Description                                                | Default Value |
-| ---------------------------------------------------------- | ------ | ---------------------------------------------------------- | ------------- |
-| fileSupportMessage                                          | string | It displays a message inside a file component.                   | -             |
-| supportedFileTypes<span class="required-asterisk">*</span> | array  | It is a list of the file types that the user can upload.          | -             |
-| maxFileSize                                                | number | It sets the maximum file size in KB that a user can upload.  | 500KB         |
+| Property                                                    | Type    | Description                                                                                 | Default Value |
+| ----------------------------------------------------------- | ------- | ------------------------------------------------------------------------------------------- | ------------- |
+| fileSupportMessage                                          | string  | It displays a message inside a file component.                                              | -             |
+| supportedFileTypes<span class="required-asterisk">\*</span> | array   | It is a list of the file types that the user can upload.                                    | -             |
+| maxFileSize                                                 | number  | It sets the maximum file size in KB that a user can upload.                                 | 500KB         |
+| useBase64Encoding                                           | boolean | It defines used encoding for files. If true base64 will be used, if false utf-8 is applied. | false         |
 
 See the following example usage:
 ```json
@@ -476,7 +479,8 @@ See the following example usage:
     "options": {
         "fileSupportMessage": "Support message",
         "supportedFileTypes": ["pem", "txt"],
-        "maxFileSize": 100
+        "maxFileSize": 100,
+        "useBase64Encoding": false
     },
     "validators": [
         {

--- a/splunk_add_on_ucc_framework/schema/schema.json
+++ b/splunk_add_on_ucc_framework/schema/schema.json
@@ -1124,6 +1124,9 @@
                 "type": "string"
               },
               "uniqueItems": true
+            },
+            "useBase64Encoding": {
+              "type": "boolean"
             }
           },
           "additionalProperties": false

--- a/ui/src/components/FileInputComponent/FileInputComponent.test.tsx
+++ b/ui/src/components/FileInputComponent/FileInputComponent.test.tsx
@@ -355,9 +355,10 @@ test('Check FileInputComponent encodes base64 correctly and passed it to handler
         supportedFileTypes: ['json'],
         useBase64Encoding: true,
     };
+    const fileContent = '{"test":"test"}';
     const handleChange = jest.fn();
 
-    const testfile = new File(['{"test":"test"}'], 'test.json', {
+    const testfile = new File([fileContent], 'test.json', {
         type: 'application/json',
     });
 
@@ -374,5 +375,5 @@ test('Check FileInputComponent encodes base64 correctly and passed it to handler
     await userEvent.upload(fileInput, testfile);
 
     // Check that handleChange is called with valid args.
-    expect(handleChange).toHaveBeenCalledWith('testFileField', btoa(`{"test":"test"}`));
+    expect(handleChange).toHaveBeenCalledWith(field, btoa(fileContent));
 });

--- a/ui/src/components/FileInputComponent/FileInputComponent.test.tsx
+++ b/ui/src/components/FileInputComponent/FileInputComponent.test.tsx
@@ -346,3 +346,33 @@ it('File input disabled - rendered correctly with disabled attr', () => {
     expect(fileComponent).toHaveAttribute('disabled');
     consoleSpy.mockRestore();
 });
+
+test('Check FileInputComponent encodes base64 correctly and passed it to handler', async () => {
+    const field = 'testFileField';
+    const disabled = false;
+    const controlOptions = {
+        fileSupportMessage: 'Support Message',
+        supportedFileTypes: ['json'],
+        useBase64Encoding: true,
+    };
+    const handleChange = jest.fn();
+
+    const testfile = new File(['{"test":"test"}'], 'test.json', {
+        type: 'application/json',
+    });
+
+    render(
+        <FileInputComponent
+            field={field}
+            disabled={disabled}
+            controlOptions={controlOptions}
+            handleChange={handleChange}
+        />
+    );
+
+    const fileInput = screen.getByTestId('file-input');
+    await userEvent.upload(fileInput, testfile);
+
+    // Check that handleChange is called with valid args.
+    expect(handleChange).toHaveBeenCalledWith('testFileField', btoa(`{"test":"test"}`));
+});

--- a/ui/src/types/globalConfig/entities.ts
+++ b/ui/src/types/globalConfig/entities.ts
@@ -232,6 +232,7 @@ export const FileEntity = CommonEditableEntityFields.extend({
             maxFileSize: z.number().optional(),
             fileSupportMessage: z.string().optional(),
             supportedFileTypes: z.array(z.string()),
+            useBase64Encoding: z.boolean().default(false).optional(),
         })
         .optional(),
     modifyFieldsOnValue: ModifyFieldsOnValue,


### PR DESCRIPTION
Add configurable support for none text files, via encoding content to base64 string.
https://splunk.atlassian.net/browse/ADDON-69993