### PR TITLE
fix: allow using Global Config Validator regardless of the default encoding

### DIFF
--- a/splunk_add_on_ucc_framework/global_config_validator.py
+++ b/splunk_add_on_ucc_framework/global_config_validator.py
@@ -55,7 +55,7 @@ class GlobalConfigValidator:
         Raises jsonschema.ValidationError if config is not valid.
         """
         schema_path = os.path.join(self._source_dir, "schema", "schema.json")
-        with open(schema_path) as f_schema:
+        with open(schema_path, encoding="utf-8") as f_schema:
             schema_raw = f_schema.read()
             schema = json.loads(schema_raw)
         try:


### PR DESCRIPTION
## Summary

### Changes

> Please provide a summary of what's being changed

Global Config Schema contains unicode characters inside descriptions. By default, it is open using the default system encoding. This change allows to use the schema regardless of the default encoding, as it is always read using utf-8.

### User experience

> Please describe what the user experience looks like before and after this change

This allows users to use UCC on different platforms with default encodings different than utf-8.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)
