### PR TITLE
feat: allow validators for oauth fields

### DIFF
--- a/docs/advanced/oauth_support.md
+++ b/docs/advanced/oauth_support.md
@@ -36,6 +36,7 @@ Auth can be used inside the entity tag. Use `type: "oauth"` in the entity list a
         - `encrypted` should be true if the user wants that particular field encrypted, otherwise, there is no need to have this parameter.
         - `required` specifies whether the field is required or not. The default value is true.
         - `defaultValue` is the initial input value (string, number, or boolean).
+        - `validators` array that is used to validate the values of fields using various [validators](../entity/validators.md).
         - `options`:
             + `placeholder`: (RENOUNCED) The placeholder for the field.
             + `disableonEdit`: When the form is in edit mode, the field becomes unable to be edited. The default value is false.

--- a/splunk_add_on_ucc_framework/schema/schema.json
+++ b/splunk_add_on_ucc_framework/schema/schema.json
@@ -595,35 +595,8 @@
         "encrypted": {
           "$ref": "#/definitions/encrypted"
         },
-        "validators": {
-          "type": "array",
-          "description": "It is used to validate the values of fields using various validators.",
-          "minItems": 1,
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/NumberValidator"
-              },
-              {
-                "$ref": "#/definitions/StringValidator"
-              },
-              {
-                "$ref": "#/definitions/RegexValidator"
-              },
-              {
-                "$ref": "#/definitions/EmailValidator"
-              },
-              {
-                "$ref": "#/definitions/Ipv4Validator"
-              },
-              {
-                "$ref": "#/definitions/UrlValidator"
-              },
-              {
-                "$ref": "#/definitions/DateValidator"
-              }
-            ]
-          }
+        "validators":{
+          "$ref": "#/definitions/AnyValidator"
         },
         "options": {
           "type": "object",
@@ -2114,6 +2087,9 @@
         },
         "modifyFieldsOnValue": {
           "$ref": "#/definitions/modifyFieldsOnValue"
+        },
+        "validators":{
+          "$ref": "#/definitions/AnyValidator"
         }
       },
       "additionalProperties": false
@@ -2353,6 +2329,36 @@
         "type"
       ],
       "additionalProperties": false
+    },
+    "AnyValidator":{
+      "type": "array",
+      "description": "It is used to validate the values of fields using various validators.",
+      "minItems": 1,
+      "items": {
+        "anyOf": [
+          {
+            "$ref": "#/definitions/NumberValidator"
+          },
+          {
+            "$ref": "#/definitions/StringValidator"
+          },
+          {
+            "$ref": "#/definitions/RegexValidator"
+          },
+          {
+            "$ref": "#/definitions/EmailValidator"
+          },
+          {
+            "$ref": "#/definitions/Ipv4Validator"
+          },
+          {
+            "$ref": "#/definitions/UrlValidator"
+          },
+          {
+            "$ref": "#/definitions/DateValidator"
+          }
+        ]
+      }
     },
     "ValueLabelPair": {
       "type": "object",

--- a/tests/testdata/expected_addons/expected_output_global_config_everything/Splunk_TA_UCCExample/bin/splunk_ta_uccexample_rh_account.py
+++ b/tests/testdata/expected_addons/expected_output_global_config_everything/Splunk_TA_UCCExample/bin/splunk_ta_uccexample_rh_account.py
@@ -120,7 +120,15 @@ fields = [
         required=False,
         encrypted=False,
         default=None,
-        validator=None
+        validator=validator.AllOf(
+            validator.String(
+                max_len=4096, 
+                min_len=10, 
+            ), 
+            validator.Pattern(
+                regex=r"""^[a-zA-Z]\w*$""", 
+            )
+        )
     ), 
     field.RestField(
         'client_id',

--- a/tests/testdata/test_addons/package_global_config_everything/globalConfig.json
+++ b/tests/testdata/test_addons/package_global_config_everything/globalConfig.json
@@ -293,12 +293,25 @@
                                     {
                                         "oauth_field": "some_text",
                                         "label": "Disabled on edit for oauth",
-                                        "help": "Enter text for field disabled on edit",
+                                        "help": "Enter text for field disabled on edit, no special characters allowed",
                                         "field": "basic_oauth_text",
                                         "required": false,
                                         "options": {
                                             "disableonEdit": true
-                                        }
+                                        },
+                                        "validators": [
+                                            {
+                                                "type": "string",
+                                                "errorMsg": "Max host length is 4096",
+                                                "minLength": 10,
+                                                "maxLength": 4096
+                                            },
+                                            {
+                                                "type": "regex",
+                                                "errorMsg": "do not use special characters",
+                                                "pattern": "^[a-zA-Z]\\w*$"
+                                            }
+                                        ]
                                     }
                                 ],
                                 "oauth": [
@@ -1864,7 +1877,7 @@
     "meta": {
         "name": "Splunk_TA_UCCExample",
         "restRoot": "splunk_ta_uccexample",
-        "version": "5.50.1+8cbb9b3c",
+        "version": "5.50.0Rb2c34d2c8",
         "displayName": "Splunk UCC test Add-on",
         "schemaVersion": "0.0.8",
         "_uccVersion": "5.50.1",

--- a/tests/testdata/test_addons/package_global_config_everything/globalConfig.json
+++ b/tests/testdata/test_addons/package_global_config_everything/globalConfig.json
@@ -302,13 +302,13 @@
                                         "validators": [
                                             {
                                                 "type": "string",
-                                                "errorMsg": "Max host length is 4096",
+                                                "errorMsg": "Length should be between 10 and 4096",
                                                 "minLength": 10,
                                                 "maxLength": 4096
                                             },
                                             {
                                                 "type": "regex",
-                                                "errorMsg": "do not use special characters",
+                                                "errorMsg": "Do not use special characters",
                                                 "pattern": "^[a-zA-Z]\\w*$"
                                             }
                                         ]
@@ -1877,7 +1877,7 @@
     "meta": {
         "name": "Splunk_TA_UCCExample",
         "restRoot": "splunk_ta_uccexample",
-        "version": "5.50.0Rb2c34d2c8",
+        "version": "5.50.1+b4cfdcd44",
         "displayName": "Splunk UCC test Add-on",
         "schemaVersion": "0.0.8",
         "_uccVersion": "5.50.1",

--- a/tests/ui/pages/account_page.py
+++ b/tests/ui/pages/account_page.py
@@ -90,6 +90,12 @@ class AccountEntity(Entity):
             browser,
             Selector(select='[data-test="control-group"][data-name="redirect_url"]'),
         )
+        self.basic_oauth_text = TextBox(
+            browser,
+            Selector(
+                select='[data-test="control-group"][data-name="basic_oauth_text"]'
+            ),
+        )
         self.search_query = TextBox(
             browser, Selector(select='[data-test="textbox"][role="textbox"]')
         )

--- a/tests/ui/test_configuration_page_account_tab.py
+++ b/tests/ui/test_configuration_page_account_tab.py
@@ -21,7 +21,7 @@ _ACCOUNT_CONFIG = {
     "endpoint": "",
     "example_help_link": "",
     "url": "https://test.example.com",
-    "basic_oauth_text": "Some correct Text",
+    "basic_oauth_text": "Some_correct_text",
 }
 
 

--- a/tests/ui/test_configuration_page_account_tab.py
+++ b/tests/ui/test_configuration_page_account_tab.py
@@ -21,7 +21,6 @@ _ACCOUNT_CONFIG = {
     "endpoint": "",
     "example_help_link": "",
     "url": "https://test.example.com",
-    "basic_oauth_text": "Some_correct_text",
 }
 
 

--- a/tests/ui/test_configuration_page_account_tab.py
+++ b/tests/ui/test_configuration_page_account_tab.py
@@ -21,6 +21,7 @@ _ACCOUNT_CONFIG = {
     "endpoint": "",
     "example_help_link": "",
     "url": "https://test.example.com",
+    "basic_oauth_text": "Some correct Text",
 }
 
 
@@ -1188,4 +1189,85 @@ class TestAccount(UccTester):
         self.assert_util(
             account.entity.save(expect_error=True),
             "Invalid URL provided. URL should start with 'https' as only secure URLs are supported. Provide URL in this format",  # noqa: E501
+        )
+
+    @pytest.mark.execute_enterprise_cloud_true
+    @pytest.mark.forwarder
+    @pytest.mark.input
+    def test_example_validation_of_oauth_fields_too_short(
+        self, ucc_smartx_selenium_helper, ucc_smartx_rest_helper
+    ):
+        """Verifies required field client id"""
+        account = AccountPage(ucc_smartx_selenium_helper, ucc_smartx_rest_helper)
+        account.entity.open()
+        account.entity.name.set_value(_ACCOUNT_CONFIG["name"])
+        account.entity.environment.select("Value2")
+        account.entity.account_radio.select("No")
+        account.entity.multiple_select.select("Option Two")
+        account.entity.username.set_value("TestClientId")
+        account.entity.password.set_value("ClientSecretTest")
+        account.entity.security_token.set_value("SecurityTokenTest")
+        account.entity.basic_oauth_text.set_value("Invalid")
+
+        self.assert_util(
+            account.entity.save,
+            "Length should be between 10 and 4096",
+            left_args={"expect_error": True},
+        )
+
+    @pytest.mark.execute_enterprise_cloud_true
+    @pytest.mark.forwarder
+    @pytest.mark.input
+    def test_example_validation_of_oauth_fields_wrong_characters(
+        self, ucc_smartx_selenium_helper, ucc_smartx_rest_helper
+    ):
+        """Verifies required field client id"""
+        account = AccountPage(ucc_smartx_selenium_helper, ucc_smartx_rest_helper)
+        account.entity.open()
+        account.entity.name.set_value(_ACCOUNT_CONFIG["name"])
+        account.entity.environment.select("Value2")
+        account.entity.account_radio.select("No")
+        account.entity.multiple_select.select("Option Two")
+        account.entity.username.set_value("TestClientId")
+        account.entity.password.set_value("ClientSecretTest")
+        account.entity.security_token.set_value("SecurityTokenTest")
+        account.entity.basic_oauth_text.set_value(
+            "Invalid due to special characters: !@#$%^&*()"
+        )
+
+        self.assert_util(
+            account.entity.save,
+            "Do not use special characters",
+            left_args={"expect_error": True},
+        )
+
+    @pytest.mark.execute_enterprise_cloud_true
+    @pytest.mark.forwarder
+    @pytest.mark.input
+    def test_example_validation_of_oauth_valid(
+        self, ucc_smartx_selenium_helper, ucc_smartx_rest_helper
+    ):
+        """Verifies required field client id"""
+        account = AccountPage(ucc_smartx_selenium_helper, ucc_smartx_rest_helper)
+        account.entity.open()
+        account.entity.name.set_value(_ACCOUNT_CONFIG["name"])
+        account.entity.environment.select("Value2")
+        account.entity.account_radio.select("No")
+        account.entity.multiple_select.select("Option Two")
+        account.entity.username.set_value("TestClientId")
+        account.entity.password.set_value("ClientSecretTest")
+        account.entity.security_token.set_value("SecurityTokenTest")
+        account.entity.basic_oauth_text.set_value("Valid_text_for_oauth")
+
+        self.assert_util(account.entity.save, True)
+
+        account.table.wait_for_rows_to_appear(1)
+
+        self.assert_util(
+            account.table.get_table()[_ACCOUNT_CONFIG["name"]],
+            {
+                "name": _ACCOUNT_CONFIG["name"],
+                "auth type": "basic",
+                "actions": "Edit | Clone | Delete",
+            },
         )

--- a/ui/src/types/globalConfig/entities.ts
+++ b/ui/src/types/globalConfig/entities.ts
@@ -255,6 +255,7 @@ export const OAuthFields = z.object({
     defaultValue: z.union([z.string(), z.number(), z.boolean()]).optional(),
     options: CommonEditableEntityOptions.optional(),
     modifyFieldsOnValue: ModifyFieldsOnValue,
+    validators: AllValidators.optional(),
 });
 
 export const OAuthEntity = CommonEditableEntityFields.extend({


### PR DESCRIPTION
**Issue number:**
https://splunk.atlassian.net/browse/ADDON-61740
## Summary

allows validators to oauth fields
### Changes
allow validators array inside globalConfig.json scheme
> Please provide a summary of what's being changed

### User experience
right now oauth fields can be validated
> Please describe what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [x] Changes are documented
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)
