### PR TITLE
docs(governance): add GitHub issue type for documentation updates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,31 +1,35 @@
 ---
 name: Bug report
 description: >-
-  Report a bug or an unexpected behavior to help us improve the package
+  Report a bug or an unexpected behavior to help us improve UCC
 title: 'BUG: '
 labels:
 - bug
+- triage
 
 body:
 - type: markdown
   attributes:
     value: >
-      ## Thank you for helping us improve ucc-gen!
+      ## Thank you for helping us improve UCC!
 
       * First, please verify that your issue is not already reported using the
       [Issue search](https://github.com/splunk/addonfactory-ucc-generator/search?q=is%3Aissue&type=issues).
 - type: textarea
   attributes:
     label: Description
-    description: >-
-      A concise description of the bug.
+    description: A concise description of the bug.
   validations:
     required: true
 - type: input
   attributes:
-    label: What ucc-gen version are you using?
+    label: What UCC version are you using?
     placeholder: For example splunk-add-on-ucc-framework==5.13.0
+  validations:
+    required: true
 - type: input
   attributes:
     label: Additional System Info
     placeholder: Python version, OS (Linux/Mac/Windows/WSL), etc.
+  validations:
+    required: true

--- a/.github/ISSUE_TEMPLATE/docs.yml
+++ b/.github/ISSUE_TEMPLATE/docs.yml
@@ -1,0 +1,37 @@
+---
+name: Documentation update
+description: Suggest a documentation update to improve everyone's experience
+title: 'Docs: '
+labels:
+  - documentation
+  - triage
+
+body:
+  - type: textarea
+    id: search_area
+    attributes:
+      label: What were you searching in the docs?
+      description: Please help us understand how you looked for information that was either unclear or not available
+    validations:
+      required: true
+  - type: input
+    id: area
+    attributes:
+      label: Is this related to an existing documentation section?
+      description: Please share a link, if applicable
+    validations:
+      required: false
+  - type: textarea
+    id: idea
+    attributes:
+      label: How can we improve?
+      description: Please share your thoughts on how we can improve this experience
+    validations:
+      required: true
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Got a suggestion in mind?
+      description: Please suggest a proposed update
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -5,6 +5,7 @@ description: >-
 title: 'Feature request: '
 labels:
 - enhancement
+- triage
 
 body:
 - type: markdown
@@ -12,9 +13,10 @@ body:
     value: >
       Please:
 
-      - [ ] Check for duplicate requests.
+      - [ ] Check for duplicate requests
 - type: textarea
   attributes:
     label: Description
-    description: >-
-      Description of the feature request.
+    description: Description of the feature request
+  validations:
+    required: true


### PR DESCRIPTION
This PR adds a new GitHub issue for documentation updates.