### PR TITLE
refactor: GlobalConfig class to self-determine json and yaml

### DIFF
--- a/splunk_add_on_ucc_framework/commands/build.py
+++ b/splunk_add_on_ucc_framework/commands/build.py
@@ -361,6 +361,24 @@ def _get_python_version_from_executable(python_binary_name: str) -> str:
         )
 
 
+def _get_and_check_global_config_path(
+    source: str, config_path: Optional[str]
+) -> Optional[str]:
+    if not config_path:
+        config_path = os.path.abspath(
+            os.path.join(source, os.pardir, "globalConfig.json")
+        )
+        if os.path.isfile(config_path):
+            return config_path
+        else:
+            config_path = os.path.abspath(
+                os.path.join(source, os.pardir, "globalConfig.yaml")
+            )
+    if os.path.isfile(config_path) and config_path.endswith((".json", ".yaml")):
+        return config_path
+    return None
+
+
 def summary_report(
     source: str,
     ta_name: str,
@@ -508,24 +526,11 @@ def generate(
     logger.info(f"Cleaned out directory {output_directory}")
     app_manifest = _get_app_manifest(source)
     ta_name = app_manifest.get_addon_name()
-    if not config_path:
-        is_global_config_yaml = False
-        config_path = os.path.abspath(
-            os.path.join(source, os.pardir, "globalConfig.json")
-        )
-        if not os.path.isfile(config_path):
-            config_path = os.path.abspath(
-                os.path.join(source, os.pardir, "globalConfig.yaml")
-            )
-            is_global_config_yaml = True
-    else:
-        is_global_config_yaml = True if config_path.endswith(".yaml") else False
 
-    if os.path.isfile(config_path):
-        logger.info(f"Using globalConfig file located @ {config_path}")
-        global_config = global_config_lib.GlobalConfig(
-            config_path, is_global_config_yaml
-        )
+    gc_path = _get_and_check_global_config_path(source, config_path)
+    if gc_path:
+        logger.info(f"Using globalConfig file located @ {gc_path}")
+        global_config = global_config_lib.GlobalConfig(gc_path)
         # handle the update of globalConfig before validating
         global_config_update.handle_global_config_update(global_config)
         try:
@@ -558,7 +563,7 @@ def generate(
         )
         logger.info("Copied UCC template directory")
         global_config_file = (
-            "globalConfig.yaml" if is_global_config_yaml else "globalConfig.json"
+            "globalConfig.yaml" if gc_path.endswith(".yaml") else "globalConfig.json"
         )
         output_global_config_path = os.path.join(
             output_directory,

--- a/splunk_add_on_ucc_framework/commands/build.py
+++ b/splunk_add_on_ucc_framework/commands/build.py
@@ -361,22 +361,18 @@ def _get_python_version_from_executable(python_binary_name: str) -> str:
         )
 
 
-def _get_and_check_global_config_path(
-    source: str, config_path: Optional[str]
-) -> Optional[str]:
+def _get_and_check_global_config_path(source: str, config_path: Optional[str]) -> str:
     if not config_path:
         config_path = os.path.abspath(
             os.path.join(source, os.pardir, "globalConfig.json")
         )
-        if os.path.isfile(config_path):
-            return config_path
-        else:
+        if not os.path.isfile(config_path):
             config_path = os.path.abspath(
                 os.path.join(source, os.pardir, "globalConfig.yaml")
             )
-    if os.path.isfile(config_path) and config_path.endswith((".json", ".yaml")):
+    if os.path.isfile(config_path):
         return config_path
-    return None
+    return ""
 
 
 def summary_report(

--- a/splunk_add_on_ucc_framework/global_config.py
+++ b/splunk_add_on_ucc_framework/global_config.py
@@ -59,12 +59,14 @@ class GlobalConfig:
     def __init__(self, global_config_path: str) -> None:
         with open(global_config_path) as f_config:
             config_raw = f_config.read()
-        self._is_global_config_yaml = False
-        try:
-            self._content = json.loads(config_raw)
-        except json.decoder.JSONDecodeError:
-            self._content = yaml_load(config_raw)
-            self._is_global_config_yaml = True
+        self._is_global_config_yaml = (
+            True if global_config_path.endswith(".yaml") else False
+        )
+        self._content = (
+            yaml_load(config_raw)
+            if self._is_global_config_yaml
+            else json.loads(config_raw)
+        )
         self._original_path = global_config_path
 
     def dump(self, path: str) -> None:

--- a/splunk_add_on_ucc_framework/global_config.py
+++ b/splunk_add_on_ucc_framework/global_config.py
@@ -56,13 +56,15 @@ class OSDependentLibraryConfig:
 
 
 class GlobalConfig:
-    def __init__(self, global_config_path: str, is_global_config_yaml: bool) -> None:
+    def __init__(self, global_config_path: str) -> None:
         with open(global_config_path) as f_config:
             config_raw = f_config.read()
-        self._content = (
-            yaml_load(config_raw) if is_global_config_yaml else json.loads(config_raw)
-        )
-        self._is_global_config_yaml = is_global_config_yaml
+        self._is_global_config_yaml = False
+        try:
+            self._content = json.loads(config_raw)
+        except json.decoder.JSONDecodeError:
+            self._content = yaml_load(config_raw)
+            self._is_global_config_yaml = True
         self._original_path = global_config_path
 
     def dump(self, path: str) -> None:

--- a/tests/unit/commands/rest_builder/test_generate_import_declare_test.py
+++ b/tests/unit/commands/rest_builder/test_generate_import_declare_test.py
@@ -40,7 +40,7 @@ def test_generate_import_declare_test_with_os_lib(tmp_path):
     global_config_path = helpers.get_testdata_file_path(
         "valid_config_with_os_libraries.json"
     )
-    global_config = gc.GlobalConfig(global_config_path, False)
+    global_config = gc.GlobalConfig(global_config_path)
 
     tmp_lib_path = tmp_path / "output"
     run_rest_builder_build(global_config, tmp_lib_path)
@@ -54,7 +54,7 @@ def test_generate_import_declare_test_without_os_lib(tmp_path):
     global_config_path = helpers.get_testdata_file_path(
         "valid_config_only_configuration.json"
     )
-    global_config = gc.GlobalConfig(global_config_path, False)
+    global_config = gc.GlobalConfig(global_config_path)
 
     tmp_lib_path = tmp_path / "output"
     run_rest_builder_build(global_config, tmp_lib_path)

--- a/tests/unit/commands/test_build.py
+++ b/tests/unit/commands/test_build.py
@@ -7,6 +7,7 @@ from splunk_add_on_ucc_framework.commands.build import (
     _add_modular_input,
     _get_build_output_path,
     _get_python_version_from_executable,
+    _get_and_check_global_config_path,
 )
 from splunk_add_on_ucc_framework.exceptions import (
     CouldNotIdentifyPythonVersionException,
@@ -40,6 +41,44 @@ def test_get_python_version_from_executable(mock_run):
     python_version = _get_python_version_from_executable("python3")
 
     assert python_version == target_python_version
+
+
+def test_get_and_check_global_config_path():
+    source = os.path.join(
+        os.path.dirname(os.path.realpath(__file__)), "testdata", "package"
+    )
+    assert None is _get_and_check_global_config_path(source, "")
+    assert None is _get_and_check_global_config_path(source, "invalid_ext.txt")
+
+    expected_return = os.path.join(
+        os.path.dirname(os.path.realpath(__file__)),
+        os.pardir,
+        "testdata",
+        "valid_config.json",
+    )
+    assert expected_return is _get_and_check_global_config_path(source, expected_return)
+
+    expected_return = os.path.join(
+        os.path.dirname(os.path.realpath(__file__)),
+        os.pardir,
+        "testdata",
+        "valid_config.yaml",
+    )
+    assert expected_return is _get_and_check_global_config_path(source, expected_return)
+
+    base = os.path.join(
+        os.path.dirname(os.path.realpath(__file__)),
+        os.pardir,
+        os.pardir,
+        "testdata",
+        "test_addons",
+        "package_global_config_everything",
+    )
+    source = os.path.join(base, "package")
+    expected_return = os.path.join(base, "globalConfig.json")
+    assert os.path.abspath(expected_return) == _get_and_check_global_config_path(
+        source, ""
+    )
 
 
 def test_get_python_version_from_executable_nonexisting_command():

--- a/tests/unit/commands/test_build.py
+++ b/tests/unit/commands/test_build.py
@@ -47,8 +47,8 @@ def test_get_and_check_global_config_path():
     source = os.path.join(
         os.path.dirname(os.path.realpath(__file__)), "testdata", "package"
     )
-    assert None is _get_and_check_global_config_path(source, "")
-    assert None is _get_and_check_global_config_path(source, "invalid_ext.txt")
+    assert _get_and_check_global_config_path(source, "") == ""
+    assert _get_and_check_global_config_path(source, "invalid_ext.txt") == ""
 
     expected_return = os.path.join(
         os.path.dirname(os.path.realpath(__file__)),
@@ -56,7 +56,7 @@ def test_get_and_check_global_config_path():
         "testdata",
         "valid_config.json",
     )
-    assert expected_return is _get_and_check_global_config_path(source, expected_return)
+    assert _get_and_check_global_config_path(source, expected_return) is expected_return
 
     expected_return = os.path.join(
         os.path.dirname(os.path.realpath(__file__)),
@@ -64,7 +64,7 @@ def test_get_and_check_global_config_path():
         "testdata",
         "valid_config.yaml",
     )
-    assert expected_return is _get_and_check_global_config_path(source, expected_return)
+    assert _get_and_check_global_config_path(source, expected_return) is expected_return
 
     base = os.path.join(
         os.path.dirname(os.path.realpath(__file__)),
@@ -76,8 +76,8 @@ def test_get_and_check_global_config_path():
     )
     source = os.path.join(base, "package")
     expected_return = os.path.join(base, "globalConfig.json")
-    assert os.path.abspath(expected_return) == _get_and_check_global_config_path(
-        source, ""
+    assert _get_and_check_global_config_path(source, "") == os.path.abspath(
+        expected_return
     )
 
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -23,14 +23,14 @@ def global_config_all_json_content():
 @pytest.fixture
 def global_config_all_json() -> global_config_lib.GlobalConfig:
     global_config_path = helpers.get_testdata_file_path("valid_config.json")
-    global_config = global_config_lib.GlobalConfig(global_config_path, False)
+    global_config = global_config_lib.GlobalConfig(global_config_path)
     return global_config
 
 
 @pytest.fixture
 def global_config_all_yaml() -> global_config_lib.GlobalConfig:
     global_config_path = helpers.get_testdata_file_path("valid_config.yaml")
-    global_config = global_config_lib.GlobalConfig(global_config_path, True)
+    global_config = global_config_lib.GlobalConfig(global_config_path)
     return global_config
 
 
@@ -39,7 +39,7 @@ def global_config_only_configuration() -> global_config_lib.GlobalConfig:
     global_config_path = helpers.get_testdata_file_path(
         "valid_config_only_configuration.json"
     )
-    global_config = global_config_lib.GlobalConfig(global_config_path, False)
+    global_config = global_config_lib.GlobalConfig(global_config_path)
     return global_config
 
 
@@ -48,5 +48,5 @@ def global_config_only_logging() -> global_config_lib.GlobalConfig:
     global_config_path = helpers.get_testdata_file_path(
         "valid_config_only_logging.json"
     )
-    global_config = global_config_lib.GlobalConfig(global_config_path, False)
+    global_config = global_config_lib.GlobalConfig(global_config_path)
     return global_config

--- a/tests/unit/test_dashboard.py
+++ b/tests/unit/test_dashboard.py
@@ -65,7 +65,7 @@ def setup(tmp_path):
     global_config_path = helpers.get_testdata_file_path(
         "valid_config_with_custom_dashboard.json"
     )
-    global_config = gc.GlobalConfig(global_config_path, False)
+    global_config = gc.GlobalConfig(global_config_path)
     tmp_ta_path = tmp_path / "test_ta"
     os.makedirs(tmp_ta_path)
     custom_dash_path = os.path.join(tmp_ta_path, "custom_dashboard.json")
@@ -108,7 +108,7 @@ def test_generate_dashboard_only_custom_components(setup, tmp_path):
     global_config_path = helpers.get_testdata_file_path(
         "valid_config_only_custom_dashboard.json"
     )
-    global_config = gc.GlobalConfig(global_config_path, False)
+    global_config = gc.GlobalConfig(global_config_path)
 
     with open(custom_dash_path, "w") as file:
         file.write(json.dumps(custom_definition))

--- a/tests/unit/test_global_config.py
+++ b/tests/unit/test_global_config.py
@@ -10,15 +10,15 @@ from splunk_add_on_ucc_framework import global_config as global_config_lib
 
 
 @pytest.mark.parametrize(
-    "filename,is_yaml",
+    "filename",
     [
-        ("valid_config.json", False),
-        ("valid_config.yaml", True),
+        "valid_config.json",
+        "valid_config.yaml",
     ],
 )
-def test_global_config_parse(filename, is_yaml):
+def test_global_config_parse(filename):
     global_config_path = helpers.get_testdata_file_path(filename)
-    global_config = global_config_lib.GlobalConfig(global_config_path, is_yaml)
+    global_config = global_config_lib.GlobalConfig(global_config_path)
 
     assert global_config.namespace == "splunk_ta_uccexample"
     assert global_config.product == "Splunk_TA_UCCExample"
@@ -84,7 +84,7 @@ def test_global_config_update_addon_version(global_config_only_configuration):
 def test_global_config_expand(tmp_path):
     global_config_path = helpers.get_testdata_file_path("valid_config_expand.json")
 
-    global_config = global_config_lib.GlobalConfig(global_config_path, False)
+    global_config = global_config_lib.GlobalConfig(global_config_path)
 
     assert {"type": "loggingTab"} in global_config.tabs
     assert count_tabs(global_config, name="logging") == 0

--- a/tests/unit/test_global_config_update.py
+++ b/tests/unit/test_global_config_update.py
@@ -15,15 +15,15 @@ from splunk_add_on_ucc_framework import global_config as global_config_lib
 
 
 @pytest.mark.parametrize(
-    "filename,is_yaml",
+    "filename",
     [
-        ("config_with_biased_terms.json", False),
-        ("config_with_biased_terms.yaml", True),
+        "config_with_biased_terms.json",
+        "config_with_biased_terms.yaml",
     ],
 )
-def test_handle_biased_terms_update(filename, is_yaml):
+def test_handle_biased_terms_update(filename):
     global_config_path = helpers.get_testdata_file_path(filename)
-    global_config = global_config_lib.GlobalConfig(global_config_path, is_yaml)
+    global_config = global_config_lib.GlobalConfig(global_config_path)
     _handle_biased_terms_update(global_config)
     expected_schema_version = "0.0.1"
     assert expected_schema_version == global_config.schema_version
@@ -46,15 +46,15 @@ def test_handle_biased_terms_update(filename, is_yaml):
 
 
 @pytest.mark.parametrize(
-    "filename,is_yaml",
+    "filename",
     [
-        ("config_with_biased_terms.json", False),
-        ("config_with_biased_terms.yaml", True),
+        "config_with_biased_terms.json",
+        "config_with_biased_terms.yaml",
     ],
 )
-def test_handle_dropping_api_version_update(filename, is_yaml):
+def test_handle_dropping_api_version_update(filename):
     global_config_path = helpers.get_testdata_file_path(filename)
-    global_config = global_config_lib.GlobalConfig(global_config_path, is_yaml)
+    global_config = global_config_lib.GlobalConfig(global_config_path)
     _handle_dropping_api_version_update(global_config)
     expected_schema_version = "0.0.3"
     assert expected_schema_version == global_config.schema_version
@@ -65,7 +65,7 @@ def test_handle_alert_action_updates(tmp_path, caplog):
     tmp_file_gc = tmp_path / "globalConfig.json"
     # a new globalConfig with minimal configs for input and configuration
     helpers.copy_testdata_gc_to_tmp_file(tmp_file_gc, "valid_config_all_alerts.json")
-    global_config = global_config_lib.GlobalConfig(str(tmp_file_gc), False)
+    global_config = global_config_lib.GlobalConfig(str(tmp_file_gc))
 
     _handle_alert_action_updates(global_config)
 
@@ -94,7 +94,7 @@ def test_migrate_old_dashboard(tmp_path, caplog):
     tmp_file_gc = tmp_path / "globalConfig.json"
     helpers.copy_testdata_gc_to_tmp_file(tmp_file_gc, "valid_config_old_dashboard.json")
 
-    global_config = global_config_lib.GlobalConfig(str(tmp_file_gc), False)
+    global_config = global_config_lib.GlobalConfig(str(tmp_file_gc))
     _handle_xml_dashboard_update(global_config)
 
     expected_schema_version = "0.0.5"
@@ -115,7 +115,7 @@ def test_tab_migration(tmp_path):
     helpers.copy_testdata_gc_to_tmp_file(tmp_file_gc, "valid_config_only_logging.json")
     assert "loggingTab" not in tmp_file_gc.read_text()
 
-    global_config = global_config_lib.GlobalConfig(str(tmp_file_gc), False)
+    global_config = global_config_lib.GlobalConfig(str(tmp_file_gc))
     _dump_with_migrated_tabs(global_config, global_config.original_path)
 
     assert "loggingTab" in tmp_file_gc.read_text()
@@ -136,7 +136,7 @@ def test_entity_migration(tmp_path):
     )
     assert '"type": "interval"' not in tmp_file_gc.read_text()
 
-    global_config = global_config_lib.GlobalConfig(str(tmp_file_gc), False)
+    global_config = global_config_lib.GlobalConfig(str(tmp_file_gc))
     _dump_with_migrated_entities(global_config, global_config.original_path)
 
     assert '"type": "interval"' in tmp_file_gc.read_text()

--- a/tests/unit/test_global_config_validator.py
+++ b/tests/unit/test_global_config_validator.py
@@ -12,16 +12,16 @@ from splunk_add_on_ucc_framework import global_config as global_config_lib
 
 
 @pytest.mark.parametrize(
-    "filename,is_yaml",
+    "filename",
     [
-        ("valid_config.json", False),
-        ("valid_config.yaml", True),
-        ("valid_config_only_logging.json", False),
+        "valid_config.json",
+        "valid_config.yaml",
+        "valid_config_only_logging.json",
     ],
 )
-def test_config_validation_when_valid(filename, is_yaml):
+def test_config_validation_when_valid(filename):
     global_config_path = helpers.get_testdata_file_path(filename)
-    global_config = global_config_lib.GlobalConfig(global_config_path, is_yaml)
+    global_config = global_config_lib.GlobalConfig(global_config_path)
 
     validator = GlobalConfigValidator(helpers.get_path_to_source_dir(), global_config)
 
@@ -34,7 +34,7 @@ def test_autocompletefields_support_integer_values():
     global_config_path = helpers.get_testdata_file_path(
         "invalid_config_configuration_autoCompleteFields_integer_values.json"
     )
-    global_config = global_config_lib.GlobalConfig(global_config_path, False)
+    global_config = global_config_lib.GlobalConfig(global_config_path)
 
     validator = GlobalConfigValidator(helpers.get_path_to_source_dir(), global_config)
 
@@ -47,7 +47,7 @@ def test_autocompletefields_children_support_integer_values():
     global_config_path = helpers.get_testdata_file_path(
         "invalid_config_configuration_autoCompleteFields_children_integer_values.json"
     )
-    global_config = global_config_lib.GlobalConfig(global_config_path, False)
+    global_config = global_config_lib.GlobalConfig(global_config_path)
 
     validator = GlobalConfigValidator(helpers.get_path_to_source_dir(), global_config)
 
@@ -59,7 +59,7 @@ def test_config_validation_when_deprecated_placeholder_is_used(caplog):
     global_config_path = helpers.get_testdata_file_path(
         "valid_config_deprecated_placeholder_usage.json"
     )
-    global_config = global_config_lib.GlobalConfig(global_config_path, False)
+    global_config = global_config_lib.GlobalConfig(global_config_path)
 
     validator = GlobalConfigValidator(helpers.get_path_to_source_dir(), global_config)
     validator.validate()
@@ -72,23 +72,20 @@ def test_config_validation_when_deprecated_placeholder_is_used(caplog):
 
 
 @pytest.mark.parametrize(
-    "filename,is_yaml,exception_message",
+    "filename,exception_message",
     [
         (
             "invalid_config_no_configuration_tabs.json",
-            False,
             "[] is too short",
         ),
         (
             "invalid_config_no_name_field_in_configuration_tab_table.json",
-            False,
             "Tab 'account' should have entity with field 'name'",
         ),
         # restHandlerName and restHandlerModule are present in the
         # "example_input_one" input
         (
             "invalid_config_both_rest_handler_name_module_are_present.json",
-            False,
             (
                 "Input 'example_input_one' has both 'restHandlerName' and "
                 "'restHandlerModule' or 'restHandlerClass' fields present. "
@@ -100,7 +97,6 @@ def test_config_validation_when_deprecated_placeholder_is_used(caplog):
         # "example_input_one" input
         (
             "invalid_config_both_rest_handler_name_class_are_present.json",
-            False,
             (
                 "Input 'example_input_one' has both 'restHandlerName' and "
                 "'restHandlerModule' or 'restHandlerClass' fields present. "
@@ -111,7 +107,6 @@ def test_config_validation_when_deprecated_placeholder_is_used(caplog):
         # Only restHandlerModule is present in the "example_input_one" input
         (
             "invalid_config_only_rest_handler_module_is_present.json",
-            False,
             (
                 "Input 'example_input_one' should have both 'restHandlerModule'"
                 " and 'restHandlerClass' fields present, only 1 of them was found."
@@ -120,7 +115,6 @@ def test_config_validation_when_deprecated_placeholder_is_used(caplog):
         # Only restHandlerClass is present in the "example_input_one" input
         (
             "invalid_config_only_rest_handler_class_is_present.json",
-            False,
             (
                 "Input 'example_input_one' should have both 'restHandlerModule'"
                 " and 'restHandlerClass' fields present, only 1 of them was found."
@@ -128,14 +122,12 @@ def test_config_validation_when_deprecated_placeholder_is_used(caplog):
         ),
         (
             "invalid_config_options_missing_for_file_input.json",
-            False,
             (
                 "Options field for the file type should be present for 'service_account' field."
             ),
         ),
         (
             "invalid_config_supported_file_types_field_is_missing.json",
-            False,
             (
                 "You should define your supported file types in "
                 "the `supportedFileTypes` field for the "
@@ -144,14 +136,12 @@ def test_config_validation_when_deprecated_placeholder_is_used(caplog):
         ),
         (
             "invalid_config_file_is_encrypted_but_not_required.json",
-            False,
             (
                 "Field service_account uses type 'file' which is encrypted and not required, this is not supported"
             ),
         ),
         (
             "invalid_config_configuration_string_validator_maxLength_less_than_minLength.json",
-            False,
             (
                 "Entity 'name' has incorrect string validator, "
                 "'maxLength' should be greater or equal than 'minLength'."
@@ -159,7 +149,6 @@ def test_config_validation_when_deprecated_placeholder_is_used(caplog):
         ),
         (
             "invalid_config_configuration_number_validator_range_should_have_2_elements.json",
-            False,
             (
                 "Entity 'interval' has incorrect number validator, "
                 "it should have 2 elements under 'range' field."
@@ -167,7 +156,6 @@ def test_config_validation_when_deprecated_placeholder_is_used(caplog):
         ),
         (
             "invalid_config_configuration_number_validator_interval_range.json",
-            False,
             (
                 "Entity 'interval' has incorrect number validator, "
                 "it should have 2 elements under 'range' field."
@@ -175,7 +163,6 @@ def test_config_validation_when_deprecated_placeholder_is_used(caplog):
         ),
         (
             "invalid_config_configuration_number_validator_range_second_element_smaller_than_first.json",
-            False,
             (
                 "Entity 'interval' has incorrect number validator, "
                 "second element should be greater or equal than first element."
@@ -183,7 +170,6 @@ def test_config_validation_when_deprecated_placeholder_is_used(caplog):
         ),
         (
             "invalid_config_configuration_regex_validator_non_compilable_pattern.json",
-            False,
             (
                 "Entity 'name' has incorrect regex validator, "
                 "pattern provided in the 'pattern' field is not compilable."
@@ -191,7 +177,6 @@ def test_config_validation_when_deprecated_placeholder_is_used(caplog):
         ),
         (
             "invalid_config_inputs_string_validator_maxLength_less_than_minLength.json",
-            False,
             (
                 "Entity 'name' has incorrect string validator, "
                 "'maxLength' should be greater or equal than 'minLength'."
@@ -199,7 +184,6 @@ def test_config_validation_when_deprecated_placeholder_is_used(caplog):
         ),
         (
             "invalid_config_inputs_number_validator_range_should_have_2_elements.json",
-            False,
             (
                 "Entity 'port' has incorrect number validator, "
                 "it should have 2 elements under 'range' field."
@@ -207,7 +191,6 @@ def test_config_validation_when_deprecated_placeholder_is_used(caplog):
         ),
         (
             "invalid_config_inputs_number_validator_range_second_element_smaller_than_first.json",
-            False,
             (
                 "Entity 'port' has incorrect number validator, "
                 "second element should be greater or equal than first element."
@@ -215,7 +198,6 @@ def test_config_validation_when_deprecated_placeholder_is_used(caplog):
         ),
         (
             "invalid_config_inputs_regex_validator_non_compilable_pattern.json",
-            False,
             (
                 "Entity 'name' has incorrect regex validator, "
                 "pattern provided in the 'pattern' field is not compilable."
@@ -223,67 +205,54 @@ def test_config_validation_when_deprecated_placeholder_is_used(caplog):
         ),
         (
             "invalid_config_no_configuration_tabs.yaml",
-            True,
             "[] is too short",
         ),
         (
             "invalid_config_no_name_field_in_configuration_tab_table.yaml",
-            True,
             "Tab 'account' should have entity with field 'name'",
         ),
         (
             "invalid_config_configuration_autoCompleteFields_duplicates.json",
-            False,
             "Duplicates found for autoCompleteFields: 'Duplicate'",
         ),
         (
             "invalid_config_configuration_children_duplicates.json",
-            False,
             "Duplicates found for autoCompleteFields children in entity 'Duplicate'",
         ),
         (
             "invalid_config_configuration_entity_duplicates.json",
-            False,
             "Duplicates found for entity field or label",
         ),
         (
             "invalid_config_configuration_tabs_duplicates.json",
-            False,
             "Duplicates found for tabs names, titles or types",
         ),
         (
             "invalid_config_configuration_tabs_type_duplicates.json",
-            False,
             "Duplicates found for tabs names, titles or types",
         ),
         (
             "invalid_config_inputs_services_duplicates.json",
-            False,
             "Duplicates found for inputs (services) names or titles",
         ),
         (
             "invalid_config_inputs_entity_duplicates.json",
-            False,
             "Duplicates found for entity field or label",
         ),
         (
             "invalid_config_inputs_children_duplicates.json",
-            False,
             "Duplicates found for autoCompleteFields children in entity 'Single Select'",
         ),
         (
             "invalid_config_inputs_autoCompleteFields_duplicates.json",
-            False,
             "Duplicates found for autoCompleteFields: 'Single Select'",
         ),
         (
             "invalid_config_inputs_multilevel_menu_duplicate_groups.json",
-            False,
             "Duplicates found for multi-level menu groups' names or titles.",
         ),
         (
             "invalid_config_inputs_multilevel_menu_invalid_groupservices.json",
-            False,
             (
                 "example_input_three ServiceName in the multi-level menu does "
                 "not match any services name."
@@ -291,7 +260,6 @@ def test_config_validation_when_deprecated_placeholder_is_used(caplog):
         ),
         (
             "invalid_config_inputs_multilevel_menu_invalid_groupname_or_grouptitle.json",
-            False,
             (
                 "example_input_three groupName or Example Input Three "
                 "groupTitle in the multi-level menu does not match any "
@@ -300,7 +268,6 @@ def test_config_validation_when_deprecated_placeholder_is_used(caplog):
         ),
         (
             "invalid_config_unsupported_name_in_dashboard_panel.json",
-            False,
             (
                 f"'unsupported_panel_name' is not a supported panel name. "
                 f"Supported panel names: {dashboard.SUPPORTED_PANEL_NAMES_READABLE}"
@@ -308,35 +275,30 @@ def test_config_validation_when_deprecated_placeholder_is_used(caplog):
         ),
         (
             "invalid_config_checkbox_groups_duplicate_fields_in_options_rows.json",
-            False,
             (
                 "Entity test_checkbox_group has duplicate field (collectFolderCollaboration) in options.rows"
             ),
         ),
         (
             "invalid_config_checkbox_groups_undefined_field_used_in_groups.json",
-            False,
             (
                 "Entity test_checkbox_group uses field (undefined_field_foo) which is not defined in options.rows"
             ),
         ),
         (
             "invalid_config_checkbox_groups_duplicate_field_in_options_groups.json",
-            False,
             (
                 "Entity test_checkbox_group has duplicate field (collectTasksAndComments) in options.groups"
             ),
         ),
         (
             "invalid_config_group_has_duplicate_labels.json",
-            False,
             (
                 "Service input_with_duplicate_group_labels has duplicate labels in groups"
             ),
         ),
         (
             "invalid_config_group_uses_fields_not_defined_in_entity.json",
-            False,
             (
                 "Service input_with_undefined_group_field uses group field "
                 "undefined_entity_field_name which is not defined in entity"
@@ -344,9 +306,9 @@ def test_config_validation_when_deprecated_placeholder_is_used(caplog):
         ),
     ],
 )
-def test_config_validation_when_error(filename, is_yaml, exception_message):
+def test_config_validation_when_error(filename, exception_message):
     global_config_path = helpers.get_testdata_file_path(filename)
-    global_config = global_config_lib.GlobalConfig(global_config_path, is_yaml)
+    global_config = global_config_lib.GlobalConfig(global_config_path)
 
     validator = GlobalConfigValidator(helpers.get_path_to_source_dir(), global_config)
     with pytest.raises(GlobalConfigValidatorException) as exc_info:
@@ -360,7 +322,7 @@ def test_config_validation_modifications_on_change():
     global_config_path = helpers.get_testdata_file_path(
         "valid_config_with_modification_on_value_change.json"
     )
-    global_config = global_config_lib.GlobalConfig(global_config_path, False)
+    global_config = global_config_lib.GlobalConfig(global_config_path)
 
     validator = GlobalConfigValidator(helpers.get_path_to_source_dir(), global_config)
 
@@ -387,7 +349,7 @@ def test_config_validation_modifications_on_change():
 )
 def test_invalid_config_modifications_correct_raises(filename, raise_message):
     global_config_path = helpers.get_testdata_file_path(filename)
-    global_config = global_config_lib.GlobalConfig(global_config_path, False)
+    global_config = global_config_lib.GlobalConfig(global_config_path)
 
     validator = GlobalConfigValidator(helpers.get_path_to_source_dir(), global_config)
 

--- a/tests/unit/test_install_python_libraries.py
+++ b/tests/unit/test_install_python_libraries.py
@@ -257,7 +257,7 @@ def test_install_python_libraries_invalid_os_libraries(
     global_config_path = helpers.get_testdata_file_path(
         "valid_config_with_invalid_os_libraries.json"
     )
-    global_config = gc.GlobalConfig(global_config_path, False)
+    global_config = gc.GlobalConfig(global_config_path)
 
     tmp_ucc_lib_target = tmp_path / "ucc-lib-target"
     tmp_lib_path = tmp_path / "lib"
@@ -288,7 +288,7 @@ def test_install_libraries_valid_os_libraries(
     global_config_path = helpers.get_testdata_file_path(
         "valid_config_with_os_libraries.json"
     )
-    global_config = gc.GlobalConfig(global_config_path, False)
+    global_config = gc.GlobalConfig(global_config_path)
 
     mock_subprocess_call.return_value = 0
     tmp_ucc_lib_target = tmp_path / "ucc-lib-target"
@@ -368,7 +368,7 @@ def test_install_libraries_version_mismatch(
     global_config_path = helpers.get_testdata_file_path(
         "valid_config_with_os_libraries.json"
     )
-    global_config = gc.GlobalConfig(global_config_path, False)
+    global_config = gc.GlobalConfig(global_config_path)
 
     tmp_ucc_lib_target = tmp_path / "ucc-lib-target"
     ucc_lib_target = str(tmp_ucc_lib_target)


### PR DESCRIPTION
**ADDON-70444**

## Summary

Refactor of globalConfig class to self-determine json or yaml file type. From now on, this class accepts only one parameter - path to the configuration file.

### Changes

Removed _is_global_config_yaml_ parameter from GlobalConfig class. 
Added determination of file type inside __init__ of GlobalConfig
The same behavior as before the changes was maintained

### User experience

no impact

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)
