### PR TITLE
chore: remove default webpack licenses

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -106,6 +106,7 @@
     "storybook": "^8.0.9",
     "style-loader": "^4.0.0",
     "stylelint": "^14.16.1",
+    "terser-webpack-plugin": "^5.3.10",
     "ts-node": "^10.9.2",
     "typescript": "^5.4.5",
     "undici": "^5.28.4",

--- a/ui/webpack.config.js
+++ b/ui/webpack.config.js
@@ -5,6 +5,7 @@ const { merge } = require('webpack-merge');
 const { LicenseWebpackPlugin } = require('license-webpack-plugin');
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 const baseConfig = require('@splunk/webpack-configs/base.config').default;
+const TerserPlugin = require("terser-webpack-plugin");
 
 const proxyTargetUrl = 'http://localhost:8000';
 
@@ -72,5 +73,13 @@ module.exports = merge(baseConfig, {
 
             return middlewares;
         },
+    },
+    optimization: {
+        minimize: true,
+        minimizer: [
+            new TerserPlugin({
+                extractComments: false,
+            }),
+        ],
     },
 });


### PR DESCRIPTION
Removing default webpack licenses that creates files with extensions `.js.LICENSE.txt`