### PR TITLE
feat: add basic textarea field to alerts

### DIFF
--- a/splunk_add_on_ucc_framework/commands/modular_alert_builder/arf_template/default_html_theme/textarea.html
+++ b/splunk_add_on_ucc_framework/commands/modular_alert_builder/arf_template/default_html_theme/textarea.html
@@ -1,0 +1,6 @@
+{% extends "basecontrol.html" %}
+{% from "helper.html" import expand_ctrl_props with context %}
+{% block control %}
+<textarea name="action.{{ mod_alert.short_name }}.param.{{ param.name }}"
+		id="{{ mod_alert.short_name }}_{{ param.name }}" {{ expand_ctrl_props(param) }}></textarea>
+{% endblock %}

--- a/splunk_add_on_ucc_framework/global_config_validator.py
+++ b/splunk_add_on_ucc_framework/global_config_validator.py
@@ -440,9 +440,8 @@ class GlobalConfigValidator:
                         raise GlobalConfigValidatorException(
                             f"{entity_type} type must have options parameter"
                         )
-                elif entity.get("options") and entity_type not in (
-                    "singleSelectSplunkSearch",
-                    "textarea",
+                elif (
+                    entity.get("options") and entity_type != "singleSelectSplunkSearch"
                 ):
                     raise GlobalConfigValidatorException(
                         f"{entity_type} type must not contain options parameter"

--- a/splunk_add_on_ucc_framework/global_config_validator.py
+++ b/splunk_add_on_ucc_framework/global_config_validator.py
@@ -440,8 +440,9 @@ class GlobalConfigValidator:
                         raise GlobalConfigValidatorException(
                             f"{entity_type} type must have options parameter"
                         )
-                elif (
-                    entity.get("options") and entity_type != "singleSelectSplunkSearch"
+                elif entity.get("options") and entity_type not in (
+                    "singleSelectSplunkSearch",
+                    "textarea",
                 ):
                     raise GlobalConfigValidatorException(
                         f"{entity_type} type must not contain options parameter"


### PR DESCRIPTION
**Issue number:[ADDON-68244](https://splunk.atlassian.net/browse/ADDON-68244)**

## Summary

Add basic textarea field to alerts.

### Changes

Added textarea.html file for rendering textarea field in alerts.

### User experience

The user can now use textarea field in alerts. Since it's basic html template additional options like rowsMin and rowsMax won't do anything.

## Checklist

* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)
