### PR TITLE
chore: fix adaptiveResponse in runtime schema

### DIFF
--- a/ui/src/types/globalConfig/alerts.ts
+++ b/ui/src/types/globalConfig/alerts.ts
@@ -14,10 +14,11 @@ export const alerts = z
             name: z.string(),
             label: z.string(),
             description: z.string(),
-            activeResponse: z
+            adaptiveResponse: z
                 .object({
                     task: z.array(z.string()).min(1),
                     supportsAdhoc: z.boolean(),
+                    supportsCloud: z.boolean(),
                     subject: z.array(z.string()).min(1),
                     category: z.array(z.string()).min(1),
                     technology: z


### PR DESCRIPTION
**Issue number:**

## Summary

#1135 changed the JSON schema and caused inconsistency between two schemas
 
### Changes

The PR adds corresponding changes to zod schema

### User experience

The runtime warning about incorrect globalConfig caused by `adaptiveResponse` should disappear. 

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)
