### PR TITLE
chore(CHANGELOG): fix pre-commit markdownlint issues

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,10 +1,8 @@
 # [5.45.0](https://github.com/splunk/addonfactory-ucc-generator/compare/v5.44.0...v5.45.0) (2024-05-28)
 
-
 ### Bug Fixes
 
 * explicitly pass required field ([#1202](https://github.com/splunk/addonfactory-ucc-generator/issues/1202)) ([a0ddbf8](https://github.com/splunk/addonfactory-ucc-generator/commit/a0ddbf896e2598afa6126d752b19aded43f34255))
-
 
 ### Features
 


### PR DESCRIPTION
**Issue number:**

## Summary

[This commit](https://github.com/splunk/addonfactory-ucc-generator/commit/44cbcd9ceedee0865f5864d9912a7ab18e331d8f) introduces the issues
```
markdownlint.............................................................Failed
- hook id: markdownlint
- exit code: 1

docs/CHANGELOG.md:3 MD012/no-multiple-blanks Multiple consecutive blank lines [Expected: 1; Actual: 2]
docs/CHANGELOG.md:8 MD012/no-multiple-blanks Multiple consecutive blank lines [Expected: 1; Actual: 2]
```
That causes pipeline failures

### Changes

Fix the symptoms, but not  aroot cause

### User experience

No UX changes

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)
