### PR TITLE
feat(dashboard): add custom filtering options for the license_usage file

### DIFF
--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -358,3 +358,48 @@ It is possible to enable only a custom panel. To do this, remove the "default" e
 ...
 }
 ```
+
+## Data volume
+
+To obtain information on data volume usage, the monitoring dashboard uses logs saved in the `license_usage.log` file.
+By default, data filtering for a specific add-on is based on the `source` (s) and names of individual inputs.
+e.g.
+
+`...source=*license_usage.log type=Usage (s IN (demo_addon_release_2*,my_input_2*))...`
+
+If data is saved in your add-on with different, non-standard values or if filtering logs
+using the source is not possible, **UCC v5.47** offers the ability to define how the search engine should
+find data regarding a given add-on.
+To do this, you need to add the `custom_license_usage` parameter in globalconfig in the **dashboard** -> **settings** section.
+This parameter takes 2 mandatory items:
+
+* `determine_by` -> is used to determine the filtering basis. It can take one of 4 possible arguments: ("source", "sourcetype", "host", "index").
+* `search_condition` -> list of strings type parameter where you can provide elements that will be used to filter events in the license usage file.
+
+e.g. of globalConfig.json:
+
+```json
+{
+...
+        "dashboard": {
+            "panels": [
+                {
+                    "name": "custom"
+                }
+            ],
+            "settings": {
+                "custom_license_usage": {
+                    "determine_by": "sourcetype",
+                    "search_condition": [
+                        "*addon123*",
+                        "my_custom_condition*"
+                    ]
+                }
+            }
+        },
+...
+}
+```
+
+the above configuration will create the following filter query:
+`...source=*license_usage.log type=Usage (st IN ("*addon123*","my_custom_condition*"))...`

--- a/splunk_add_on_ucc_framework/dashboard.py
+++ b/splunk_add_on_ucc_framework/dashboard.py
@@ -18,7 +18,7 @@ import logging
 import os
 import sys
 
-from typing import Dict, List, Any
+from typing import Dict, List, Any, Optional, Tuple
 
 from splunk_add_on_ucc_framework import global_config as global_config_lib
 from splunk_add_on_ucc_framework import utils
@@ -51,13 +51,13 @@ default_definition_json_filename = {
 
 data_ingestion = (
     "index=_internal source=*license_usage.log type=Usage "
-    "(s IN ({input_names})) | timechart sum(b) as Usage | "
+    "({determine_by} IN ({lic_usg_condition})) | timechart sum(b) as Usage | "
     'rename Usage as \\"Data volume\\"'
 )
 
 data_ingestion_and_events = (
     "index=_internal source=*license_usage.log type=Usage "
-    "(s IN ({input_names})) | timechart sum(b) as Usage "
+    "({determine_by} IN ({lic_usg_condition})) | timechart sum(b) as Usage "
     '| rename Usage as \\"Data volume\\" '
     "| join _time [search index=_internal source=*{addon_name}* action=events_ingested "
     '| timechart sum(n_events) as \\"Number of events\\" ]'
@@ -71,7 +71,7 @@ events_count = (
 )
 
 table_sourcetype_query = (
-    "index=_internal source=*license_usage.log type=Usage (s IN ({input_names})) "
+    "index=_internal source=*license_usage.log type=Usage ({determine_by} IN ({lic_usg_condition})) "
     "| stats sparkline(sum(b)) as sparkvolume, sum(b) as Bytes by st "
     "| join type=left st [search index = _internal source=*{addon_name}* action=events_ingested "
     "| stats latest(_time) AS le, sparkline(sum(n_events)) as sparkevent, "
@@ -83,7 +83,7 @@ table_sourcetype_query = (
     'sparkvolume as \\"Volume trendline (Bytes)\\", sparkevent as \\"Event trendline\\"'
 )
 table_source_query = (
-    "index=_internal source=*license_usage.log type=Usage (s IN ({input_names})) "
+    "index=_internal source=*license_usage.log type=Usage ({determine_by} IN ({lic_usg_condition})) "
     "| stats sparkline(sum(b)) as sparkvolume, sum(b) as Bytes by s "
     "| join type=left s [search index = _internal source=*{addon_name}* action=events_ingested "
     "| stats latest(_time) AS le, sparkline(sum(n_events)) as sparkevent, "
@@ -96,13 +96,13 @@ table_source_query = (
 )
 table_host_query = (
     "index=_internal source=*license_usage.log type=Usage "
-    "(s IN ({input_names})) "
+    "({determine_by} IN ({lic_usg_condition})) "
     "| stats sparkline(sum(b)) as sparkvolume, sum(b) as Bytes by h "
     "| table h, Bytes, sparkvolume "
     '| rename h as \\"Host\\", Bytes as \\"Data volume\\", sparkvolume as \\"Volume trendline (Bytes)\\"'
 )
 table_index_query = (
-    "index=_internal source=*license_usage.log type=Usage (s IN ({input_names})) "
+    "index=_internal source=*license_usage.log type=Usage ({determine_by} IN ({lic_usg_condition})) "
     "| stats sparkline(sum(b)) as sparkvolume, sum(b) as Bytes by idx "
     "| join type=left idx [search index = _internal source=*{addon_name}* action=events_ingested "
     "| stats latest(_time) AS le, sparkline(sum(n_events)) as sparkevent, "
@@ -147,9 +147,18 @@ resource_memory_query = (
 
 
 def generate_dashboard_content(
-    addon_name: str, input_names: List[str], definition_json_name: str
+    addon_name: str,
+    input_names: List[str],
+    definition_json_name: str,
+    lic_usg_search_params: Optional[Tuple[str, str]],
 ) -> str:
-    input_names_str = ",".join([name + "*" for name in input_names])
+    determine_by = lic_usg_search_params[0] if lic_usg_search_params else "s"
+    lic_usg_condition = (
+        lic_usg_search_params[1]
+        if lic_usg_search_params
+        else (",".join([name + "*" for name in input_names]))
+    )
+
     content = ""
 
     if definition_json_name == default_definition_json_filename["overview"]:
@@ -158,7 +167,9 @@ def generate_dashboard_content(
             .get_template(definition_json_name)
             .render(
                 data_ingestion_and_events=data_ingestion_and_events.format(
-                    input_names=input_names_str, addon_name=addon_name.lower()
+                    lic_usg_condition=lic_usg_condition,
+                    addon_name=addon_name.lower(),
+                    determine_by=determine_by,
                 ),
                 errors_count=errors_count.format(addon_name=addon_name.lower()),
                 events_count=events_count.format(addon_name=addon_name.lower()),
@@ -170,20 +181,30 @@ def generate_dashboard_content(
             utils.get_j2_env()
             .get_template(definition_json_name)
             .render(
-                data_ingestion=data_ingestion.format(input_names=input_names_str),
+                data_ingestion=data_ingestion.format(
+                    lic_usg_condition=lic_usg_condition, determine_by=determine_by
+                ),
                 errors_count=errors_count.format(addon_name=addon_name.lower()),
                 events_count=events_count.format(addon_name=addon_name.lower()),
                 table_sourcetype=table_sourcetype_query.format(
-                    input_names=input_names_str, addon_name=addon_name.lower()
+                    lic_usg_condition=lic_usg_condition,
+                    addon_name=addon_name.lower(),
+                    determine_by=determine_by,
                 ),
                 table_source=table_source_query.format(
-                    input_names=input_names_str, addon_name=addon_name.lower()
+                    lic_usg_condition=lic_usg_condition,
+                    addon_name=addon_name.lower(),
+                    determine_by=determine_by,
                 ),
                 table_host=table_host_query.format(
-                    input_names=input_names_str, addon_name=addon_name.lower()
+                    lic_usg_condition=lic_usg_condition,
+                    addon_name=addon_name.lower(),
+                    determine_by=determine_by,
                 ),
                 table_index=table_index_query.format(
-                    input_names=input_names_str, addon_name=addon_name.lower()
+                    lic_usg_condition=lic_usg_condition,
+                    addon_name=addon_name.lower(),
+                    determine_by=determine_by,
                 ),
                 table_account=table_account_query.format(addon_name=addon_name.lower()),
                 table_input=table_input_query.format(
@@ -230,10 +251,12 @@ def generate_dashboard(
 
     panels_to_display = {PANEL_DEFAULT: False, PANEL_CUSTOM: False}
 
+    lic_usg_search_params = _get_license_usage_search_params(global_config.dashboard)
+
     if PANEL_DEFAULT in panel_names:
         for definition_json_name in default_definition_json_filename.values():
             content = generate_dashboard_content(
-                addon_name, input_names, definition_json_name
+                addon_name, input_names, definition_json_name, lic_usg_search_params
             )
             with open(
                 os.path.join(definition_json_path, definition_json_name), "w"
@@ -258,6 +281,28 @@ def generate_dashboard(
         os.path.join(definition_json_path, "panels_to_display.json"), "w"
     ) as file:
         file.write(json.dumps(panels_to_display))
+
+
+def _get_license_usage_search_params(
+    dashboard: Dict[Any, Any]
+) -> Optional[Tuple[str, str]]:
+    determine_by_map = {"source": "s", "sourcetype": "st", "host": "h", "index": "idx"}
+
+    try:
+        lic_usg_type = dashboard["settings"]["custom_license_usage"]["determine_by"]
+        lic_usg_search_items = dashboard["settings"]["custom_license_usage"][
+            "search_condition"
+        ]
+    except KeyError:
+        logger.info(
+            "No custom license usage search condition found. Proceeding with default parameters."
+        )
+        return None
+
+    determine_by = determine_by_map[lic_usg_type]
+    lic_usg_condition = ",".join(['\\"' + el + '\\"' for el in lic_usg_search_items])
+
+    return determine_by, lic_usg_condition
 
 
 def get_custom_json_content(custom_dashboard_path: str) -> Dict[Any, Any]:

--- a/splunk_add_on_ucc_framework/schema/schema.json
+++ b/splunk_add_on_ucc_framework/schema/schema.json
@@ -331,6 +331,35 @@
           "properties": {
             "custom_tab_name": {
               "type": "string"
+            },
+            "custom_license_usage": {
+              "type": "object",
+              "description": "Settings for creating custom search query for license usage.",
+              "properties": {
+                "determine_by": {
+                  "type": "string",
+                  "description": "Specify what to use (source or sourcetype) to search events in license usage.",
+                  "enum": [
+                    "source",
+                    "sourcetype",
+                    "host",
+                    "index"
+                  ]
+                },
+                "search_condition": {
+                  "type": "array",
+                  "description": "Elements that will be used as a query condition.",
+                  "minItems": 1,
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "required": [
+                "determine_by",
+                "search_condition"
+              ],
+              "additionalProperties": false
             }
           },
           "additionalProperties": false

--- a/tests/unit/test_dashboard.py
+++ b/tests/unit/test_dashboard.py
@@ -9,10 +9,8 @@ from splunk_add_on_ucc_framework import dashboard
 import tests.unit.helpers as helpers
 from splunk_add_on_ucc_framework import global_config as gc
 
-
 expected_folder = path.join(path.dirname(__file__), "expected_results")
 definition_jsons_path = dashboard.default_definition_json_filename
-
 
 custom_definition = {
     "visualizations": {
@@ -175,6 +173,7 @@ def test_generate_dashboard_with_custom_components_invalid_xml_file(
 
 def test_generate_dashboard_with_custom_components_no_content(setup, tmp_path, caplog):
     global_config, custom_dash_path, definition_jsons_file_path = setup
+
     with open(custom_dash_path, "w") as file:
         file.write("{}")
 
@@ -193,3 +192,72 @@ def test_generate_dashboard_with_custom_components_no_content(setup, tmp_path, c
         f"(see https://splunk.github.io/addonfactory-ucc-generator/dashboard/)"
     )
     assert expected_msg in caplog.text
+
+
+@pytest.mark.parametrize(
+    "custom_settings, expected_result",
+    [
+        (
+            ("source", ["*cond1", "*cond2"]),
+            'index=_internal source=*license_usage.log type=Usage (s IN ("*cond1","*cond2")) |',
+        ),
+        (
+            ("sourcetype", ["*cond1*"]),
+            'index=_internal source=*license_usage.log type=Usage (st IN ("*cond1*")) |',
+        ),
+        (
+            ("host", ["*cond1", "cond2*", "cond3*"]),
+            'index=_internal source=*license_usage.log type=Usage (h IN ("*cond1","cond2*","cond3*")) |',
+        ),
+        (
+            ("index", ["cond1", "cond2"]),
+            'index=_internal source=*license_usage.log type=Usage (idx IN ("cond1","cond2")) |',
+        ),
+    ],
+)
+def test_custom_license_usage_search(
+    setup, tmp_path, caplog, custom_settings, expected_result
+):
+    global_config, custom_dash_path, definition_jsons_file_path = setup
+
+    settings = {
+        "settings": {
+            "custom_license_usage": {
+                "determine_by": custom_settings[0],
+                "search_condition": custom_settings[1],
+            }
+        }
+    }
+
+    global_config.dashboard.update(settings)
+
+    with open(custom_dash_path, "w") as file:
+        file.write(json.dumps(custom_definition))
+
+    with mock.patch("os.path.abspath") as path_abs:
+        path_abs.return_value = custom_dash_path
+        dashboard.generate_dashboard(
+            global_config,
+            "Splunk_TA_UCCExample",
+            str(definition_jsons_file_path),
+        )
+
+    with open(
+        os.path.join(definition_jsons_file_path, "overview_definition.json")
+    ) as file:
+        def_json = json.loads(file.read())
+        query = def_json["dataSources"]["overview_data_volume_ds"]["options"]["query"]
+        assert query.startswith(expected_result)
+
+    with open(
+        os.path.join(definition_jsons_file_path, "data_ingestion_tab_definition.json")
+    ) as file:
+        def_json = json.loads(file.read())
+        query_1 = def_json["dataSources"]["data_ingestion_data_volume_ds"]["options"][
+            "query"
+        ]
+        assert query_1.startswith(expected_result)
+
+        for el in def_json["inputs"]["data_ingestion_table_input"]["options"]["items"]:
+            if el["label"] in ("Source type", "Source", "Host", "Index"):
+                assert el["value"].startswith(expected_result)


### PR DESCRIPTION
**Issue number:[ADDON-71696](https://splunk.atlassian.net/browse/ADDON-71696)**

## Summary

Added possibility to change default queries used by monitoring dashboard for filtering license_usage.log file.

### Changes

Added new settings in globalConfig.json file for dashboard for custom filtering:
* **determine_by** -> is used to determine the filtering basis. It can take one of 4 possible arguments: (“source”, “sourcetype”, “host”, “index”).
* **search_condition** -> list of strings type parameter where you can provide elements that will be used to filter events in the license usage file.

### User experience

The user can use custom filters to search the license_usage file to determine the addon's data volume usage using globalConfig.json file:
```
        "dashboard": {
            "panels": [
                {
                    "name": "custom"
                }
            ],
            "settings": {
                "custom_license_usage": {
                    "determine_by": "sourcetype",
                    "search_condition": [
                        "*addon123*",
                        "my_custom_condition*"
                    ]
                }
            }
        },
```

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)
