### PR TITLE
chore: fix use instance_type instead of product_type

### DIFF
--- a/ui/src/hooks/usePlatform.ts
+++ b/ui/src/hooks/usePlatform.ts
@@ -59,17 +59,13 @@ export const usePlatform = (globalConfig: GlobalConfig, page?: StandardPages) =>
 
         const resultsSubscription = mySearchJob
             .getResults()
-            .subscribe(
-                (result: {
-                    results?: Array<{ product_type?: string; instance_type?: string }>;
-                }) => {
-                    if (result.results?.[0]?.product_type === 'cloud') {
-                        setPlatform('cloud');
-                    } else {
-                        setPlatform('enterprise');
-                    }
+            .subscribe((result: { results?: Array<{ instance_type?: string }> }) => {
+                if (result.results?.[0]?.instance_type === 'cloud') {
+                    setPlatform('cloud');
+                } else {
+                    setPlatform('enterprise');
                 }
-            );
+            });
 
         return () => {
             resultsSubscription.unsubscribe();


### PR DESCRIPTION
**Issue number:**
https://splunk.atlassian.net/browse/ADDON-74887
## Summary
changing verifying product_type into verifying instance_type

product_type got value enterprise even for cloud
instance_type is used to determine cloud (does not appear for enterprise)

### Changes
use correct prop
> Please provide a summary of what's being changed

### User experience
none
> Please describe what the user experience looks like before and after this change

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented
* [ ] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)
