### PR TITLE
feat: extended rh_templates to pass user validators to resthandler

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,6 @@ classifiers = [
 python = "^3.7"
 jinja2 = ">=2,<4"
 addonfactory-splunk-conf-parser-lib = "^0.4.3"
-splunktaucclib = "^6.4.0"
 dunamai = "^1.9.0"
 jsonschema = "^4.4.0"
 PyYAML = "^6.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ classifiers = [
 python = "^3.7"
 jinja2 = ">=2,<4"
 addonfactory-splunk-conf-parser-lib = "^0.4.3"
+splunktaucclib = "^6.4.0"
 dunamai = "^1.9.0"
 jsonschema = "^4.4.0"
 PyYAML = "^6.0"

--- a/splunk_add_on_ucc_framework/commands/rest_builder/global_config_builder_schema.py
+++ b/splunk_add_on_ucc_framework/commands/rest_builder/global_config_builder_schema.py
@@ -217,15 +217,8 @@ class GlobalConfigBuilderSchema:
             if field["field"] != "name":
                 fields.append(rest_field)
             else:
-                special_fields.append(
-                    RestFieldBuilder(
-                        field["field"],
-                        _is_true(field.get("required")),
-                        _is_true(field.get("encrypted")),
-                        field.get("defaultValue"),
-                        ValidatorBuilder().build(field.get("validators")),
-                    )
-                )
+                special_fields.append(rest_field)
+
         return fields, special_fields
 
     """

--- a/splunk_add_on_ucc_framework/commands/rest_builder/global_config_builder_schema.py
+++ b/splunk_add_on_ucc_framework/commands/rest_builder/global_config_builder_schema.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 import json
-from typing import Dict, List, Set, Any
+from typing import Dict, List, Set, Any, Tuple
 
 from splunk_add_on_ucc_framework import global_config as global_config_lib
 
@@ -105,10 +105,11 @@ class GlobalConfigBuilderSchema:
             )
             self._endpoints[name] = endpoint
             content = self._get_oauth_enitities(config["entity"])
-            fields = self._parse_fields(content)
+            fields, special_fields = self._parse_fields(content)
             entity = SingleModelEntityBuilder(
                 None,
                 fields,
+                special_fields=special_fields,
                 conf_name=config.get("conf"),
             )
             endpoint.add_entity(entity)
@@ -140,10 +141,11 @@ class GlobalConfigBuilderSchema:
         self._endpoints["settings"] = endpoint
         for setting in self.global_config.settings:
             content = self._get_oauth_enitities(setting["entity"])
-            fields = self._parse_fields(content)
+            fields, special_fields = self._parse_fields(content)
             entity = MultipleModelEntityBuilder(
                 setting["name"],
                 fields,
+                special_fields=special_fields,
             )
             endpoint.add_entity(entity)
             self._settings_conf_file_names.add(endpoint.conf_name)
@@ -170,10 +172,11 @@ class GlobalConfigBuilderSchema:
                 )
                 self._endpoints[name] = single_model_endpoint
                 content = self._get_oauth_enitities(input_item["entity"])
-                fields = self._parse_fields(content)
+                fields, special_fields = self._parse_fields(content)
                 single_model_entity = SingleModelEntityBuilder(
                     None,
                     fields,
+                    special_fields=special_fields,
                     conf_name=input_item["conf"],
                 )
                 single_model_endpoint.add_entity(single_model_entity)
@@ -189,28 +192,42 @@ class GlobalConfigBuilderSchema:
                 )
                 self._endpoints[name] = data_input_endpoint
                 content = self._get_oauth_enitities(input_item["entity"])
-                fields = self._parse_fields(content)
+                fields, special_fields = self._parse_fields(content)
                 data_input_entity = DataInputEntityBuilder(
                     None,
                     fields,
+                    special_fields=special_fields,
                     input_type=input_item["name"],
                 )
                 data_input_endpoint.add_entity(data_input_entity)
 
     def _parse_fields(
         self, fields_content: List[Dict[str, Any]]
-    ) -> List[RestFieldBuilder]:
-        return [
-            RestFieldBuilder(
-                field["field"],
-                _is_true(field.get("required")),
-                _is_true(field.get("encrypted")),
-                field.get("defaultValue"),
-                ValidatorBuilder().build(field.get("validators")),
-            )
-            for field in fields_content
-            if field["field"] != "name"
-        ]
+    ) -> Tuple[List[RestFieldBuilder], List[RestFieldBuilder]]:
+        fields = []
+        special_fields = []
+        for field in fields_content:
+            if field["field"] != "name":
+                fields.append(
+                    RestFieldBuilder(
+                        field["field"],
+                        _is_true(field.get("required")),
+                        _is_true(field.get("encrypted")),
+                        field.get("defaultValue"),
+                        ValidatorBuilder().build(field.get("validators")),
+                    )
+                )
+            else:
+                special_fields.append(
+                    RestFieldBuilder(
+                        field["field"],
+                        _is_true(field.get("required")),
+                        _is_true(field.get("encrypted")),
+                        field.get("defaultValue"),
+                        ValidatorBuilder().build(field.get("validators")),
+                    )
+                )
+        return fields, special_fields
 
     """
     If the entity contains type oauth then we need to alter the content to generate proper entities to generate

--- a/splunk_add_on_ucc_framework/commands/rest_builder/global_config_builder_schema.py
+++ b/splunk_add_on_ucc_framework/commands/rest_builder/global_config_builder_schema.py
@@ -207,16 +207,15 @@ class GlobalConfigBuilderSchema:
         fields = []
         special_fields = []
         for field in fields_content:
+            rest_field = RestFieldBuilder(
+                field["field"],
+                _is_true(field.get("required")),
+                _is_true(field.get("encrypted")),
+                field.get("defaultValue"),
+                ValidatorBuilder().build(field.get("validators")),
+            )
             if field["field"] != "name":
-                fields.append(
-                    RestFieldBuilder(
-                        field["field"],
-                        _is_true(field.get("required")),
-                        _is_true(field.get("encrypted")),
-                        field.get("defaultValue"),
-                        ValidatorBuilder().build(field.get("validators")),
-                    )
-                )
+                fields.append(rest_field)
             else:
                 special_fields.append(
                     RestFieldBuilder(

--- a/splunk_add_on_ucc_framework/generators/conf_files/create_account_conf.py
+++ b/splunk_add_on_ucc_framework/generators/conf_files/create_account_conf.py
@@ -36,7 +36,7 @@ class AccountConf(ConfGenerator):
                 if account["name"] == "oauth":
                     continue
                 content = self._gc_schema._get_oauth_enitities(account["entity"])
-                fields = self._gc_schema._parse_fields(content)
+                fields, special_fields = self._gc_schema._parse_fields(content)
                 self.account_fields.append(
                     ("<name>", [f"{f._name} = " for f in fields])
                 )

--- a/splunk_add_on_ucc_framework/generators/conf_files/create_settings_conf.py
+++ b/splunk_add_on_ucc_framework/generators/conf_files/create_settings_conf.py
@@ -33,7 +33,7 @@ class SettingsConf(ConfGenerator):
             self.conf_spec_file = f"{self.conf_file}.spec"
             for setting in self._global_config.settings:
                 content = self._gc_schema._get_oauth_enitities(setting["entity"])
-                fields = self._gc_schema._parse_fields(content)
+                fields, special_fields = self._gc_schema._parse_fields(content)
                 self.settings_stanzas.append(
                     (setting["name"], [f"{f._name} = " for f in fields])
                 )

--- a/tests/testdata/expected_addons/expected_output_global_config_configuration/Splunk_TA_UCCExample/bin/splunk_ta_uccexample_rh_account.py
+++ b/tests/testdata/expected_addons/expected_output_global_config_configuration/Splunk_TA_UCCExample/bin/splunk_ta_uccexample_rh_account.py
@@ -14,6 +14,24 @@ import logging
 util.remove_http_proxy_env_vars()
 
 
+special_fields = [
+    field.RestField(
+        'name',
+        required=True,
+        encrypted=False,
+        default=None,
+        validator=validator.AllOf(
+            validator.String(
+                max_len=50,
+                min_len=1,
+            ),
+            validator.Pattern(
+                regex=r"""^[a-zA-Z]\w*$""",
+            )
+        )
+    )
+]
+
 fields = [
     field.RestField(
         'custom_endpoint',
@@ -128,7 +146,7 @@ fields = [
         validator=None
     )
 ]
-model = RestModel(fields, name=None)
+model = RestModel(fields, name=None, special_fields=special_fields)
 
 
 endpoint = SingleModel(

--- a/tests/testdata/expected_addons/expected_output_global_config_configuration/Splunk_TA_UCCExample/bin/splunk_ta_uccexample_rh_settings.py
+++ b/tests/testdata/expected_addons/expected_output_global_config_configuration/Splunk_TA_UCCExample/bin/splunk_ta_uccexample_rh_settings.py
@@ -14,6 +14,10 @@ import logging
 util.remove_http_proxy_env_vars()
 
 
+special_fields = [
+
+]
+
 fields_proxy = [
     field.RestField(
         'proxy_enabled',
@@ -78,8 +82,12 @@ fields_proxy = [
         validator=None
     )
 ]
-model_proxy = RestModel(fields_proxy, name='proxy')
+model_proxy = RestModel(fields_proxy, name='proxy', special_fields=special_fields)
 
+
+special_fields = [
+
+]
 
 fields_logging = [
     field.RestField(
@@ -90,8 +98,12 @@ fields_logging = [
         validator=None
     )
 ]
-model_logging = RestModel(fields_logging, name='logging')
+model_logging = RestModel(fields_logging, name='logging', special_fields=special_fields)
 
+
+special_fields = [
+
+]
 
 fields_custom_abc = [
     field.RestField(
@@ -160,7 +172,7 @@ fields_custom_abc = [
         )
     )
 ]
-model_custom_abc = RestModel(fields_custom_abc, name='custom_abc')
+model_custom_abc = RestModel(fields_custom_abc, name='custom_abc', special_fields=special_fields)
 
 
 endpoint = MultipleModel(

--- a/tests/testdata/expected_addons/expected_output_global_config_everything/Splunk_TA_UCCExample/bin/splunk_ta_uccexample_rh_account.py
+++ b/tests/testdata/expected_addons/expected_output_global_config_everything/Splunk_TA_UCCExample/bin/splunk_ta_uccexample_rh_account.py
@@ -14,6 +14,24 @@ import logging
 util.remove_http_proxy_env_vars()
 
 
+special_fields = [
+    field.RestField(
+        'name',
+        required=True,
+        encrypted=False,
+        default=None,
+        validator=validator.AllOf(
+            validator.String(
+                max_len=50,
+                min_len=1,
+            ),
+            validator.Pattern(
+                regex=r"""^[a-zA-Z]\w*$""",
+            )
+        )
+    )
+]
+
 fields = [
     field.RestField(
         'custom_endpoint',
@@ -179,7 +197,7 @@ fields = [
         validator=None
     )
 ]
-model = RestModel(fields, name=None)
+model = RestModel(fields, name=None, special_fields=special_fields)
 
 
 endpoint = SingleModel(

--- a/tests/testdata/expected_addons/expected_output_global_config_everything/Splunk_TA_UCCExample/bin/splunk_ta_uccexample_rh_example_input_four.py
+++ b/tests/testdata/expected_addons/expected_output_global_config_everything/Splunk_TA_UCCExample/bin/splunk_ta_uccexample_rh_example_input_four.py
@@ -14,6 +14,24 @@ import logging
 util.remove_http_proxy_env_vars()
 
 
+special_fields = [
+    field.RestField(
+        'name',
+        required=True,
+        encrypted=False,
+        default=None,
+        validator=validator.AllOf(
+            validator.Pattern(
+                regex=r"""^[a-zA-Z]\w*$""",
+            ),
+            validator.String(
+                max_len=100,
+                min_len=1,
+            )
+        )
+    )
+]
+
 fields = [
     field.RestField(
         'interval',
@@ -32,7 +50,7 @@ fields = [
     )
 
 ]
-model = RestModel(fields, name=None)
+model = RestModel(fields, name=None, special_fields=special_fields)
 
 
 

--- a/tests/testdata/expected_addons/expected_output_global_config_everything/Splunk_TA_UCCExample/bin/splunk_ta_uccexample_rh_example_input_one.py
+++ b/tests/testdata/expected_addons/expected_output_global_config_everything/Splunk_TA_UCCExample/bin/splunk_ta_uccexample_rh_example_input_one.py
@@ -14,6 +14,24 @@ import logging
 util.remove_http_proxy_env_vars()
 
 
+special_fields = [
+    field.RestField(
+        'name',
+        required=True,
+        encrypted=False,
+        default=None,
+        validator=validator.AllOf(
+            validator.Pattern(
+                regex=r"""^[a-zA-Z]\w*$""",
+            ),
+            validator.String(
+                max_len=100,
+                min_len=1,
+            )
+        )
+    )
+]
+
 fields = [
     field.RestField(
         'input_one_checkbox',
@@ -161,7 +179,7 @@ fields = [
     )
 
 ]
-model = RestModel(fields, name=None)
+model = RestModel(fields, name=None, special_fields=special_fields)
 
 
 

--- a/tests/testdata/expected_addons/expected_output_global_config_everything/Splunk_TA_UCCExample/bin/splunk_ta_uccexample_rh_example_input_two.py
+++ b/tests/testdata/expected_addons/expected_output_global_config_everything/Splunk_TA_UCCExample/bin/splunk_ta_uccexample_rh_example_input_two.py
@@ -14,6 +14,24 @@ import logging
 util.remove_http_proxy_env_vars()
 
 
+special_fields = [
+    field.RestField(
+        'name',
+        required=True,
+        encrypted=False,
+        default=None,
+        validator=validator.AllOf(
+            validator.Pattern(
+                regex=r"""^[a-zA-Z]\w*$""",
+            ),
+            validator.String(
+                max_len=100,
+                min_len=1,
+            )
+        )
+    )
+]
+
 fields = [
     field.RestField(
         'interval',
@@ -119,7 +137,7 @@ fields = [
     )
 
 ]
-model = RestModel(fields, name=None)
+model = RestModel(fields, name=None, special_fields=special_fields)
 
 
 

--- a/tests/testdata/expected_addons/expected_output_global_config_everything/Splunk_TA_UCCExample/bin/splunk_ta_uccexample_rh_settings.py
+++ b/tests/testdata/expected_addons/expected_output_global_config_everything/Splunk_TA_UCCExample/bin/splunk_ta_uccexample_rh_settings.py
@@ -14,6 +14,10 @@ import logging
 util.remove_http_proxy_env_vars()
 
 
+special_fields = [
+
+]
+
 fields_proxy = [
     field.RestField(
         'proxy_enabled',
@@ -83,8 +87,12 @@ fields_proxy = [
         validator=None
     )
 ]
-model_proxy = RestModel(fields_proxy, name='proxy')
+model_proxy = RestModel(fields_proxy, name='proxy', special_fields=special_fields)
 
+
+special_fields = [
+
+]
 
 fields_logging = [
     field.RestField(
@@ -95,8 +103,12 @@ fields_logging = [
         validator=None
     )
 ]
-model_logging = RestModel(fields_logging, name='logging')
+model_logging = RestModel(fields_logging, name='logging', special_fields=special_fields)
 
+
+special_fields = [
+
+]
 
 fields_custom_abc = [
     field.RestField(
@@ -165,7 +177,7 @@ fields_custom_abc = [
         )
     )
 ]
-model_custom_abc = RestModel(fields_custom_abc, name='custom_abc')
+model_custom_abc = RestModel(fields_custom_abc, name='custom_abc', special_fields=special_fields)
 
 
 endpoint = MultipleModel(

--- a/tests/unit/generators/conf_files/test_create_account_conf_spec.py
+++ b/tests/unit/generators/conf_files/test_create_account_conf_spec.py
@@ -49,7 +49,10 @@ def test_set_attributes(global_config, input_dir, output_dir, ucc_dir, ta_name):
     ]
     account_spec._global_config.namespace = TA_NAME
     account_spec._gc_schema._get_oauth_enitities.return_value = "mocked_content"
-    account_spec._gc_schema._parse_fields.return_value = [MagicMock(_name="field2")]
+    account_spec._gc_schema._parse_fields.return_value = (
+        [MagicMock(_name="field2")],
+        [MagicMock(_name="field3")],
+    )
 
     account_spec._set_attributes()
 

--- a/tests/unit/generators/conf_files/test_create_settings_conf.py
+++ b/tests/unit/generators/conf_files/test_create_settings_conf.py
@@ -44,7 +44,10 @@ def test_set_attributes(global_config, input_dir, output_dir, ucc_dir, ta_name):
     settings_conf._global_config.settings = [{"entity": "entity1", "name": "setting1"}]
     settings_conf._global_config.namespace = TA_NAME
     settings_conf._gc_schema._get_oauth_enitities.return_value = "mocked_content"
-    settings_conf._gc_schema._parse_fields.return_value = [MagicMock(_name="field1")]
+    settings_conf._gc_schema._parse_fields.return_value = (
+        [MagicMock(_name="field1")],
+        [MagicMock(_name="field3")],
+    )
 
     settings_conf._gc_schema._endpoints = {"settings": MagicMock()}
     settings_conf._gc_schema._endpoints[
@@ -104,7 +107,10 @@ def test_set_attributes_no_settings_key(
 
     settings_conf._global_config.settings = [{"entity": "entity1", "name": "setting1"}]
     settings_conf._gc_schema._get_oauth_enitities.return_value = "mocked_content"
-    settings_conf._gc_schema._parse_fields.return_value = [MagicMock(_name="field1")]
+    settings_conf._gc_schema._parse_fields.return_value = (
+        [MagicMock(_name="field1")],
+        [MagicMock(_name="field3")],
+    )
 
     settings_conf._gc_schema._endpoints = {}
 


### PR DESCRIPTION
**Issue number:[ADDON-74237](https://splunk.atlassian.net/browse/ADDON-74237)**

## Summary

Extended rh_templates to pass user validators to resthandler
this pr requires changes from splunktauuclib: https://github.com/splunk/addonfactory-ucc-library/pull/316

### Changes

* rh_templates now has an additional list "special_fields"
* rh_templates now adds "special_fields" to RestModel object
* GlobalConfigBuilderSchema now calculates "special_fields" for rh_templates

### User experience

Name field will be validated with users validators, provided in the globalconfig, on the server side.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)
