### PR TITLE
feat(dashboard): add error categories to chart and event table in the error panel

### DIFF
--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -76,7 +76,7 @@ and 3 optional parameters:
 * `msg_before` - custom message before exception traceback. Default: None
 * `msg_after` - custom message after exception traceback. Default: None
 
-Additionally, function [`log_exception`](https://github.com/splunk/addonfactory-solutions-library-python/blob/v5.0.0/solnlib/log.py#L303) has a new, **mandatory** parameter `exc_label` thanks to which you can log your own, non-standard types.
+Additionally, function [`log_exception`](https://github.com/splunk/addonfactory-solutions-library-python/blob/v5.0.0/solnlib/log.py#L329) has a new, **mandatory** parameter `exc_label` thanks to which you can log your own, non-standard types.
 
 All of the above is available in the `log` module of the `solnlib` library from **version 5.0**. Please make sure you are using this version of `solnlib` library if you want to take full advantage of the extended error panel.
 

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -25,21 +25,21 @@ As of now, 4 pre-built panels are supported:
 
 The above function takes 5 positional parameters which are:
 
-* logger
-* modular_input_name
-* sourcetype
-* n_events
-* index
+* `logger`
+* `modular_input_name`
+* `sourcetype`
+* `n_events`
+* `index`
 
 and 2 optional named parameters:
 
-* account
-* host
+* `account`
+* `host`
 
 If you additionally provide `account` and `host` arguments - you will get a better visibility in your dashboard.
-Additionally, as `modular_input_name` you should pass the full input in the format **demo_input://my_input_1**.
+Please note that as a `modular_input_name` you should pass the full input in the format: **`demo_input://my_input_1`**.
 
-Example of a logging function:
+Example of an `events_ingested` function:
 
 ```python
 from solnlib import log
@@ -56,6 +56,53 @@ log.events_ingested(
 ```
 
 as a reference, you can check the input in the demo add-on described [here](quickstart.md/#initialize-new-add-on).
+
+**IMPORTANT**: From version **v5.46.0** the error section has been expanded to include a division into error categories. This solution is based on additional exception logging functions:
+
+* `log_connection_error`
+* `log_configuration_error`
+* `log_permission_error`
+* `log_authentication_error`
+* `log_server_error`
+
+Above functions take 2 mandatory parameters:
+
+* `logger` - your add-on logger
+* `exc` - exception thrown
+
+and 3 optional parameters:
+
+* `full_msg` - if set to True, full traceback will be logged. Default: True
+* `msg_before` - custom message before exception traceback. Default: None
+* `msg_after` - custom message after exception traceback. Default: None
+
+Additionally, function [`log_exception`](https://github.com/splunk/addonfactory-solutions-library-python/blob/v5.0.0/solnlib/log.py#L303) has a new, **mandatory** parameter `exc_label` thanks to which you can log your own, non-standard types.
+
+All of the above is available in the `log` module of the `solnlib` library from **version 5.0**. Please make sure you are using this version of `solnlib` library if you want to take full advantage of the extended error panel.
+
+Example of a logging functions:
+
+```python
+from solnlib import log
+
+...
+except MyCustomException as e:
+    log.log_exception(logger, e, "my custom error")
+except UnauthorisedError as e:
+    log.log_authentication_error(logger, e)
+except PermissionError as e:
+    log.log_permission_error(logger, e, msg_after="test after")
+except ConnectionError as e:
+    log.log_connection_error(logger, e, msg_before="test before", msg_after="test after")
+except AddonConfigurationError as e:
+    log.log_configuration_error(logger, e, full_msg=False, msg_before="test before")
+except ServiceServerError as e:
+    log.log_server_error(logger, e)
+except Exception as e:
+    log.log_exception(logger, e, "Other")
+```
+
+## Configuration
 
 To be able to add a monitoring dashboard page to an existing add-on, you need to adjust your
 globalConfig file and include a new "dashboard" page there. See the following example:
@@ -96,7 +143,7 @@ globalConfig file and include a new "dashboard" page there. See the following ex
 
 ## Migration path
 
-XML-based dashboard will be migrated during the build process. All the necessary changes will be made automatically.
+Default, XML-based dashboard will be migrated during the build process. All the necessary changes will be made automatically.
 
 ## Custom components
 
@@ -105,7 +152,7 @@ To do this, create a **custom_dashboard.json** file in the add-on's root directo
 
 This definition json file must be created according to the UDF framework standards described [here](https://splunkui.splunk.com/Packages/dashboard-docs/?path=%2FIntroduction)
 
-**dashboard_components.xml** location:
+**custom_dashboard.json** location:
 
 ```
 <TA>
@@ -116,7 +163,7 @@ This definition json file must be created according to the UDF framework standar
  ...
 ```
 
-Sample **dashboard_components.xml** structure:
+Sample **custom_dashboard.json** structure:
 
 ```json
 {

--- a/splunk_add_on_ucc_framework/dashboard.py
+++ b/splunk_add_on_ucc_framework/dashboard.py
@@ -193,15 +193,12 @@ def generate_dashboard_content(
         )
 
     if definition_json_name == default_definition_json_filename["errors_tab"]:
-        custom_types = {"label": "MyCustomType", "value": "MyCustomType"}
-
         content = (
             utils.get_j2_env()
             .get_template(definition_json_name)
             .render(
                 errors_count=errors_count.format(addon_name=addon_name.lower()),
                 errors_list=errors_list_query.format(addon_name=addon_name.lower()),
-                custom_aaa=custom_types,
             )
         )
 

--- a/splunk_add_on_ucc_framework/dashboard.py
+++ b/splunk_add_on_ucc_framework/dashboard.py
@@ -62,7 +62,9 @@ data_ingestion_and_events = (
     "| join _time [search index=_internal source=*{addon_name}* action=events_ingested "
     '| timechart sum(n_events) as \\"Number of events\\" ]'
 )
-errors_count = "index=_internal source=*{addon_name}* ERROR | timechart count as Errors"
+errors_count = (
+    "index=_internal source=*{addon_name}* ERROR | timechart count as Errors by exc_l"
+)
 events_count = (
     "index=_internal source=*{addon_name}* action=events_ingested | "
     'timechart sum(n_events) as \\"Number of events\\"'
@@ -191,12 +193,15 @@ def generate_dashboard_content(
         )
 
     if definition_json_name == default_definition_json_filename["errors_tab"]:
+        custom_types = {"label": "MyCustomType", "value": "MyCustomType"}
+
         content = (
             utils.get_j2_env()
             .get_template(definition_json_name)
             .render(
                 errors_count=errors_count.format(addon_name=addon_name.lower()),
                 errors_list=errors_list_query.format(addon_name=addon_name.lower()),
+                custom_aaa=custom_types,
             )
         )
 

--- a/splunk_add_on_ucc_framework/dashboard.py
+++ b/splunk_add_on_ucc_framework/dashboard.py
@@ -264,22 +264,22 @@ def generate_dashboard(
 
 
 def get_custom_json_content(custom_dashboard_path: str) -> Dict[Any, Any]:
-    custom_dashbaord = load_custom_json(custom_dashboard_path)
+    custom_dashboard = load_custom_json(custom_dashboard_path)
 
-    if not custom_dashbaord:
+    if not custom_dashboard:
         logger.error(
             f"Custom dashboard page set in globalConfig.json but custom content not found. "
             f"Please verify if file {custom_dashboard_path} has a proper structure "
             f"(see https://splunk.github.io/addonfactory-ucc-generator/dashboard/)"
         )
         sys.exit(1)
-    return custom_dashbaord
+    return custom_dashboard
 
 
 def load_custom_json(json_path: str) -> Dict[Any, Any]:
     try:
         with open(json_path) as dashboard_file:
-            custom_dashbaord = json.load(dashboard_file)
+            custom_dashboard = json.load(dashboard_file)
     except FileNotFoundError:
         logger.error(
             f"Custom dashboard page set in globalConfig.json but "
@@ -289,4 +289,4 @@ def load_custom_json(json_path: str) -> Dict[Any, Any]:
     except json.decoder.JSONDecodeError:
         logger.error(f"{json_path} it's not a valid json file")
         sys.exit(1)
-    return custom_dashbaord
+    return custom_dashboard

--- a/splunk_add_on_ucc_framework/schema/schema.json
+++ b/splunk_add_on_ucc_framework/schema/schema.json
@@ -323,7 +323,7 @@
         "troubleshooting_url": {
           "text": {
             "type": "string",
-            "description": "Link to external TA documentation used for redirection on error dashbaord page"
+            "description": "Link to external TA documentation used for redirection on error dashboard page"
           }
         }
       },

--- a/splunk_add_on_ucc_framework/schema/schema.json
+++ b/splunk_add_on_ucc_framework/schema/schema.json
@@ -321,10 +321,9 @@
           }
         },
         "troubleshooting_url": {
-          "text": {
-            "type": "string",
-            "description": "Link to external TA documentation used for redirection on error dashboard page"
-          }
+          "type": "string",
+          "description": "Link to external TA documentation used for redirection on error dashboard page",
+          "format": "uri"
         }
       },
       "required": ["panels"],
@@ -1703,18 +1702,18 @@
         "defaultView": {
           "type": "string",
           "anyOf": [
-              {
-                "const": "inputs"
-              },
-              {
-                "const": "configuration"
-              },
-              {
-                "const": "dashboard"
-              },
-              {
-                "const": "search"
-              }
+            {
+              "const": "inputs"
+            },
+            {
+              "const": "configuration"
+            },
+            {
+              "const": "dashboard"
+            },
+            {
+              "const": "search"
+            }
           ]
         },
         "os-dependentLibraries": {

--- a/splunk_add_on_ucc_framework/schema/schema.json
+++ b/splunk_add_on_ucc_framework/schema/schema.json
@@ -319,6 +319,12 @@
           "items": {
             "$ref": "#/definitions/DashboardPanel"
           }
+        },
+        "troubleshooting_url": {
+          "text": {
+            "type": "string",
+            "description": "Link to external TA documentation used for redirection on error dashbaord page"
+          }
         }
       },
       "required": ["panels"],

--- a/splunk_add_on_ucc_framework/templates/errors_tab_definition.json
+++ b/splunk_add_on_ucc_framework/templates/errors_tab_definition.json
@@ -91,7 +91,7 @@
     "errors_tab_errors_list_ds": {
       "type": "ds.search",
       "options": {
-        "query": "{{errors_list}}",
+        "query": "{{errors_list}} exc_l IN ($error_types$)",
         "queryParameters": {
           "earliest": "$errors_tab_time.earliest$",
           "latest": "$errors_tab_time.latest$"
@@ -108,12 +108,51 @@
       },
       "title": "Time",
       "type": "input.timerange"
+    },
+    "errors_type_input": {
+      "options": {
+                "items": [
+            {
+                "label": "All",
+                "value": "*"
+            },
+            {
+                "label": "Permission",
+                "value": "Permission"
+            },
+            {
+                "label": "Authentication",
+                "value": "Authentication"
+            },
+            {
+                "label": "Connection",
+                "value": "Connection"
+            },
+            {
+                "label": "Configuration",
+                "value": "Configuration"
+            },
+            {
+                "label": "Server",
+                "value": "Server"
+            },
+            {
+                "label": "Other",
+                "value": "Other"
+            },
+            {{custom_aaa|tojson}}],
+        "token": "error_types",
+        "defaultValue": "*"
+      },
+      "title": "Error types",
+      "type": "input.multiselect"
     }
   },
   "layout": {
     "type": "grid",
     "globalInputs": [
-      "errors_tab_input"
+      "errors_tab_input",
+      "errors_type_input"
     ],
     "structure": [
       {

--- a/splunk_add_on_ucc_framework/templates/errors_tab_definition.json
+++ b/splunk_add_on_ucc_framework/templates/errors_tab_definition.json
@@ -117,30 +117,26 @@
                 "value": "*"
             },
             {
-                "label": "Permission",
-                "value": "Permission"
+                "label": "Permission Error",
+                "value": "\"Permission Error\""
             },
             {
-                "label": "Authentication",
-                "value": "Authentication"
+                "label": "Authentication Error",
+                "value": "\"Authentication Error\""
             },
             {
-                "label": "Connection",
-                "value": "Connection"
+                "label": "Connection Error",
+                "value": "\"Connection Error\""
             },
             {
-                "label": "Configuration",
-                "value": "Configuration"
+                "label": "Configuration Error",
+                "value": "\"Configuration Error\""
             },
             {
-                "label": "Server",
-                "value": "Server"
-            },
-            {
-                "label": "Other",
-                "value": "Other"
-            },
-            {{custom_aaa|tojson}}],
+                "label": "Server Error",
+                "value": "\"Server Error\""
+            }
+                ],
         "token": "error_types",
         "defaultValue": "*"
       },

--- a/splunk_add_on_ucc_framework/templates/input.helper-init-template
+++ b/splunk_add_on_ucc_framework/templates/input.helper-init-template
@@ -86,4 +86,4 @@ def stream_events(inputs: smi.InputDefinition, event_writer: smi.EventWriter):
             )
             log.modular_input_end(logger, normalized_input_name)
         except Exception as e:
-            log.log_exception(logger, e, msg_before="Exception raised while ingesting data for demo_input: ")
+            log.log_exception(logger, e, "my custom error type", msg_before="Exception raised while ingesting data for demo_input: ")

--- a/tests/testdata/expected_addons/expected_addon_after_init/demo_addon_for_splunk/package/bin/demo_input_helper.py
+++ b/tests/testdata/expected_addons/expected_addon_after_init/demo_addon_for_splunk/package/bin/demo_input_helper.py
@@ -86,4 +86,4 @@ def stream_events(inputs: smi.InputDefinition, event_writer: smi.EventWriter):
             )
             log.modular_input_end(logger, normalized_input_name)
         except Exception as e:
-            log.log_exception(logger, e, msg_before="Exception raised while ingesting data for demo_input: ")
+            log.log_exception(logger, e, "my custom error type", msg_before="Exception raised while ingesting data for demo_input: ")

--- a/tests/unit/expected_results/errors_tab_definition.json
+++ b/tests/unit/expected_results/errors_tab_definition.json
@@ -81,7 +81,7 @@
     "errors_tab_errors_count_ds": {
       "type": "ds.search",
       "options": {
-        "query": "index=_internal source=*splunk_ta_uccexample* ERROR | timechart count as Errors",
+        "query": "index=_internal source=*splunk_ta_uccexample* ERROR | timechart count as Errors by exc_l",
         "queryParameters": {
           "earliest": "$errors_tab_time.earliest$",
           "latest": "$errors_tab_time.latest$"
@@ -91,7 +91,7 @@
     "errors_tab_errors_list_ds": {
       "type": "ds.search",
       "options": {
-        "query": "index=_internal source=*splunk_ta_uccexample* ERROR",
+        "query": "index=_internal source=*splunk_ta_uccexample* ERROR exc_l IN ($error_types$)",
         "queryParameters": {
           "earliest": "$errors_tab_time.earliest$",
           "latest": "$errors_tab_time.latest$"
@@ -108,12 +108,47 @@
       },
       "title": "Time",
       "type": "input.timerange"
+    },
+    "errors_type_input": {
+      "options": {
+                "items": [
+            {
+                "label": "All",
+                "value": "*"
+            },
+            {
+                "label": "Permission Error",
+                "value": "\"Permission Error\""
+            },
+            {
+                "label": "Authentication Error",
+                "value": "\"Authentication Error\""
+            },
+            {
+                "label": "Connection Error",
+                "value": "\"Connection Error\""
+            },
+            {
+                "label": "Configuration Error",
+                "value": "\"Configuration Error\""
+            },
+            {
+                "label": "Server Error",
+                "value": "\"Server Error\""
+            }
+                ],
+        "token": "error_types",
+        "defaultValue": "*"
+      },
+      "title": "Error types",
+      "type": "input.multiselect"
     }
   },
   "layout": {
     "type": "grid",
     "globalInputs": [
-      "errors_tab_input"
+      "errors_tab_input",
+      "errors_type_input"
     ],
     "structure": [
       {

--- a/tests/unit/expected_results/overview_definition.json
+++ b/tests/unit/expected_results/overview_definition.json
@@ -113,7 +113,7 @@
     "overview_errors_count_ds": {
       "type": "ds.search",
       "options": {
-        "query": "index=_internal source=*splunk_ta_uccexample* ERROR | timechart count as Errors",
+        "query": "index=_internal source=*splunk_ta_uccexample* ERROR | timechart count as Errors by exc_l",
         "queryParameters": {
           "earliest": "$overview_time.earliest$",
           "latest": "$overview_time.latest$"

--- a/ui/package.json
+++ b/ui/package.json
@@ -27,6 +27,7 @@
     "@splunk/dashboard-presets": "^27.1.0",
     "@splunk/dashboard-state": "^27.1.0",
     "@splunk/react-icons": "^4.5.0",
+    "@splunk/dashboard-types": "^27.1.0",
     "@splunk/react-page": "^7.0.0",
     "@splunk/react-toast-notifications": "^0.11.3",
     "@splunk/react-ui": "^4.32.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -30,6 +30,7 @@
     "@splunk/react-page": "^7.0.0",
     "@splunk/react-toast-notifications": "^0.11.3",
     "@splunk/react-ui": "^4.32.0",
+    "@splunk/search-job": "^3.1.0",
     "@splunk/splunk-utils": "^3.1.0",
     "@splunk/themes": "^0.19.0",
     "@splunk/ui-utils": "^1.6.0",

--- a/ui/src/components/DashboardInfoModal/DashboardInfoModal.tsx
+++ b/ui/src/components/DashboardInfoModal/DashboardInfoModal.tsx
@@ -7,7 +7,6 @@ import P from '@splunk/react-ui/Paragraph';
 import QuestionCircle from '@splunk/react-icons/QuestionCircle';
 
 import { StyledButton } from '../../pages/EntryPageStyle';
-import { getUnifiedConfigs } from '../../util/util';
 
 const ModalWrapper = styled(Modal)`
     width: 700px;
@@ -26,7 +25,6 @@ interface DashboardInfoModalProps {
 }
 
 function DashboardInfoModal(props: DashboardInfoModalProps) {
-    const globalConfig = getUnifiedConfigs();
     return (
         <ModalWrapper open={props.open}>
             <Modal.Header
@@ -49,10 +47,10 @@ function DashboardInfoModal(props: DashboardInfoModalProps) {
                 ))}
             </Modal.Body>
             <Modal.Footer>
-                {globalConfig.pages.dashboard?.panels[0].name ? ( // to do change it into troubleshooting link
+                {props?.troubleshootingButton?.link ? ( // to do change it into troubleshooting link
                     <StyledButton
                         icon={<QuestionCircle width={16} height={16} />}
-                        to={globalConfig.pages.dashboard?.panels[0].name}
+                        to={props?.troubleshootingButton?.link}
                         label={props.troubleshootingButton?.label || 'Troubleshooting {add-on}'}
                         openInNewContext
                     />

--- a/ui/src/components/DashboardInfoModal/DashboardInfoModal.tsx
+++ b/ui/src/components/DashboardInfoModal/DashboardInfoModal.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import Modal from '@splunk/react-ui/Modal';
+import Message from '@splunk/react-ui/Message';
+import styled from 'styled-components';
+import Heading from '@splunk/react-ui/Heading';
+import P from '@splunk/react-ui/Paragraph';
+import QuestionCircle from '@splunk/react-icons/QuestionCircle';
+
+import { StyledButton } from '../../pages/EntryPageStyle';
+import { getUnifiedConfigs } from '../../util/util';
+
+const ModalWrapper = styled(Modal)`
+    width: 700px;
+`;
+
+interface DashboardInfoModalProps {
+    open: boolean;
+    title: string;
+    subtitle?: string;
+    handleRequestClose: () => void;
+    errorTypesInfo: { header: string; description: string }[];
+    closeBtnLabel?: string;
+    infoMessage?: string;
+    listIntroductionText?: string;
+    troubleshootingButton?: { label?: string; link?: string };
+}
+
+function DashboardInfoModal(props: DashboardInfoModalProps) {
+    const globalConfig = getUnifiedConfigs();
+    return (
+        <ModalWrapper open={props.open}>
+            <Modal.Header
+                onRequestClose={() => props.handleRequestClose()}
+                title={props.title}
+                subtitle={props.subtitle}
+            />
+            <Modal.Body>
+                {props?.infoMessage ? (
+                    <Message appearance="fill" type="info">
+                        {props.infoMessage}
+                    </Message>
+                ) : null}
+                {props?.listIntroductionText ? <P>{props.listIntroductionText}</P> : null}
+                {props.errorTypesInfo.map((typeInfo) => (
+                    <>
+                        <Heading level={4}>{typeInfo.header}</Heading>
+                        <P>{typeInfo.description}</P>
+                    </>
+                ))}
+            </Modal.Body>
+            <Modal.Footer>
+                {globalConfig.pages.dashboard?.panels[0].name ? ( // to do change it into troubleshooting link
+                    <StyledButton
+                        icon={<QuestionCircle width={16} height={16} />}
+                        to={globalConfig.pages.dashboard?.panels[0].name}
+                        label={props.troubleshootingButton?.label || 'Troubleshooting {add-on}'}
+                        openInNewContext
+                    />
+                ) : null}
+                <StyledButton
+                    appearance="primary"
+                    onClick={() => props.handleRequestClose()}
+                    label={props.closeBtnLabel || 'Close'}
+                />
+            </Modal.Footer>
+        </ModalWrapper>
+    );
+}
+
+export default DashboardInfoModal;

--- a/ui/src/pages/Dashboard/Error.tsx
+++ b/ui/src/pages/Dashboard/Error.tsx
@@ -1,18 +1,60 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { DashboardCore } from '@splunk/dashboard-core';
 import { DashboardContextProvider } from '@splunk/dashboard-context';
 import EnterpriseViewOnlyPreset from '@splunk/dashboard-presets/EnterpriseViewOnlyPreset';
+import Button from '@splunk/react-ui/Button';
+import { variables } from '@splunk/themes';
+import styled from 'styled-components';
+import QuestionCircle from '@splunk/react-icons/QuestionCircle';
+
 import { getActionButtons, waitForElementToDisplayAndMoveThemToCanvas } from './utils';
+import DashboardInfoModal from '../../components/DashboardInfoModal/DashboardInfoModal';
+import {
+    OPEN_SEARCH_LABEL,
+    TROUBLESHOOTING_BTN_LABEL,
+    TROUBLESHOOTING_CONFIG,
+} from './ErrorPageConfig';
+
+const OpenSearchStyledBtn = styled(Button)`
+    max-width: fit-content;
+    font-size: ${variables.fontSize};
+    align-content: flex-end;
+    place-self: end;
+    grid-column: 5;
+    grid-row: 6;
+    top: 62px;
+`;
+
+const OpenTroubleshootingBtn = styled(OpenSearchStyledBtn)`
+    margin-right: 145px;
+`;
+
 
 export const ErrorDashboard = ({
     dashboardDefinition,
 }: {
     dashboardDefinition: Record<string, unknown>;
 }) => {
+    const [displayTroubleShootingModal, setDisplayTroubleShootingModal] = useState(false);
+
     useEffect(() => {
         waitForElementToDisplayAndMoveThemToCanvas(
-            '[data-input-id="errors_tab_input"]',
+            '[data-input-id="errors_tab_input"][data-input-type="input.timerange"]',
             '#errors_tab_description_viz'
+        );
+
+        waitForElementToDisplayAndMoveThemToCanvas(
+            '[data-input-id="errors_type_input"][data-input-type="input.multiselect"]',
+            '#errors_tab_errors_list_viz'
+        );
+
+        waitForElementToDisplayAndMoveThemToCanvas(
+            '#open_search_error_events_tab_with_types',
+            '#errors_tab_errors_list_viz'
+        );
+        waitForElementToDisplayAndMoveThemToCanvas(
+            '#open_trouble_shooting_overlay',
+            '#errors_tab_errors_list_viz'
         );
     }, []);
 
@@ -21,7 +63,38 @@ export const ErrorDashboard = ({
             preset={EnterpriseViewOnlyPreset}
             initialDefinition={dashboardDefinition}
         >
-            <DashboardCore width="100%" height="auto" actionMenus={getActionButtons('error')} />
+            <>
+                <OpenSearchStyledBtn
+                    id="open_search_error_events_tab_with_types"
+                    label={OPEN_SEARCH_LABEL}
+                    openInNewContext
+                    onClick={
+                        () =>
+                            (
+                                document.querySelector(
+                                    '#errors_tab_errors_list_viz [data-test="open-search-button"]'
+                                ) as HTMLElement
+                            )?.click() // todo: no better easy way to get events table query
+                    }
+                />
+                <OpenTroubleshootingBtn
+                    id="open_trouble_shooting_overlay"
+                    label={TROUBLESHOOTING_BTN_LABEL}
+                    onClick={() => setDisplayTroubleShootingModal(true)}
+                    icon={<QuestionCircle width={16} height={16} />}
+                />
+                <DashboardInfoModal
+                    title={TROUBLESHOOTING_CONFIG.TITLE}
+                    subtitle={TROUBLESHOOTING_CONFIG.DESCRIPTION}
+                    open={displayTroubleShootingModal}
+                    handleRequestClose={() => setDisplayTroubleShootingModal(false)}
+                    closeBtnLabel={TROUBLESHOOTING_CONFIG.CLOSE_LABEL}
+                    infoMessage={TROUBLESHOOTING_CONFIG.INFO_MESSAGE}
+                    listIntroductionText={TROUBLESHOOTING_CONFIG.LIST_INTRODUCTION_TEXT}
+                    errorTypesInfo={TROUBLESHOOTING_CONFIG.BASIC_ERROR_TYPES}
+                />
+                <DashboardCore width="100%" height="auto" actionMenus={getActionButtons('error')} />
+            </>
         </DashboardContextProvider>
     ) : null;
 };

--- a/ui/src/pages/Dashboard/Error.tsx
+++ b/ui/src/pages/Dashboard/Error.tsx
@@ -29,7 +29,6 @@ const OpenTroubleshootingBtn = styled(OpenSearchStyledBtn)`
     margin-right: 145px;
 `;
 
-
 export const ErrorDashboard = ({
     dashboardDefinition,
 }: {
@@ -56,6 +55,9 @@ export const ErrorDashboard = ({
             '#open_trouble_shooting_overlay',
             '#errors_tab_errors_list_viz'
         );
+
+        // call to for error types
+        // index=_internal source=*splunk_ta_uccexample* ERROR | dedup exc_l | table exc_l
     }, []);
 
     return dashboardDefinition ? (

--- a/ui/src/pages/Dashboard/Error.tsx
+++ b/ui/src/pages/Dashboard/Error.tsx
@@ -22,9 +22,9 @@ const OpenSearchStyledBtn = styled(Button)`
     font-size: ${variables.fontSize};
     align-content: flex-end;
     place-self: end;
-    grid-column: 5;
-    grid-row: 6;
-    top: 62px;
+    grid-column: 2;
+    grid-row: 4;
+    bottom: 8px;
 `;
 
 const OpenTroubleshootingBtn = styled(OpenSearchStyledBtn)`

--- a/ui/src/pages/Dashboard/Error.tsx
+++ b/ui/src/pages/Dashboard/Error.tsx
@@ -1,20 +1,14 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import { DashboardCore } from '@splunk/dashboard-core';
 import { DashboardContextProvider } from '@splunk/dashboard-context';
 import EnterpriseViewOnlyPreset from '@splunk/dashboard-presets/EnterpriseViewOnlyPreset';
 import Button from '@splunk/react-ui/Button';
 import { variables } from '@splunk/themes';
 import styled from 'styled-components';
-import QuestionCircle from '@splunk/react-icons/QuestionCircle';
 import SearchJob from '@splunk/search-job';
 
 import { getActionButtons, waitForElementToDisplayAndMoveThemToCanvas } from './utils';
-import DashboardInfoModal from '../../components/DashboardInfoModal/DashboardInfoModal';
-import {
-    OPEN_SEARCH_LABEL,
-    TROUBLESHOOTING_BTN_LABEL,
-    TROUBLESHOOTING_CONFIG,
-} from './ErrorPageConfig';
+import { OPEN_SEARCH_LABEL } from './ErrorPageConfig';
 import { getUnifiedConfigs } from '../../util/util';
 
 const OpenSearchStyledBtn = styled(Button)`
@@ -27,9 +21,9 @@ const OpenSearchStyledBtn = styled(Button)`
     bottom: 8px;
 `;
 
-const OpenTroubleshootingBtn = styled(OpenSearchStyledBtn)`
-    margin-right: 145px;
-`;
+// const OpenTroubleshootingBtn = styled(OpenSearchStyledBtn)` // commented out for now but will be needed latter on
+//     margin-right: 145px;
+// `;
 
 let apiReference: { updateDefinition: (arg0: Record<string, unknown>) => void } | null = null;
 
@@ -38,7 +32,7 @@ export const ErrorDashboard = ({
 }: {
     dashboardDefinition: Record<string, unknown>;
 }) => {
-    const [displayTroubleShootingModal, setDisplayTroubleShootingModal] = useState(false);
+    // const [displayTroubleShootingModal, setDisplayTroubleShootingModal] = useState(false); // commented out for now but will be needed latter on
 
     const globalConfig = getUnifiedConfigs();
 
@@ -63,10 +57,10 @@ export const ErrorDashboard = ({
             '#open_search_error_events_tab_with_types',
             '#errors_tab_errors_list_viz'
         );
-        waitForElementToDisplayAndMoveThemToCanvas(
-            '#open_trouble_shooting_overlay',
-            '#errors_tab_errors_list_viz'
-        );
+        // waitForElementToDisplayAndMoveThemToCanvas( // commented out for now but will be needed latter on
+        //     '#open_trouble_shooting_overlay',
+        //     '#errors_tab_errors_list_viz'
+        // );
 
         // search call to for error types
         const mySearchJob = SearchJob.create(
@@ -139,13 +133,13 @@ export const ErrorDashboard = ({
                             )?.click() // todo: no better easy way to get events table query
                     }
                 />
-                <OpenTroubleshootingBtn
+                {/* <OpenTroubleshootingBtn // commented out for now but will be needed latter on
                     id="open_trouble_shooting_overlay"
                     label={TROUBLESHOOTING_BTN_LABEL}
                     onClick={() => setDisplayTroubleShootingModal(true)}
                     icon={<QuestionCircle width={16} height={16} />}
-                />
-                <DashboardInfoModal
+                /> */}
+                {/* <DashboardInfoModal  // commented out for now but will be needed latter on
                     title={TROUBLESHOOTING_CONFIG.TITLE}
                     subtitle={TROUBLESHOOTING_CONFIG.DESCRIPTION}
                     open={displayTroubleShootingModal}
@@ -157,7 +151,7 @@ export const ErrorDashboard = ({
                     troubleshootingButton={{
                         link: globalConfig.pages.dashboard?.troubleshooting_url,
                     }}
-                />
+                /> */}
                 <DashboardCore
                     width="100%"
                     height="auto"

--- a/ui/src/pages/Dashboard/ErrorPageConfig.ts
+++ b/ui/src/pages/Dashboard/ErrorPageConfig.ts
@@ -1,0 +1,34 @@
+export const TROUBLESHOOTING_CONFIG = {
+    BASIC_ERROR_TYPES: [
+        {
+            header: 'Authentication',
+            description:
+                'Brief description for authentication errors and a generic approach to address it.',
+        },
+        {
+            header: 'Permission',
+            description:
+                'Brief description for permission errors and a generic approach to address it.',
+        },
+        {
+            header: 'Connection',
+            description:
+                'Brief description for connection errors and a generic approach to address it.',
+        },
+        {
+            header: 'Configuration',
+            description:
+                'Brief description for configuration errors and a generic approach to address it.',
+        },
+    ],
+    LIST_INTRODUCTION_TEXT: 'Here are common error types for Splunk TAs:',
+    CLOSE_LABEL: 'Close',
+    DESCRIPTION: 'Description',
+    TITLE: 'Troubleshoot add-on errors',
+    INFO_MESSAGE:
+        'These are generic instructions provided by Splunk. For detailed troubleshooting guidance, please refer to each TA’s documentation if there is one.',
+};
+
+export const OPEN_SEARCH_LABEL = 'Open in Search';
+
+export const TROUBLESHOOTING_BTN_LABEL = 'Troubleshoot add-on errors';

--- a/ui/src/pages/Dashboard/ErrorPageConfig.ts
+++ b/ui/src/pages/Dashboard/ErrorPageConfig.ts
@@ -1,34 +1,34 @@
-export const TROUBLESHOOTING_CONFIG = {
-    BASIC_ERROR_TYPES: [
-        {
-            header: 'Authentication',
-            description:
-                'Brief description for authentication errors and a generic approach to address it.',
-        },
-        {
-            header: 'Permission',
-            description:
-                'Brief description for permission errors and a generic approach to address it.',
-        },
-        {
-            header: 'Connection',
-            description:
-                'Brief description for connection errors and a generic approach to address it.',
-        },
-        {
-            header: 'Configuration',
-            description:
-                'Brief description for configuration errors and a generic approach to address it.',
-        },
-    ],
-    LIST_INTRODUCTION_TEXT: 'Here are common error types for Splunk TAs:',
-    CLOSE_LABEL: 'Close',
-    DESCRIPTION: 'Description',
-    TITLE: 'Troubleshoot add-on errors',
-    INFO_MESSAGE:
-        'These are generic instructions provided by Splunk. For detailed troubleshooting guidance, please refer to each TA’s documentation if there is one.',
-};
+// export const TROUBLESHOOTING_CONFIG = {
+//     BASIC_ERROR_TYPES: [
+//         {
+//             header: 'Authentication',
+//             description:
+//                 'Brief description for authentication errors and a generic approach to address it.',
+//         },
+//         {
+//             header: 'Permission',
+//             description:
+//                 'Brief description for permission errors and a generic approach to address it.',
+//         },
+//         {
+//             header: 'Connection',
+//             description:
+//                 'Brief description for connection errors and a generic approach to address it.',
+//         },
+//         {
+//             header: 'Configuration',
+//             description:
+//                 'Brief description for configuration errors and a generic approach to address it.',
+//         },
+//     ],
+//     LIST_INTRODUCTION_TEXT: 'Here are common error types for Splunk TAs:',
+//     CLOSE_LABEL: 'Close',
+//     DESCRIPTION: 'Description',
+//     TITLE: 'Troubleshoot add-on errors',
+//     INFO_MESSAGE:
+//         'These are generic instructions provided by Splunk. For detailed troubleshooting guidance, please refer to each TA’s documentation if there is one.',
+// };
 
 export const OPEN_SEARCH_LABEL = 'Open in Search';
 
-export const TROUBLESHOOTING_BTN_LABEL = 'Troubleshoot add-on errors';
+// export const TROUBLESHOOTING_BTN_LABEL = 'Troubleshoot add-on errors';

--- a/ui/src/pages/Dashboard/dashboardStyle.css
+++ b/ui/src/pages/Dashboard/dashboardStyle.css
@@ -160,6 +160,7 @@ body {
 }
 
 #errors_tab_errors_list_viz {
+    margin-top: 70px;
     height: 600px;
     grid-row: 7 / 7;
 }
@@ -167,6 +168,14 @@ body {
 #errors_tab_errors_count_viz {
     grid-row: 3 / 6;
     margin-top: 16px;
+}
+
+[data-input-id='errors_type_input'] {
+    grid-column: 1;
+    grid-row: 6;
+    > div {
+        margin: 16px 0;
+    }
 }
 
 /* resource tab */

--- a/ui/src/pages/Dashboard/dashboardStyle.css
+++ b/ui/src/pages/Dashboard/dashboardStyle.css
@@ -306,6 +306,6 @@ body {
     color: var(--dashboard-ucc-grey-color);
 }
 
-#errors_tab_errors_list_viz svg[data-test="placeholder-icon"]{
+#errors_tab_errors_list_viz svg[data-test='placeholder-icon'] {
     max-height: 400px;
 }

--- a/ui/src/pages/Dashboard/dashboardStyle.css
+++ b/ui/src/pages/Dashboard/dashboardStyle.css
@@ -140,6 +140,7 @@ body {
     grid-row: 1;
     height: 20px;
     margin-top: 32px;
+    width: 600px;
 }
 
 #errors_tab_timerange_label_start_viz {
@@ -150,7 +151,7 @@ body {
 
 #errors_tab_timerange_label_end_viz {
     grid-column: 1;
-    grid-row: 2;
+    grid-row: 1;
     margin-left: 145px;
     display: flex;
     margin-top: 37px;

--- a/ui/src/pages/Dashboard/dashboardStyle.css
+++ b/ui/src/pages/Dashboard/dashboardStyle.css
@@ -131,24 +131,29 @@ body {
 /* error tab */
 
 [data-input-id='errors_tab_input'] {
-    grid-column: 5;
-    grid-row: 2;
+    grid-column: 2;
+    grid-row: 1;
 }
 
 #errors_tab_description_viz {
+    grid-column: 1 / 3;
+    grid-row: 1;
+    height: 20px;
     margin-top: 32px;
 }
 
 #errors_tab_timerange_label_start_viz {
-    grid-row: 2;
-    margin-top: 12px;
+    grid-column: 1;
+    grid-row: 1;
+    margin-top: 37px;
 }
 
 #errors_tab_timerange_label_end_viz {
+    grid-column: 1;
     grid-row: 2;
     margin-left: 145px;
     display: flex;
-    margin-top: 12px;
+    margin-top: 37px;
 }
 
 [data-test='status-icon-container'] {
@@ -160,22 +165,37 @@ body {
 }
 
 #errors_tab_errors_list_viz {
-    margin-top: 70px;
-    height: 600px;
-    grid-row: 7 / 7;
+    margin-top: 8px;
+    height: fit-content;
+    grid-row: 5;
+    grid-column: 1 / 3;
 }
 
 #errors_tab_errors_count_viz {
-    grid-row: 3 / 6;
+    grid-row: 2;
+    height: 400px;
+    grid-column: 1 / 3;
     margin-top: 16px;
 }
 
 [data-input-id='errors_type_input'] {
     grid-column: 1;
-    grid-row: 6;
-    > div {
-        margin: 16px 0;
-    }
+    grid-row: 4;
+}
+
+#errors_tab_errors_list_viz div {
+    height: fit-content;
+}
+
+[data-test-panel-id='errorsTabPanel'] [data-test='grid-layout-canvas'] {
+    grid-template-columns: 94% 5%;
+    grid-template-rows: auto auto auto auto auto;
+    height: fit-content;
+}
+
+#errors_tab_label_viz {
+    grid-column: 1;
+    grid-row: 1;
 }
 
 /* resource tab */

--- a/ui/src/pages/Dashboard/dashboardStyle.css
+++ b/ui/src/pages/Dashboard/dashboardStyle.css
@@ -188,7 +188,7 @@ body {
 }
 
 [data-test-panel-id='errorsTabPanel'] [data-test='grid-layout-canvas'] {
-    grid-template-columns: 94% 5%;
+    grid-template-columns: 94.5% 5%;
     grid-template-rows: auto auto auto auto auto;
     height: fit-content;
 }

--- a/ui/src/pages/Dashboard/dashboardStyle.css
+++ b/ui/src/pages/Dashboard/dashboardStyle.css
@@ -63,6 +63,7 @@ body {
 
 #data_ingestion_description_viz {
     margin-top: 32px;
+    width: 600px;
 }
 
 #data_ingestion_timerange_label_start_viz {
@@ -192,6 +193,7 @@ body {
     grid-template-columns: 94.5% 5%;
     grid-template-rows: auto auto auto auto auto;
     height: fit-content;
+    overflow-x: hidden;
 }
 
 #errors_tab_label_viz {
@@ -213,6 +215,7 @@ body {
 
 #resource_tab_description_viz {
     margin-top: 32px;
+    width: 600px;
 }
 
 #resource_tab_timerange_label_start_viz {

--- a/ui/src/pages/Dashboard/dashboardStyle.css
+++ b/ui/src/pages/Dashboard/dashboardStyle.css
@@ -305,3 +305,7 @@ body {
     margin: auto;
     color: var(--dashboard-ucc-grey-color);
 }
+
+#errors_tab_errors_list_viz svg[data-test="placeholder-icon"]{
+    max-height: 400px;
+}

--- a/ui/src/pages/Dashboard/utils.tsx
+++ b/ui/src/pages/Dashboard/utils.tsx
@@ -95,13 +95,19 @@ export const createNewQueryBasedOnSearchAndHideTraffic = (
     return newQuery;
 };
 
-export const openSearchInNewTabWithQuery = (query: string, queryParams: Record<string, string>) => {
+export const openSearchInNewTabWithQuery = (query: string | null, queryParams: object | null) => {
+    if (!query) {
+        // eslint-disable-next-line no-console
+        console.error('No search query provided - openSearchInNewTabWithQuery');
+        return;
+    }
+
     const dashboardUrl = window.location.origin + window.location.pathname;
     const lastIndex = dashboardUrl.lastIndexOf('/');
     const searchUrl = new URL(`${dashboardUrl.slice(0, lastIndex)}/search`);
     searchUrl.searchParams.append('q', query);
-    Object.keys(queryParams).forEach((paramKey) => {
-        searchUrl.searchParams.append(paramKey, queryParams[paramKey]);
+    Object.entries(queryParams || {}).forEach(([key, value]) => {
+        searchUrl.searchParams.append(key, value);
     });
     window.open(searchUrl, '_blank')?.focus();
 };
@@ -113,7 +119,12 @@ export const getActionButtons = (serviceName: string) => {
         <OpenSearchButton
             key={`${serviceName}_opensearch`}
             onOpenSearchClick={(x) => {
-                openSearchInNewTabWithQuery(x.options.query, x.options.queryParameters);
+                if (
+                    typeof x?.options?.query === 'string' &&
+                    typeof x?.options?.queryParameters === 'object'
+                ) {
+                    openSearchInNewTabWithQuery(x.options.query, x.options.queryParameters);
+                }
             }}
         />,
     ];

--- a/ui/src/pages/Dashboard/utils.tsx
+++ b/ui/src/pages/Dashboard/utils.tsx
@@ -96,9 +96,9 @@ export const createNewQueryBasedOnSearchAndHideTraffic = (
 };
 
 export const openSearchInNewTabWithQuery = (query: string, queryParams: Record<string, string>) => {
-    const dashabordUrl = window.location.origin + window.location.pathname;
-    const lastIndex = dashabordUrl.lastIndexOf('/');
-    const searchUrl = new URL(`${dashabordUrl.slice(0, lastIndex)}/search`);
+    const dashboardUrl = window.location.origin + window.location.pathname;
+    const lastIndex = dashboardUrl.lastIndexOf('/');
+    const searchUrl = new URL(`${dashboardUrl.slice(0, lastIndex)}/search`);
     searchUrl.searchParams.append('q', query);
     Object.keys(queryParams).forEach((paramKey) => {
         searchUrl.searchParams.append(paramKey, queryParams[paramKey]);

--- a/ui/src/types/globalConfig/pages.ts
+++ b/ui/src/types/globalConfig/pages.ts
@@ -158,6 +158,7 @@ export const pages = z.object({
     dashboard: z
         .object({
             panels: z.array(z.object({ name: z.string() })).min(1),
+            troubleshooting_url: z.string().optional(),
         })
         .optional(),
 });

--- a/ui/src/types/modules.d.ts
+++ b/ui/src/types/modules.d.ts
@@ -1,5 +1,6 @@
 declare module '@splunk/splunk-utils/config';
 declare module '@splunk/splunk-utils/url';
+declare module '@splunk/search-job';
 // declaring modules as utils does not seem to have types
 
 declare module '@splunk/ui-utils/i18n';

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -2594,6 +2594,11 @@
     "@splunk/dashboard-utils" "^27.1.0"
     lodash "^4.17.21"
 
+"@splunk/dashboard-types@^27.1.0":
+  version "27.1.0"
+  resolved "https://registry.npmjs.org/@splunk/dashboard-types/-/dashboard-types-27.1.0.tgz#56c063368b8965b64aa01dd3a2f2ae040b684d41"
+  integrity sha512-pfvE3KgrwL7w7nCm5ELf8m/m9OwStL8mFB/RHVG1w/QlSid/fVWMRUmMnGyxNDRtac+vKcjSREdbxq4k9JN8dg==
+
 "@splunk/dashboard-ui@^27.1.0":
   version "27.1.0"
   resolved "https://registry.npmjs.org/@splunk/dashboard-ui/-/dashboard-ui-27.1.0.tgz#803cfecb93e862d76459b1fce2b879a5880a3e40"

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -2889,7 +2889,7 @@
     react-event-listener "^0.6.4"
     xpath "^0.0.32"
 
-"@splunk/search-job@^3.0.0":
+"@splunk/search-job@^3.0.0", "@splunk/search-job@^3.1.0":
   version "3.1.0"
   resolved "https://registry.npmjs.org/@splunk/search-job/-/search-job-3.1.0.tgz#7e4962b55a1919fd82b78f2f2bf9c2d5c5065ece"
   integrity sha512-L2AXkZGimqdBN9A1sENWGVAD8/yzB5RNpg8ZgfBW4JCJlMKdNrAXyu69xtsvjrRuYp/gTd//65x/6AljUr4HDA==


### PR DESCRIPTION
**Issue number:[ADDON-68670](https://splunk.atlassian.net/browse/ADDON-68670)**

## Summary

Error section has been expanded to include a division into error categories.

### Changes

* Error categories were added to error chart
* Error categories were added to error event table
* Multiselect filter was added to error event table

### User experience

The user will have access to a more detailed chart and table including types of errors.
The user will now be able to filter the results in the table using multi-select with specific error types as filters.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)
