### PR TITLE
refactor(api): encode URL path

### DIFF
--- a/ui/src/components/BaseFormView/BaseFormView.tsx
+++ b/ui/src/components/BaseFormView/BaseFormView.tsx
@@ -9,7 +9,7 @@ import Validator, { SaveValidator } from '../../util/Validator';
 import { getUnifiedConfigs, generateToast } from '../../util/util';
 import { MODE_CLONE, MODE_CREATE, MODE_EDIT, MODE_CONFIG } from '../../constants/modes';
 import { PAGE_INPUT, PAGE_CONF } from '../../constants/pages';
-import { axiosCallWrapper } from '../../util/axiosCallWrapper';
+import { axiosCallWrapper, generateEndPointUrl } from '../../util/axiosCallWrapper';
 import { parseErrorMsg, getFormattedMessage } from '../../util/messageUtil';
 import { getBuildDirPath } from '../../util/script';
 
@@ -862,7 +862,7 @@ class BaseFormView extends PureComponent<BaseFormProps, BaseFormState> {
         }
 
         axiosCallWrapper({
-            serviceName: this.endpoint,
+            endpointUrl: generateEndPointUrl(encodeURIComponent(this.endpoint)),
             body,
             customHeaders: { 'Content-Type': 'application/x-www-form-urlencoded' },
             method: 'post',
@@ -1134,12 +1134,16 @@ class BaseFormView extends PureComponent<BaseFormProps, BaseFormState> {
             return false;
         }
 
+        const baseUrl = new URL(
+            `https://${this.datadict.endpoint || this.datadict.endpoint_token}`
+        );
+        baseUrl.pathname = this.oauthConf?.accessTokenEndpoint || '';
+        const url = baseUrl.toString();
+
         const code = decodeURIComponent(message.code);
         const data: Record<string, AcceptableFormValueOrNullish> = {
             method: 'POST',
-            url: `https://${this.datadict.endpoint || this.datadict.endpoint_token}${
-                this.oauthConf?.accessTokenEndpoint
-            }`,
+            url,
             grant_type: 'authorization_code',
             client_id: this.datadict.client_id,
             client_secret: this.datadict.client_secret,
@@ -1159,7 +1163,7 @@ class BaseFormView extends PureComponent<BaseFormProps, BaseFormState> {
             }
         });
 
-        const OAuthEndpoint = `${this.appName}_oauth/oauth`;
+        const OAuthEndpoint = `${encodeURIComponent(this.appName)}_oauth/oauth`;
         // Internal handler call to get the access token and other values
         axiosCallWrapper({
             endpointUrl: OAuthEndpoint,

--- a/ui/src/components/BaseFormView/BaseFormView.tsx
+++ b/ui/src/components/BaseFormView/BaseFormView.tsx
@@ -142,8 +142,10 @@ class BaseFormView extends PureComponent<BaseFormProps, BaseFormState> {
         this.groupEntities = [];
         this.endpoint =
             props.mode === MODE_EDIT || props.mode === MODE_CONFIG
-                ? `${this.props.serviceName}/${encodeURIComponent(this.props.stanzaName)}`
-                : `${this.props.serviceName}`;
+                ? `${encodeURIComponent(this.props.serviceName)}/${encodeURIComponent(
+                      this.props.stanzaName
+                  )}`
+                : `${encodeURIComponent(this.props.serviceName)}`;
         this.pageContext = props.pageContext;
 
         this.util = {
@@ -862,7 +864,7 @@ class BaseFormView extends PureComponent<BaseFormProps, BaseFormState> {
         }
 
         axiosCallWrapper({
-            endpointUrl: generateEndPointUrl(encodeURIComponent(this.endpoint)),
+            endpointUrl: generateEndPointUrl(this.endpoint),
             body,
             customHeaders: { 'Content-Type': 'application/x-www-form-urlencoded' },
             method: 'post',

--- a/ui/src/components/ConfigurationFormView.jsx
+++ b/ui/src/components/ConfigurationFormView.jsx
@@ -8,7 +8,7 @@ import WaitSpinner from '@splunk/react-ui/WaitSpinner';
 import axios from 'axios';
 import BaseFormView from './BaseFormView/BaseFormView';
 import { StyledButton } from '../pages/EntryPageStyle';
-import { axiosCallWrapper } from '../util/axiosCallWrapper';
+import { axiosCallWrapper, generateEndPointUrl } from '../util/axiosCallWrapper';
 import { MODE_CONFIG } from '../constants/modes';
 import { WaitSpinnerWrapper } from './table/CustomTableStyle';
 import { PAGE_CONF } from '../constants/pages';
@@ -28,7 +28,7 @@ function ConfigurationFormView({ serviceName }) {
     useEffect(() => {
         const abortController = new AbortController();
         axiosCallWrapper({
-            serviceName: `settings/${serviceName}`,
+            endpointUrl: generateEndPointUrl(`settings/${encodeURIComponent(serviceName)}`),
             handleError: true,
             signal: abortController.signal,
             callbackOnError: (err) => {

--- a/ui/src/components/DeleteModal/DeleteModal.test.tsx
+++ b/ui/src/components/DeleteModal/DeleteModal.test.tsx
@@ -52,7 +52,7 @@ it('close model and callback after cancel click', async () => {
 it('correct delete request', async () => {
     server.use(
         http.delete(
-            '/servicesNS/nobody/-/mockGeneratedEndPointUrl',
+            '/servicesNS/nobody/-/restRoot_serviceName/stanzaName',
             () => new HttpResponse(undefined, { status: 201 })
         )
     );

--- a/ui/src/components/DeleteModal/DeleteModal.tsx
+++ b/ui/src/components/DeleteModal/DeleteModal.tsx
@@ -8,7 +8,7 @@ import { _ } from '@splunk/ui-utils/i18n';
 import { generateToast } from '../../util/util';
 import { StyledButton } from '../../pages/EntryPageStyle';
 
-import { axiosCallWrapper } from '../../util/axiosCallWrapper';
+import { axiosCallWrapper, generateEndPointUrl } from '../../util/axiosCallWrapper';
 import TableContext from '../../context/TableContext';
 import { parseErrorMsg, getFormattedMessage } from '../../util/messageUtil';
 import { PAGE_INPUT } from '../../constants/pages';
@@ -52,9 +52,11 @@ class DeleteModal extends Component<DeleteModalProps, DeleteModalState> {
             (prevState) => ({ ...prevState, isDeleting: true, ErrorMsg: '' }),
             () => {
                 axiosCallWrapper({
-                    serviceName: `${this.props.serviceName}/${encodeURIComponent(
-                        this.props.stanzaName
-                    )}`,
+                    endpointUrl: generateEndPointUrl(
+                        `${encodeURIComponent(this.props.serviceName)}/${encodeURIComponent(
+                            this.props.stanzaName
+                        )}`
+                    ),
                     customHeaders: { 'Content-Type': 'application/x-www-form-urlencoded' },
                     method: 'delete',
                     handleError: false,

--- a/ui/src/components/MultiInputComponent/MultiInputComponent.tsx
+++ b/ui/src/components/MultiInputComponent/MultiInputComponent.tsx
@@ -4,9 +4,10 @@ import styled from 'styled-components';
 import WaitSpinner from '@splunk/react-ui/WaitSpinner';
 import { z } from 'zod';
 
-import { AxiosCallType, axiosCallWrapper } from '../../util/axiosCallWrapper';
+import { AxiosCallType, axiosCallWrapper, generateEndPointUrl } from '../../util/axiosCallWrapper';
 import { filterResponse } from '../../util/util';
 import { MultipleSelectCommonOptions } from '../../types/globalConfig/entities';
+import { invariant } from '../../util/invariant';
 
 const MultiSelectWrapper = styled(Multiselect)`
     width: 320px !important;
@@ -79,19 +80,20 @@ function MultiInputComponent(props: MultiInputComponentProps) {
         let current = true;
         const abortController = new AbortController();
 
+        const url = referenceName
+            ? generateEndPointUrl(encodeURIComponent(referenceName))
+            : endpointUrl;
+        invariant(
+            url,
+            '[MultiInputComponent] referenceName or endpointUrl or items must be provided'
+        );
+
         const apiCallOptions = {
             signal: abortController.signal,
             handleError: true,
             params: { count: -1 },
-            serviceName: '',
-            endpointUrl: '',
+            endpointUrl: url,
         } satisfies AxiosCallType;
-        if (referenceName) {
-            apiCallOptions.serviceName = referenceName;
-        } else if (endpointUrl) {
-            apiCallOptions.endpointUrl = endpointUrl;
-        }
-
         if (dependencyValues) {
             apiCallOptions.params = { ...apiCallOptions.params, ...dependencyValues };
         }

--- a/ui/src/components/SingleInputComponent/SingleInputComponent.tsx
+++ b/ui/src/components/SingleInputComponent/SingleInputComponent.tsx
@@ -12,7 +12,6 @@ import { SelectCommonOptions } from '../../types/globalConfig/entities';
 import { filterResponse } from '../../util/util';
 import { getValueMapTruthyFalse } from '../../util/considerFalseAndTruthy';
 import { StandardPages } from '../../types/components/shareableTypes';
-import { invariant } from '../../util/invariant';
 
 const SelectWrapper = styled(Select)`
     width: 320px !important;

--- a/ui/src/components/SingleInputComponent/SingleInputComponent.tsx
+++ b/ui/src/components/SingleInputComponent/SingleInputComponent.tsx
@@ -114,16 +114,17 @@ function SingleInputComponent(props: SingleInputComponentProps) {
             return;
         }
 
-        let current = true;
-        const abortController = new AbortController();
-
         const url = referenceName
             ? generateEndPointUrl(encodeURIComponent(referenceName))
             : endpointUrl;
-        invariant(
-            url,
-            '[SingleInputComponent] referenceName or endpointUrl or autoCompleteFields must be provided'
-        );
+
+        if ((dependencies && !dependencyValues) || !url) {
+            setOptions([]);
+            return;
+        }
+
+        let current = true;
+        const abortController = new AbortController();
 
         const backendCallOptions = {
             signal: abortController.signal,
@@ -135,34 +136,31 @@ function SingleInputComponent(props: SingleInputComponentProps) {
         if (dependencyValues) {
             backendCallOptions.params = { ...backendCallOptions.params, ...dependencyValues };
         }
-        if (!dependencies || dependencyValues) {
-            setLoading(true);
-            axiosCallWrapper(backendCallOptions)
-                .then((response) => {
-                    if (current) {
-                        setOptions(
-                            generateOptions(
-                                filterResponse(
-                                    response.data.entry,
-                                    labelField,
-                                    valueField,
-                                    allowList,
-                                    denyList
-                                )
+
+        setLoading(true);
+        axiosCallWrapper(backendCallOptions)
+            .then((response) => {
+                if (current) {
+                    setOptions(
+                        generateOptions(
+                            filterResponse(
+                                response.data.entry,
+                                labelField,
+                                valueField,
+                                allowList,
+                                denyList
                             )
-                        );
-                        setLoading(false);
-                    }
-                })
-                .catch(() => {
-                    if (current) {
-                        setLoading(false);
-                    }
-                    setOptions([]);
-                });
-        } else {
-            setOptions([]);
-        }
+                        )
+                    );
+                    setLoading(false);
+                }
+            })
+            .catch(() => {
+                if (current) {
+                    setLoading(false);
+                }
+                setOptions([]);
+            });
 
         // eslint-disable-next-line consistent-return
         return () => {

--- a/ui/src/components/table/TableWrapper.tsx
+++ b/ui/src/components/table/TableWrapper.tsx
@@ -3,7 +3,7 @@ import update from 'immutability-helper';
 import axios from 'axios';
 
 import { WaitSpinnerWrapper } from './CustomTableStyle';
-import { axiosCallWrapper } from '../../util/axiosCallWrapper';
+import { axiosCallWrapper, generateEndPointUrl } from '../../util/axiosCallWrapper';
 import { getUnifiedConfigs, generateToast } from '../../util/util';
 import CustomTable from './CustomTable';
 import TableHeader from './TableHeader';
@@ -143,7 +143,7 @@ const TableWrapper: React.FC<ITableWrapperProps> = ({
             const requests =
                 services?.map((service) =>
                     axiosCallWrapper({
-                        serviceName: service.name,
+                        endpointUrl: generateEndPointUrl(encodeURIComponent(service.name)),
                         params: { count: -1 },
                         signal: abortController.signal,
                     })
@@ -204,7 +204,9 @@ const TableWrapper: React.FC<ITableWrapperProps> = ({
         const body = new URLSearchParams();
         body.append('disabled', String(!row.disabled));
         axiosCallWrapper({
-            serviceName: `${row.serviceName}/${row.name}`,
+            endpointUrl: generateEndPointUrl(
+                `${encodeURIComponent(row.serviceName)}/${encodeURIComponent(row.name)}`
+            ),
             body,
             customHeaders: { 'Content-Type': 'application/x-www-form-urlencoded' },
             method: 'post',

--- a/ui/src/pages/Configuration/tests/ConfigurationPage.test.tsx
+++ b/ui/src/pages/Configuration/tests/ConfigurationPage.test.tsx
@@ -16,7 +16,7 @@ const getUnifiedConfigsMock = getUnifiedConfigs as jest.Mock;
 
 beforeEach(() => {
     server.use(
-        http.get(`/servicesNS/nobody/-/:endpointUrl`, () =>
+        http.get(`/servicesNS/nobody/-/:endpointUrl/:serviceName`, () =>
             HttpResponse.json(mockServerResponseWithContent)
         )
     );

--- a/ui/src/public/mockServiceWorker.js
+++ b/ui/src/public/mockServiceWorker.js
@@ -8,7 +8,7 @@
  * - Please do NOT serve this file on production.
  */
 
-const PACKAGE_VERSION = '2.4.8'
+const PACKAGE_VERSION = '2.4.11'
 const INTEGRITY_CHECKSUM = '26357c79639bfa20d64c0efca2a87423'
 const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
 const activeClientIds = new Set()

--- a/ui/src/public/mockServiceWorker.js
+++ b/ui/src/public/mockServiceWorker.js
@@ -8,7 +8,7 @@
  * - Please do NOT serve this file on production.
  */
 
-const PACKAGE_VERSION = '2.4.11'
+const PACKAGE_VERSION = '2.4.8'
 const INTEGRITY_CHECKSUM = '26357c79639bfa20d64c0efca2a87423'
 const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
 const activeClientIds = new Set()

--- a/ui/src/types/modules.d.ts
+++ b/ui/src/types/modules.d.ts
@@ -1,5 +1,38 @@
 declare module '@splunk/splunk-utils/config';
-declare module '@splunk/splunk-utils/url';
+declare module '@splunk/splunk-utils/url' {
+    export type Sharing = '' | 'app' | 'global' | 'system';
+
+    export interface NamespaceOptions {
+        app?: string;
+        owner?: string;
+        sharing?: Sharing;
+    }
+
+    export interface ConfigOptions {
+        /** Config options including `splunkdPath`. Defaults to the value provided by `@splunk/splunk-utils/config`. */
+        splunkdPath?: string;
+    }
+
+    /**
+     * Creates a fully qualified URL for the specified endpoint.
+     * For example:
+     * ```
+     * createRESTURL('server/info'); // "/en-US/splunkd/__raw/services/server/info"
+     * createRESTURL('saved/searches', {app: 'search'}); // "/en-US/splunkd/__raw/servicesNS/-/search/saved/searches"
+     * ```
+     * @param endpoint - An endpoint to a REST API.
+     * @param namespaceOptions - Optional namespace options.
+     * @param configOptions - Optional config options.
+     * @returns The URL of the REST API endpoint.
+     * @alias createRESTURL
+     */
+    export function createRESTURL(
+        endpoint: string,
+        namespaceOptions?: NamespaceOptions,
+        configOptions?: ConfigOptions
+    ): string;
+}
+
 declare module '@splunk/search-job';
 // declaring modules as utils does not seem to have types
 

--- a/ui/src/util/__mocks__/util.ts
+++ b/ui/src/util/__mocks__/util.ts
@@ -1,7 +1,5 @@
 import { mockUnifiedConfig } from './mockUnifiedConfig';
 
-export const generateEndPointUrl = jest.fn(() => 'mockGeneratedEndPointUrl');
-
 export const getUnifiedConfigs = jest.fn().mockImplementation(() => mockUnifiedConfig);
 
 export const generateToast = jest.fn();

--- a/ui/src/util/util.ts
+++ b/ui/src/util/util.ts
@@ -24,13 +24,6 @@ export function getMetaInfo() {
     };
 }
 
-export function generateEndPointUrl(name: string) {
-    if (!unifiedConfigs) {
-        throw new Error('No GlobalConfig set');
-    }
-    return `${unifiedConfigs.meta.restRoot}_${name}`;
-}
-
 export function setUnifiedConfig(unifiedConfig: GlobalConfig) {
     const result = GlobalConfigSchema.safeParse(unifiedConfig);
     if (!result.success) {


### PR DESCRIPTION
**Issue number:** ADDON-75718

## Summary

### Changes

- Encoded all dynamic parameters that comes into URL path, including the ones that come from user input (as input name) and from globalConfig.json

#### not essential changes
- removed serviceName from axiosCallWrapper since it is leaking abstraction
- unmocked generateEndPointUrl that causes small changes in tests

### User experience

It may only impact users if they put special symbols to entity names and expect it will go directly as part of URL.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)
