### PR TITLE
feat: Improve input helper module init scripts

### DIFF
--- a/splunk_add_on_ucc_framework/schema/schema.json
+++ b/splunk_add_on_ucc_framework/schema/schema.json
@@ -2314,6 +2314,10 @@
               "restHandlerClass": {
                 "type": "string",
                 "maxLength": 100
+              },
+              "inputHelperModule": {
+                "type": "string",
+                "maxLength": 100
               }
             },
             "required": ["name", "title", "table", "entity"]

--- a/splunk_add_on_ucc_framework/templates/globalConfig.json.init-template
+++ b/splunk_add_on_ucc_framework/templates/globalConfig.json.init-template
@@ -107,6 +107,7 @@
                             "required": true
                         }
                     ],
+                    "inputHelperModule": "{{addon_input_name}}_helper",
                     "title": "{{addon_input_name}}"
                 }
             ],

--- a/splunk_add_on_ucc_framework/templates/input.helper-init-template
+++ b/splunk_add_on_ucc_framework/templates/input.helper-init-template
@@ -82,7 +82,7 @@ def stream_events(inputs: smi.InputDefinition, event_writer: smi.EventWriter):
                 sourcetype,
                 len(data),
                 input_item.get("index"),
-                account=input_item.get("account")
+                account=input_item.get("account"),
             )
             log.modular_input_end(logger, normalized_input_name)
         except Exception as e:

--- a/splunk_add_on_ucc_framework/templates/input.helper-init-template
+++ b/splunk_add_on_ucc_framework/templates/input.helper-init-template
@@ -81,6 +81,8 @@ def stream_events(inputs: smi.InputDefinition, event_writer: smi.EventWriter):
                 normalized_input_name,
                 sourcetype,
                 len(data),
+                input_item.get("index"),
+                account=input_item.get("account")
             )
             log.modular_input_end(logger, normalized_input_name)
         except Exception as e:

--- a/tests/testdata/expected_addons/expected_addon_after_init/demo_addon_for_splunk/globalConfig.json
+++ b/tests/testdata/expected_addons/expected_addon_after_init/demo_addon_for_splunk/globalConfig.json
@@ -107,6 +107,7 @@
                             "required": true
                         }
                     ],
+                    "inputHelperModule": "demo_input_helper",
                     "title": "demo_input"
                 }
             ],

--- a/tests/testdata/expected_addons/expected_addon_after_init/demo_addon_for_splunk/package/bin/demo_input_helper.py
+++ b/tests/testdata/expected_addons/expected_addon_after_init/demo_addon_for_splunk/package/bin/demo_input_helper.py
@@ -81,6 +81,8 @@ def stream_events(inputs: smi.InputDefinition, event_writer: smi.EventWriter):
                 normalized_input_name,
                 sourcetype,
                 len(data),
+                input_item.get("index"),
+                account=input_item.get("account"),
             )
             log.modular_input_end(logger, normalized_input_name)
         except Exception as e:

--- a/ui/src/types/globalConfig/pages.ts
+++ b/ui/src/types/globalConfig/pages.ts
@@ -91,6 +91,7 @@ export const TableLessServiceSchema = z.object({
     restHandlerModule: z.string().optional(),
     restHandlerClass: z.string().optional(),
     warning: WarningSchema,
+    inputHelperModule: z.string().optional(),
 });
 export const TableFullServiceSchema = TableLessServiceSchema.extend({
     description: z.string().optional(),


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

1. A change in globalConfig.json to enable input module helper by default.
2. Added lines for monitoring.

### User experience

> Please describe what the user experience looks like before and after this change

The feature will work as before during the build stage but the init scripts will contain proper values. Before that, the helper module got generated in the init stage without a proper parameter in the config.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)
