### PR TITLE
test(textarea_height): test height within a range instead of certain amount of pixels

### DIFF
--- a/tests/ui/test_input_page.py
+++ b/tests/ui/test_input_page.py
@@ -2470,17 +2470,25 @@ class TestInputPage(UccTester):
         """
         input_page = InputPage(ucc_smartx_selenium_helper, ucc_smartx_rest_helper)
         input_page.table.edit_row("dummy_input_one")
-        min_textarea_height = 71
-        max_textarea_height = 311
+        min_textarea_height = 66
+        max_textarea_height = 306
+        tolerance = 5
         long_input = ""
         self.assert_util(
-            min_textarea_height, input_page.entity1.text_area.get_textarea_height
+            min_textarea_height - tolerance
+            <= input_page.entity1.text_area.get_textarea_height()
+            <= min_textarea_height + tolerance,
+            True,
         )
+
         for i in range(1, 50):
             long_input += f"{str(i)}\n"
         input_page.entity1.text_area.append_value(long_input)
         self.assert_util(
-            max_textarea_height, input_page.entity1.text_area.get_textarea_height
+            max_textarea_height - tolerance
+            <= input_page.entity1.text_area.get_textarea_height()
+            <= max_textarea_height + tolerance,
+            True,
         )
 
     @pytest.mark.execute_enterprise_cloud_true


### PR DESCRIPTION
**Issue number:** None
## Summary

### Changes

The test uses a tolerance of ±5 pixels to ensure that the height is within an acceptable range, rather than requiring an exact pixel match. This makes the test more robust and less likely to fail due to minor, non-critical differences in rendering.

### User experience

No changes

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)
