### PR TITLE
ci(workflow): add test-unit to required checks

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -299,8 +299,9 @@ jobs:
   all-checks:
     if: ${{ !cancelled() }}
     needs:
-      - test-ui
       - test-unit
+      - test-smoke
+      - test-ui
       - build-test-addon-openapi-client
       - storybook-screenshots
     runs-on: ubuntu-latest
@@ -311,7 +312,7 @@ jobs:
         id: check
         shell: bash
         run: |
-          ALL_JOBS_PASSED=$(echo "$NEEDS" | jq "all(.[]; .result == \"success\")")
+          ALL_JOBS_PASSED=$(echo "$NEEDS" | jq 'all(.[]; .result == "success" or (.result == "skipped" and .steps | all(.[]; .conclusion == "success")))')
           if [[ "$ALL_JOBS_PASSED" == "true" ]]
           then
               echo "all-checks=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -47,6 +47,15 @@ jobs:
           fossa test --debug
         env:
           FOSSA_API_KEY: ${{ secrets.FOSSA_API_KEY }}
+      - name: Check for failed steps for jobs with continue-on-error
+        if: ${{ failure() }}
+        run: echo "failed=true" >> $GITHUB_ENV
+
+      - name: Set output if steps failed
+        run: |
+          echo "failed=${{ env.failed }}" >> $GITHUB_ENV
+    outputs:
+      failed: ${{ env.failed }}
 
   pre-commit:
     runs-on: ubuntu-latest
@@ -143,6 +152,15 @@ jobs:
       - run: |
           poetry install
           poetry run pytest --cov=splunk_add_on_ucc_framework --cov-report=xml tests/unit
+      - name: Check for failed steps for jobs with continue-on-error
+        if: ${{ failure() }}
+        run: echo "failed=true" >> $GITHUB_ENV
+
+      - name: Set output if steps failed
+        run: |
+          echo "failed=${{ env.failed }}" >> $GITHUB_ENV
+    outputs:
+      failed: ${{ env.failed }}
 
   test-smoke:
     name: test-smoke ${{ matrix.python-version }}
@@ -173,6 +191,15 @@ jobs:
       - run: |
           poetry install
           poetry run pytest tests/smoke
+      - name: Check for failed steps for jobs with continue-on-error
+        if: ${{ failure() }}
+        run: echo "failed=true" >> $GITHUB_ENV
+
+      - name: Set output if steps failed
+        run: |
+          echo "failed=${{ env.failed }}" >> $GITHUB_ENV
+    outputs:
+      failed: ${{ env.failed }}
 
   build-test-addon:
     runs-on: ubuntu-latest
@@ -312,7 +339,7 @@ jobs:
         id: check
         shell: bash
         run: |
-          ALL_JOBS_PASSED=$(echo "$NEEDS" | jq 'all(.[]; .result == "success" or (.result == "skipped" and .steps | all(.[]; .conclusion == "success")))')
+          ALL_JOBS_PASSED=$(echo "$NEEDS" | jq 'all(.[]; .result == "success" and (.outputs.failed // "false") != "true")')
           if [[ "$ALL_JOBS_PASSED" == "true" ]]
           then
               echo "all-checks=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -300,6 +300,7 @@ jobs:
     if: ${{ !cancelled() }}
     needs:
       - test-ui
+      - test-unit
       - build-test-addon-openapi-client
       - storybook-screenshots
     runs-on: ubuntu-latest

--- a/tests/unit/test_global_config_validator.py
+++ b/tests/unit/test_global_config_validator.py
@@ -78,6 +78,7 @@ def test_config_validation_when_deprecated_placeholder_is_used(caplog):
             "invalid_config_no_configuration_tabs.json",
             "[] is too short",
         ),
+        False,
         (
             "invalid_config_no_name_field_in_configuration_tab_table.json",
             "Tab 'account' should have entity with field 'name'",

--- a/tests/unit/test_global_config_validator.py
+++ b/tests/unit/test_global_config_validator.py
@@ -78,7 +78,6 @@ def test_config_validation_when_deprecated_placeholder_is_used(caplog):
             "invalid_config_no_configuration_tabs.json",
             "[] is too short",
         ),
-        False,
         (
             "invalid_config_no_name_field_in_configuration_tab_table.json",
             "Tab 'account' should have entity with field 'name'",


### PR DESCRIPTION
**Issue number:** -

## Summary

Github actions marks jobs as succeeded if it failed with `continue-on-error`. There is no other way to check if jobs were actually failed. That the reason why adding `test-unit` to `all-checks` did not have any effect.

### Changes

Add output variable for every `continue-on-error` jobs that helps to identify failed ones during `all-checks`. You might check the result when tests are broken: https://github.com/splunk/addonfactory-ucc-generator/actions/runs/9365665879/job/25782687764#step:3:1

### User experience

No impact

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)
