### PR TITLE
refactor: extract alert entity

### DIFF
--- a/splunk_add_on_ucc_framework/global_config_validator.py
+++ b/splunk_add_on_ucc_framework/global_config_validator.py
@@ -434,39 +434,6 @@ class GlobalConfigValidator:
                     )
                 else:
                     fields.append(entity.get("field"))
-                entity_type = entity.get("type")
-                if entity_type in ("radio", "singleSelect"):
-                    if not entity.get("options"):
-                        raise GlobalConfigValidatorException(
-                            f"{entity_type} type must have options parameter"
-                        )
-                elif (
-                    entity.get("options") and entity_type != "singleSelectSplunkSearch"
-                ):
-                    raise GlobalConfigValidatorException(
-                        f"{entity_type} type must not contain options parameter"
-                    )
-                if entity_type in ("singleSelectSplunkSearch",):
-                    if not all(
-                        [
-                            entity.get("search"),
-                            entity.get("valueField"),
-                            entity.get("labelField"),
-                        ]
-                    ):
-                        raise GlobalConfigValidatorException(
-                            f"{entity_type} type must have search, valueLabel and valueField parameters"
-                        )
-                elif any(
-                    [
-                        entity.get("search"),
-                        entity.get("valueField"),
-                        entity.get("labelField"),
-                    ]
-                ):
-                    raise GlobalConfigValidatorException(
-                        f"{entity_type} type must not contain search, valueField or labelField parameter"
-                    )
 
     def _validate_panels(self) -> None:
         """

--- a/splunk_add_on_ucc_framework/schema/schema.json
+++ b/splunk_add_on_ucc_framework/schema/schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
-    "AlertEntity": {
+    "AlertSingleSelectSplunkSearchEntity": {
       "type": "object",
       "description": "Alerts configuration. The alert action can help a user to take action on the alerts that have been triggered. The knowledge from Splunk can be sent to an outside service or to pull additional or detailed information related to the trigger details.",
       "properties": {
@@ -16,16 +16,9 @@
           "description": "The text that would be shown in the alert action UI."
         },
         "type": {
+          "const": "singleSelectSplunkSearch",
           "type": "string",
-          "enum": [
-            "text",
-            "textarea",
-            "checkbox",
-            "singleSelect",
-            "radio",
-            "singleSelectSplunkSearch"
-          ],
-          "description": "The type of the user input in the alert. Available choices: “text”, “checkbox”, “singleSelect”, “radio”, “singleSelectSplunkSearch”."
+          "description": "Exactly: singleSelectSplunkSearch"
         },
         "help": {
           "type": "string",
@@ -84,7 +77,226 @@
       "required": [
         "field",
         "label",
+        "type",
+        "search",
+        "valueField",
+        "labelField"
+      ],
+      "additionalProperties": false
+    },
+    "AlertTextEntity": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "text",
+          "type": "string",
+          "description": "Exactly: text"
+        },
+        "field": {
+          "$ref": "#/definitions/Field"
+        },
+        "label": {
+          "$ref": "#/definitions/entityLabel"
+        },
+        "help": {
+          "$ref": "#/definitions/help"
+        },
+        "defaultValue": {
+          "description": "The initial input value.",
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
+        "required": {
+          "$ref": "#/definitions/required"
+        }
+      },
+      "required": [
+        "field",
+        "label",
         "type"
+      ],
+      "additionalProperties": false
+    },
+    "AlertTextareaEntity": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "textarea",
+          "type": "string",
+          "description": "Exactly: textarea"
+        },
+        "field": {
+          "$ref": "#/definitions/Field"
+        },
+        "label": {
+          "$ref": "#/definitions/entityLabel"
+        },
+        "defaultValue": {
+          "type": "string",
+          "description": "The initial input value."
+        },
+        "help": {
+          "$ref": "#/definitions/help"
+        },
+        "required": {
+          "$ref": "#/definitions/required"
+        }
+      },
+      "required": [
+        "field",
+        "label",
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    "AlertCheckboxEntity": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "checkbox",
+          "type": "string",
+          "description": "Exactly: checkbox"
+        },
+        "field": {
+          "$ref": "#/definitions/Field"
+        },
+        "label": {
+          "$ref": "#/definitions/entityLabel"
+        },
+        "defaultValue": {
+          "anyOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "description": "The initial input value."
+        },
+        "help": {
+          "$ref": "#/definitions/help"
+        },
+        "required": {
+          "$ref": "#/definitions/required"
+        }
+      },
+      "required": [
+        "field",
+        "label",
+        "type"
+      ],
+      "additionalProperties": false
+    },
+    "AlertSingleSelectEntity": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "singleSelect",
+          "type": "string",
+          "description": "Exactly: singleSelect"
+        },
+        "field": {
+          "$ref": "#/definitions/Field"
+        },
+        "label": {
+          "$ref": "#/definitions/entityLabel"
+        },
+        "defaultValue": {
+          "description": "The initial input value.",
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
+        "help": {
+          "$ref": "#/definitions/help"
+        },
+        "required": {
+          "$ref": "#/definitions/required"
+        },
+        "options": {
+          "type": "object",
+          "description": "Static choices that a user can select in the alert action UI.",
+          "properties": {
+            "items": {
+              "type": "array",
+              "description": "An array of options with a label and a value.",
+              "items": {
+                "$ref": "#/definitions/ValueLabelPair"
+              }
+            }
+          }
+        }
+      },
+      "required": [
+        "field",
+        "label",
+        "type",
+        "options"
+      ],
+      "additionalProperties": false
+    },
+    "AlertRadioEntity": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "const": "radio",
+          "type": "string",
+          "description": "Exactly: radio"
+        },
+        "field": {
+          "$ref": "#/definitions/Field"
+        },
+        "label": {
+          "$ref": "#/definitions/entityLabel"
+        },
+        "defaultValue": {
+          "description": "The initial input value.",
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            }
+          ]
+        },
+        "help": {
+          "$ref": "#/definitions/help"
+        },
+        "required": {
+          "$ref": "#/definitions/required"
+        },
+        "options": {
+          "type": "object",
+          "description": "Static choices that a user can select in the alert action UI.",
+          "properties": {
+            "items": {
+              "type": "array",
+              "description": "An array of options with a label and a value.",
+              "items": {
+                "$ref": "#/definitions/ValueLabelPair"
+              }
+            }
+          }
+        }
+      },
+      "required": [
+        "field",
+        "label",
+        "type",
+        "options"
       ],
       "additionalProperties": false
     },
@@ -182,22 +394,22 @@
           "items": {
             "anyOf": [
               {
-                "$ref": "#/definitions/TextEntity"
+                "$ref": "#/definitions/AlertTextEntity"
               },
               {
-                "$ref": "#/definitions/TextareaEntity"
+                "$ref": "#/definitions/AlertTextareaEntity"
               },
               {
-                "$ref": "#/definitions/SingleSelectEntity"
+                "$ref": "#/definitions/AlertCheckboxEntity"
               },
               {
-                "$ref": "#/definitions/CheckboxEntity"
+                "$ref": "#/definitions/AlertSingleSelectEntity"
               },
               {
-                "$ref": "#/definitions/RadioEntity"
+                "$ref": "#/definitions/AlertRadioEntity"
               },
               {
-                "$ref": "#/definitions/AlertEntity"
+                "$ref": "#/definitions/AlertSingleSelectSplunkSearchEntity"
               }
             ]
           }


### PR DESCRIPTION
**Issue number:[ADDON-73358](https://splunk.atlassian.net/browse/ADDON-73358)**

## Summary

Alerts used to have only one entity and were created using the same schema where the type was based on the enum. Additional validation of whether a given parameter for a specific enum is correct was done on the backend. Now each entity has its own definition and no additional validation is needed on BE.

### Changes

Extracted AlertsEntity into 6 schemas, one for each enum.
Removed BE validation for required parameters.

### User experience

No impact

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)
