### PR TITLE
fix: schema for mapping custom api value

### DIFF
--- a/splunk_add_on_ucc_framework/schema/schema.json
+++ b/splunk_add_on_ucc_framework/schema/schema.json
@@ -785,6 +785,10 @@
               "type": "string",
               "description": "If you use endpointUrl and your data are not simple text data, you can specify here which property of retrieved object should be used.```item.content?.[labelField]``` "
             },
+            "valueField": {
+              "type": "string",
+              "description": "If you use endpointUrl and your data are not simple text data, you can specify here which property of retrieved object should be used as value for each item.```item.content?.[valueField]```"
+            },
             "autoCompleteFields": {
               "$ref": "#/definitions/AutoCompleteFields"
             },
@@ -913,6 +917,10 @@
             "labelField": {
               "type": "string",
               "description": "If you use endpointUrl and your data are not simple text data, you can specify here which property of retrieved object should be used.```item.content?.[labelField]``` "
+            },
+            "valueField": {
+              "type": "string",
+              "description": "If you use endpointUrl and your data are not simple text data, you can specify here which property of retrieved object should be used as value for each item.```item.content?.[valueField]```"
             },
             "autoCompleteFields": {
               "$ref": "#/definitions/AutoCompleteFields"


### PR DESCRIPTION
**Issue number:**[ADDON-72535](https://splunk.atlassian.net/browse/ADDON-72535) 

## Summary

Schema changes that allow valueField inside globalConfig file

### Changes

Allow optional string property valueField inside globalConfig file

### User experience

User can build with valueField in globalConfig

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)
