### PR TITLE
fix(oauth): set loglevel in oauth rh template to use log level set in add-on

### DIFF
--- a/splunk_add_on_ucc_framework/commands/rest_builder/endpoint/oauth_model.py
+++ b/splunk_add_on_ucc_framework/commands/rest_builder/endpoint/oauth_model.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from typing import List
+from typing import List, Any
 
 from splunk_add_on_ucc_framework import utils
 from splunk_add_on_ucc_framework.commands.rest_builder.endpoint.base import (
@@ -22,9 +22,11 @@ from splunk_add_on_ucc_framework.commands.rest_builder.endpoint.base import (
 
 
 class OAuthModelEndpointBuilder(RestEndpointBuilder):
-    def __init__(self, name: str, namespace: str, app_name: str) -> None:
+    def __init__(self, name: str, namespace: str, app_name: str, **kwargs: Any) -> None:
         super().__init__(name, namespace)
         self._app_name = app_name
+        self._log_stanza = kwargs.get("log_stanza") or "logging"
+        self._log_level_field = kwargs.get("log_level_field") or "loglevel"
 
     def actions(self) -> List[str]:
         return ["edit"]
@@ -35,5 +37,7 @@ class OAuthModelEndpointBuilder(RestEndpointBuilder):
             .get_template("oauth.template")
             .render(
                 app_name=self._app_name,
+                log_stanza=self._log_stanza,
+                log_level_field=self._log_level_field,
             )
         )

--- a/splunk_add_on_ucc_framework/commands/rest_builder/global_config_builder_schema.py
+++ b/splunk_add_on_ucc_framework/commands/rest_builder/global_config_builder_schema.py
@@ -115,10 +115,13 @@ class GlobalConfigBuilderSchema:
             # If we have given oauth support then we have to add endpoint for accesstoken
             for entity_element in config["entity"]:
                 if entity_element["type"] == "oauth":
+                    log_details = self.global_config.logging_tab
                     oauth_endpoint = OAuthModelEndpointBuilder(
                         name="oauth",
                         namespace=self.global_config.namespace,
                         app_name=self.global_config.product,
+                        log_stanza=log_details.get("name"),
+                        log_level_field=log_details.get("entity", [{}])[0].get("field"),
                     )
                     self._endpoints["oauth"] = oauth_endpoint
                     self._oauth_conf_file_names.add(oauth_endpoint.conf_name)

--- a/splunk_add_on_ucc_framework/global_config.py
+++ b/splunk_add_on_ucc_framework/global_config.py
@@ -124,6 +124,24 @@ class GlobalConfig:
         return settings
 
     @property
+    def logging_tab(self) -> Dict[str, Any]:
+        for tab in self.tabs:
+            if tab.get("type") == "loggingTab":
+                return tab
+            elif all(
+                [
+                    len(tab.get("entity", {})) == 1,
+                    tab.get("entity", [{}])[0].get("type") == "singleSelect",
+                    tab.get("entity", [{}])[0].get("field") is not None,
+                    tab.get("entity", [{}])[0].get("options") is not None,
+                    tab.get("entity", [{}])[0].get("defaultValue", "").upper()
+                    in ("DEBUG", "INFO", "WARN", "WARNING", "ERROR", "CRITICAL"),
+                ]
+            ):
+                return tab
+        return {}
+
+    @property
     def configs(self) -> List[Any]:
         configs = []
         for tab in self.tabs:

--- a/splunk_add_on_ucc_framework/global_config.py
+++ b/splunk_add_on_ucc_framework/global_config.py
@@ -22,7 +22,7 @@ import yaml
 
 from splunk_add_on_ucc_framework import utils
 from splunk_add_on_ucc_framework.entity import expand_entity
-from splunk_add_on_ucc_framework.tabs import resolve_tab
+from splunk_add_on_ucc_framework.tabs import resolve_tab, LoggingTab
 
 Loader = getattr(yaml, "CSafeLoader", yaml.SafeLoader)
 yaml_load = functools.partial(yaml.load, Loader=Loader)
@@ -126,18 +126,7 @@ class GlobalConfig:
     @property
     def logging_tab(self) -> Dict[str, Any]:
         for tab in self.tabs:
-            if tab.get("type") == "loggingTab":
-                return tab
-            elif all(
-                [
-                    len(tab.get("entity", {})) == 1,
-                    tab.get("entity", [{}])[0].get("type") == "singleSelect",
-                    tab.get("entity", [{}])[0].get("field") is not None,
-                    tab.get("entity", [{}])[0].get("options") is not None,
-                    tab.get("entity", [{}])[0].get("defaultValue", "").upper()
-                    in ("DEBUG", "INFO", "WARN", "WARNING", "ERROR", "CRITICAL"),
-                ]
-            ):
+            if LoggingTab.from_definition(tab) is not None:
                 return tab
         return {}
 

--- a/splunk_add_on_ucc_framework/templates/oauth.template
+++ b/splunk_add_on_ucc_framework/templates/oauth.template
@@ -38,6 +38,19 @@ class {{app_name | lower}}_rh_oauth2_token(admin.MConfigHandler):
     This method checks which action is getting called and what parameters are required for the request.
     """
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(self, *args, **kwargs)
+        session_key = self.getSessionKey()
+        log_level = conf_manager.get_log_level(
+            logger=logger,
+            session_key=session_key,
+            app_name="{{app_name}}",
+            conf_name="{{app_name | lower}}_settings",
+            log_stanza="{{log_stanza}}",
+            log_level_field="{{log_level_field}}"
+        )
+        logger.set_level(log_level)
+
     def setup(self):
         if self.requestedAction == admin.ACTION_EDIT:
             # Add required args in supported args

--- a/tests/testdata/expected_addons/expected_output_global_config_configuration/Splunk_TA_UCCExample/bin/splunk_ta_uccexample_rh_oauth.py
+++ b/tests/testdata/expected_addons/expected_output_global_config_configuration/Splunk_TA_UCCExample/bin/splunk_ta_uccexample_rh_oauth.py
@@ -38,6 +38,19 @@ class splunk_ta_uccexample_rh_oauth2_token(admin.MConfigHandler):
     This method checks which action is getting called and what parameters are required for the request.
     """
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(self, *args, **kwargs)
+        session_key = self.getSessionKey()
+        log_level = conf_manager.get_log_level(
+            logger=logger,
+            session_key=session_key,
+            app_name="Splunk_TA_UCCExample",
+            conf_name="splunk_ta_uccexample_settings",
+            log_stanza="logging",
+            log_level_field="loglevel"
+        )
+        logger.set_level(log_level)
+
     def setup(self):
         if self.requestedAction == admin.ACTION_EDIT:
             # Add required args in supported args

--- a/tests/testdata/expected_addons/expected_output_global_config_everything/Splunk_TA_UCCExample/bin/splunk_ta_uccexample_rh_oauth.py
+++ b/tests/testdata/expected_addons/expected_output_global_config_everything/Splunk_TA_UCCExample/bin/splunk_ta_uccexample_rh_oauth.py
@@ -38,6 +38,19 @@ class splunk_ta_uccexample_rh_oauth2_token(admin.MConfigHandler):
     This method checks which action is getting called and what parameters are required for the request.
     """
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(self, *args, **kwargs)
+        session_key = self.getSessionKey()
+        log_level = conf_manager.get_log_level(
+            logger=logger,
+            session_key=session_key,
+            app_name="Splunk_TA_UCCExample",
+            conf_name="splunk_ta_uccexample_settings",
+            log_stanza="logging",
+            log_level_field="loglevel"
+        )
+        logger.set_level(log_level)
+
     def setup(self):
         if self.requestedAction == admin.ACTION_EDIT:
             # Add required args in supported args

--- a/tests/unit/commands/rest_builder/test_global_config_builder_schema.py
+++ b/tests/unit/commands/rest_builder/test_global_config_builder_schema.py
@@ -54,7 +54,7 @@ def test_global_config_builder_schema_custom_rh_config(global_config_all_json):
     autospec=True,
 )
 def test__builder_configs_for_oauth(mock_oauth_model, global_config_all_json):
-    _ = GlobalConfigBuilderSchema(global_config_all_json)
+    GlobalConfigBuilderSchema(global_config_all_json)
 
     mock_oauth_model.assert_called_once_with(
         app_name="Splunk_TA_UCCExample",

--- a/tests/unit/commands/rest_builder/test_global_config_builder_schema.py
+++ b/tests/unit/commands/rest_builder/test_global_config_builder_schema.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from splunk_add_on_ucc_framework.commands.rest_builder.global_config_builder_schema import (
     GlobalConfigBuilderSchema,
 )
@@ -44,4 +46,20 @@ def test_global_config_builder_schema_custom_rh_config(global_config_all_json):
             "account", RestEndpointBuilder("", "")
         ).rh_class
         == "CustomAccountValidator"
+    )
+
+
+@patch(
+    "splunk_add_on_ucc_framework.commands.rest_builder.global_config_builder_schema.OAuthModelEndpointBuilder",
+    autospec=True,
+)
+def test__builder_configs_for_oauth(mock_oauth_model, global_config_all_json):
+    _ = GlobalConfigBuilderSchema(global_config_all_json)
+
+    mock_oauth_model.assert_called_once_with(
+        app_name="Splunk_TA_UCCExample",
+        log_level_field="loglevel",
+        log_stanza="logging",
+        name="oauth",
+        namespace="splunk_ta_uccexample",
     )


### PR DESCRIPTION
**Issue number:** ADDON-58434

## Summary

### Changes

The OAuth RH template is updated. It now fetches the configured log level in the add-on and writes logs as per the level set.

### User experience

Using this feature, developers wouldn't have to update their OAuth RH file in their source code to get the log level set by the user in the add-on.
## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)
