### PR TITLE
fix: explicitly pass required field

### DIFF
--- a/ui/src/components/BaseFormView/stories/BaseFormView.stories.tsx
+++ b/ui/src/components/BaseFormView/stories/BaseFormView.stories.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+import BaseFormView from '../BaseFormView';
+import {
+    PAGE_CONFIG_BOTH_OAUTH,
+    getConfigOauthBasic,
+    getConfigOauthOauth,
+} from './globalConfigs/configPageOauth';
+import { setUnifiedConfig } from '../../../util/util';
+import { GlobalConfig } from '../../../types/globalConfig/globalConfig';
+import { Mode } from '../../../constants/modes';
+import { BaseFormProps } from '../BaseFormTypes';
+
+interface BaseFormStoriesProps extends BaseFormProps {
+    config: GlobalConfig;
+}
+
+const meta = {
+    title: 'BaseFormView',
+    render: (props) => {
+        setUnifiedConfig(props.config);
+        return (
+            <BaseFormView
+                serviceName={props.serviceName}
+                mode={props.mode}
+                page={props.page}
+                stanzaName={props.stanzaName}
+                handleFormSubmit={props.handleFormSubmit}
+            />
+        );
+    },
+} satisfies Meta<BaseFormStoriesProps>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const OuathBasic: Story = {
+    args: {
+        currentServiceState: {},
+        serviceName: 'account',
+        mode: 'create' as Mode,
+        page: 'configuration',
+        stanzaName: 'unknownStanza',
+        handleFormSubmit: fn(),
+        config: getConfigOauthBasic() as GlobalConfig,
+    },
+};
+
+export const OauthOauth: Story = {
+    args: {
+        currentServiceState: {},
+        serviceName: 'account',
+        mode: 'create' as Mode,
+        page: 'configuration',
+        stanzaName: 'unknownStanza',
+        handleFormSubmit: fn(),
+        config: getConfigOauthOauth() as GlobalConfig,
+    },
+};
+
+export const BothOauth: Story = {
+    args: {
+        currentServiceState: {},
+        serviceName: 'account',
+        mode: 'create' as Mode,
+        page: 'configuration',
+        stanzaName: 'unknownStanza',
+        handleFormSubmit: fn(),
+        config: PAGE_CONFIG_BOTH_OAUTH as GlobalConfig,
+    },
+};

--- a/ui/src/components/BaseFormView/stories/__images__/BaseFormView-both-oauth-chromium.png
+++ b/ui/src/components/BaseFormView/stories/__images__/BaseFormView-both-oauth-chromium.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a52afa89bb9d7d51c70d39b52a042342b6618df71625cc888e9a2bc8100fef72
+size 30526

--- a/ui/src/components/BaseFormView/stories/__images__/BaseFormView-oauth-oauth-chromium.png
+++ b/ui/src/components/BaseFormView/stories/__images__/BaseFormView-oauth-oauth-chromium.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fa6e4a868eea93d0778462b24894c2657894ff6c2357a94090308bdfba908ec7
+size 44126

--- a/ui/src/components/BaseFormView/stories/__images__/BaseFormView-ouath-basic-chromium.png
+++ b/ui/src/components/BaseFormView/stories/__images__/BaseFormView-ouath-basic-chromium.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7c53c6470fe7cc8e4baea0a2a4d68847d56a5925e6c29190d7f0ac8446f1b586
+size 26558

--- a/ui/src/components/BaseFormView/stories/globalConfigs/configPageOauth.ts
+++ b/ui/src/components/BaseFormView/stories/globalConfigs/configPageOauth.ts
@@ -1,0 +1,239 @@
+export const PAGE_CONFIG_BOTH_OAUTH = {
+    pages: {
+        configuration: {
+            tabs: [
+                {
+                    name: 'account',
+                    table: {
+                        actions: ['edit', 'delete', 'clone'],
+                        header: [
+                            {
+                                label: 'Name',
+                                field: 'name',
+                            },
+                            {
+                                label: 'Auth Type',
+                                field: 'auth_type',
+                            },
+                        ],
+                    },
+                    entity: [
+                        {
+                            type: 'text',
+                            label: 'Name',
+                            validators: [
+                                {
+                                    type: 'string',
+                                    errorMsg: 'Length of ID should be between 1 and 50',
+                                    minLength: 1,
+                                    maxLength: 50,
+                                },
+                                {
+                                    type: 'regex',
+                                    errorMsg:
+                                        'Name must begin with a letter and consist exclusively of alphanumeric characters and underscores.',
+                                    pattern: '^[a-zA-Z]\\w*$',
+                                },
+                            ],
+                            field: 'name',
+                            help: 'Enter a unique name for this account.',
+                            required: true,
+                        },
+                        {
+                            type: 'text',
+                            label: 'Endpoint URL',
+                            help: 'Enter the endpoint URL.',
+                            field: 'endpoint',
+                            options: {
+                                display: false,
+                                requiredWhenVisible: true,
+                            },
+                        },
+                        {
+                            type: 'oauth',
+                            field: 'oauth',
+                            label: 'Not used',
+                            options: {
+                                auth_type: ['basic', 'oauth'],
+                                basic: [
+                                    {
+                                        oauth_field: 'username',
+                                        label: 'Username',
+                                        help: 'Enter the username for this account.',
+                                        field: 'username',
+                                    },
+                                    {
+                                        oauth_field: 'password',
+                                        label: 'Password',
+                                        encrypted: true,
+                                        help: 'Enter the password for this account.',
+                                        field: 'password',
+                                    },
+                                    {
+                                        oauth_field: 'security_token',
+                                        label: 'Security Token',
+                                        encrypted: true,
+                                        help: 'Enter the security token.',
+                                        field: 'token',
+                                    },
+                                    {
+                                        oauth_field: 'some_text',
+                                        label: 'Disabled on edit for oauth',
+                                        help: 'Enter text for field disabled on edit',
+                                        field: 'basic_oauth_text',
+                                        required: false,
+                                        options: {
+                                            disableonEdit: true,
+                                        },
+                                    },
+                                ],
+                                oauth: [
+                                    {
+                                        oauth_field: 'client_id',
+                                        label: 'Client Id',
+                                        field: 'client_id',
+                                        help: 'Enter the Client Id for this account.',
+                                    },
+                                    {
+                                        oauth_field: 'client_secret',
+                                        label: 'Client Secret',
+                                        field: 'client_secret',
+                                        encrypted: true,
+                                        help: 'Enter the Client Secret key for this account.',
+                                    },
+                                    {
+                                        oauth_field: 'redirect_url',
+                                        label: 'Redirect url',
+                                        field: 'redirect_url',
+                                        help: 'Copy and paste this URL into your app.',
+                                    },
+                                    {
+                                        oauth_field: 'endpoint_token',
+                                        label: 'Token endpoint',
+                                        field: 'endpoint_token',
+                                        help: 'Put here endpoint used for token acqusition ie. login.salesforce.com',
+                                    },
+                                    {
+                                        oauth_field: 'endpoint_authorize',
+                                        label: 'Authorize endpoint',
+                                        field: 'endpoint_authorize',
+                                        help: 'Put here endpoint used for authorization ie. login.salesforce.com',
+                                    },
+                                    {
+                                        oauth_field: 'oauth_some_text',
+                                        label: 'Disabled on edit for oauth',
+                                        help: 'Enter text for field disabled on edit',
+                                        field: 'oauth_oauth_text',
+                                        required: false,
+                                        options: {
+                                            disableonEdit: true,
+                                            enable: false,
+                                        },
+                                    },
+                                ],
+                                auth_code_endpoint: '/services/oauth2/authorize',
+                                access_token_endpoint: '/services/oauth2/token',
+                                oauth_timeout: 30,
+                                oauth_state_enabled: false,
+                            },
+                        },
+                    ],
+                    title: 'Account',
+                    restHandlerModule: 'splunk_ta_uccexample_validate_account_rh',
+                    restHandlerClass: 'CustomAccountValidator',
+                },
+            ],
+            title: 'Configuration',
+            description: 'Set up your add-on',
+        },
+        inputs: {
+            services: [
+                {
+                    name: 'example_input_one',
+                    entity: [
+                        {
+                            type: 'text',
+                            label: 'Name',
+                            validators: [
+                                {
+                                    type: 'regex',
+                                    errorMsg:
+                                        'Input Name must begin with a letter and consist exclusively of alphanumeric characters and underscores.',
+                                    pattern: '^[a-zA-Z]\\w*$',
+                                },
+                                {
+                                    type: 'string',
+                                    errorMsg: 'Length of input name should be between 1 and 100',
+                                    minLength: 1,
+                                    maxLength: 100,
+                                },
+                            ],
+                            field: 'name',
+                            help: 'A unique name for the data input.',
+                            required: true,
+                        },
+                        {
+                            type: 'checkbox',
+                            label: 'Example Checkbox',
+                            field: 'input_one_checkbox',
+                            help: 'This is an example checkbox for the input one entity',
+                            defaultValue: true,
+                        },
+                    ],
+                    title: 'Example Input One',
+                },
+            ],
+            title: 'Inputs',
+            description: 'Manage your data inputs',
+            subDescription: {
+                text: "Input page - Ingesting data from to Splunk Cloud? Have you tried the new Splunk Data Manager yet?\nData Manager makes AWS data ingestion simpler, more automated and centrally managed for you, while co-existing with AWS and/or Kinesis TAs.\nRead our [[blogPost]] to learn more about Data Manager and it's availability on your Splunk Cloud instance.",
+                links: [
+                    {
+                        slug: 'blogPost',
+                        link: 'https://splk.it/31oy2b2',
+                        linkText: 'blog post',
+                    },
+                ],
+            },
+            table: {
+                actions: ['edit', 'enable', 'delete', 'search', 'clone'],
+                header: [
+                    {
+                        label: 'Name',
+                        field: 'name',
+                    },
+                ],
+                moreInfo: [
+                    {
+                        label: 'Name',
+                        field: 'name',
+                    },
+                ],
+            },
+        },
+    },
+    meta: {
+        name: 'Splunk_TA_UCCExample',
+        restRoot: 'splunk_ta_uccexample',
+        version: '5.41.0R9c5fbfe0',
+        displayName: 'Splunk UCC test Add-on',
+        schemaVersion: '0.0.3',
+        _uccVersion: '5.41.0',
+    },
+};
+
+export const getConfigOauthBasic = () => {
+    const configCp = JSON.parse(JSON.stringify(PAGE_CONFIG_BOTH_OAUTH));
+    if (configCp.pages.configuration.tabs[0].entity[2].options?.auth_type) {
+        configCp.pages.configuration.tabs[0].entity[2].options.auth_type = ['basic'];
+    }
+    return configCp;
+};
+
+export const getConfigOauthOauth = () => {
+    const configCp = JSON.parse(JSON.stringify(PAGE_CONFIG_BOTH_OAUTH));
+    if (configCp.pages.configuration.tabs[0].entity[2].options?.auth_type) {
+        configCp.pages.configuration.tabs[0].entity[2].options.auth_type = ['oauth'];
+    }
+    return configCp;
+};

--- a/ui/src/components/ControlWrapper/ControlWrapper.tsx
+++ b/ui/src/components/ControlWrapper/ControlWrapper.tsx
@@ -125,6 +125,11 @@ class ControlWrapper extends React.PureComponent<ControlWrapperProps> {
             </>
         );
 
+        const isFieldRequired =
+            this.props.entity?.required === undefined
+                ? 'oauth_field' in (this.props.entity || {}) // if required is undefined use true for oauth fields and false for others
+                : this.props.entity?.required; // if required present use required
+
         return (
             this.props.display && (
                 <ControlGroupWrapper
@@ -135,6 +140,7 @@ class ControlWrapper extends React.PureComponent<ControlWrapperProps> {
                     // @ts-expect-error property should be data-name, but is mapped in obj ControlGroupWrapper
                     dataName={this?.props?.entity.field}
                     labelWidth={240}
+                    required={isFieldRequired}
                 >
                     <CustomElement>{rowView}</CustomElement>
                 </ControlGroupWrapper>


### PR DESCRIPTION
**Issue number:** [ADDON-68506](https://splunk.atlassian.net/browse/ADDON-68506)

## Summary
[UCC UI] Show asterisk for all required fields

### Changes

Fix bug that by default Asterix was not added to any field . Right now by default required is true for oauth fields and false for any other fields. (If field contains `oauth_field` property (every oauth field contains it), it is marked with asterix by default, unless specified differently.

Pass required parameter explicitly to wrapper.

### User experience

Asterix should be displayed correctly for oauth fields.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)
