### PR TITLE
chore(deps): add module resolution for d3-color and d3-interpolate

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -121,6 +121,8 @@
     "@npmcli/git": "^2.1.0",
     "@types/react": "^16.14.62",
     "css-what": "^5.1.0",
+    "d3-color": "^3.1.0",
+    "d3-interpolate": "^3.0.1",
     "glob-parent": "^5.1.2",
     "postcss": "^8.4.47",
     "semver": "^7.6.3",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -5663,12 +5663,7 @@ d3-collection@^1.0.7:
   resolved "https://registry.npmjs.org/d3-collection/-/d3-collection-1.0.7.tgz#349bd2aa9977db071091c13144d5e4f16b5b310e"
   integrity sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A==
 
-"d3-color@1 - 2":
-  version "2.0.0"
-  resolved "https://registry.npmjs.org/d3-color/-/d3-color-2.0.0.tgz#8d625cab42ed9b8f601a1760a389f7ea9189d62e"
-  integrity sha512-SPXi0TSKPD4g9tw0NMZFnR95XVgUZiBH+uUTqQuDu1OsE2zomHU7ho0FISciaPvosimixwHFl3WHLGabv6dDgQ==
-
-"d3-color@1 - 3":
+"d3-color@1 - 2", "d3-color@1 - 3", d3-color@^3.0.0:
   version "3.1.0"
   resolved "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz#395b2833dfac71507f12ac2f7af23bf819de24e2"
   integrity sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==


### PR DESCRIPTION
**Issue number:** -

## Summary
Apply 'the fix' from splunk visualizations team
https://splunk.atlassian.net/browse/SCP-70409?focusedCommentId=15609860


### Changes

- Override module resolution to bring v3 instead of required v2. Potentially, it may break functionality

### User experience
-

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)
