### PR TITLE
docs: allow 2 blank lines in markdown files

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -8,6 +8,11 @@ MD010:
   # Include code blocks
   code_blocks: false
 
+# MD012/no-multiple-blanks
+MD012:
+  # 2 Consecutive blank lines for changelog
+  maximum: 2
+
 # MD013/line-length
 MD013: false
 


### PR DESCRIPTION
**Issue number:**

## Summary

Allow 2 empty line in markdown linter

### Changes

>

### User experience

>

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)
