### PR TITLE
chore(ui-dev-mode): ignore ResizeObserver warning during dev mode

### DIFF
--- a/ui/webpack.config.js
+++ b/ui/webpack.config.js
@@ -51,6 +51,19 @@ module.exports = merge(baseConfig, {
     },
     devServer: {
         hot: false,
+        client: {
+            overlay: {
+                runtimeErrors: (error) => {
+                    if (
+                        error?.message ===
+                        'ResizeObserver loop completed with undelivered notifications.'
+                    ) {
+                        return false;
+                    }
+                    return true;
+                },
+            },
+        },
         proxy: [
             {
                 target: proxyTargetUrl,


### PR DESCRIPTION
**Issue number:**

## Summary

### Changes

Ignore warning because it comes from splunk visualization.

### User experience
No change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented
* [ ] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)
