### PR TITLE
tests: make dashboard page tests more deterministic

### DIFF
--- a/ui/src/pages/Dashboard/stories/DashboardPage.stories.tsx
+++ b/ui/src/pages/Dashboard/stories/DashboardPage.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import React from 'react';
+import { expect, within } from '@storybook/test';
 import DashboardPage from '../DashboardPage';
 
 import { DASHBOARD_JSON_MOCKS } from '../tests/mockJs';
@@ -28,4 +29,12 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const DashboardPageView: Story = {};
+export const DashboardPageView: Story = {
+    play: async ({ canvasElement }) => {
+        const canvas = within(canvasElement);
+
+        const dataIngestion = await canvas.findByRole('heading', { name: 'Data Ingestion' });
+
+        await expect(dataIngestion).toBeInTheDocument();
+    },
+};

--- a/ui/src/pages/Dashboard/stories/__images__/DashboardPage-dashboard-page-view-chromium.png
+++ b/ui/src/pages/Dashboard/stories/__images__/DashboardPage-dashboard-page-view-chromium.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e3ab31581751878440ac853fb4743106686d48f8b089cd990e7373e9f11dda5f
-size 36828
+oid sha256:85aed016c022217bc02abae4af6dc3e6020fe2e76b16e1762738775b268d27dd
+size 77810


### PR DESCRIPTION
**Issue number:**

## Summary

the story does not wait until dashboard finishes loading before taking a screenshot. It causes random mismatches of screenshots because sometimes it loads before taking a screenshot, sometimes it does not.

### Changes

story waits for the dashboard to appear on the page before taking a screenshot

### User experience

No effect 

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)
