### PR TITLE
refactor: remove unused function

### DIFF
--- a/splunk_add_on_ucc_framework/install_python_libraries.py
+++ b/splunk_add_on_ucc_framework/install_python_libraries.py
@@ -82,15 +82,6 @@ def _pip_is_lib_installed(
         raise CouldNotInstallRequirements from e
 
 
-def _check_ucc_library_in_requirements_file(path_to_requirements: str) -> bool:
-    with open(path_to_requirements) as f_reqs:
-        content = f_reqs.readlines()
-    for line in content:
-        if "splunktaucclib" in line:
-            return True
-    return False
-
-
 def install_python_libraries(
     source_path: str,
     ucc_lib_target: str,

--- a/tests/unit/test_install_python_libraries.py
+++ b/tests/unit/test_install_python_libraries.py
@@ -10,7 +10,6 @@ from splunk_add_on_ucc_framework.global_config import OSDependentLibraryConfig
 from splunk_add_on_ucc_framework.install_python_libraries import (
     CouldNotInstallRequirements,
     SplunktaucclibNotFound,
-    _check_ucc_library_in_requirements_file,
     install_libraries,
     install_python_libraries,
     remove_execute_bit,
@@ -19,56 +18,6 @@ from splunk_add_on_ucc_framework.install_python_libraries import (
 )
 
 from splunk_add_on_ucc_framework import global_config as gc
-
-
-@pytest.mark.parametrize(
-    "requirements_content,expected_result",
-    [
-        ("", False),
-        ("splunk-sdk", False),
-        ("splunk-sdk\n", False),
-        ("splunktaucclib", True),
-        ("splunktaucclib\n", True),
-        ("splunktaucclib==6.0.0\n", True),
-        ("solnlib\nsplunktaucclib\n", True),
-        ("solnlib==5.0.0\nsplunktaucclib==6.0.0\n", True),
-        (
-            """splunktalib==2.2.6; python_version >= "3.7" and python_version < "4.0" \
-        --hash=sha256:bba70ac7407cdedcb45437cb152ac0e43aae16b978031308e6bec548d3543119 \
-        --hash=sha256:8d58d697a842319b4c675557b0cc4a9c68e8d909389a98ed240e2bb4ff358d31
-    splunktaucclib==5.0.7; python_version >= "3.7" and python_version < "4.0" \
-        --hash=sha256:3ddc1276c41c809c16ae810cb20e9eb4abd2f94dba5ddf460cf9c49b50f659ac \
-        --hash=sha256:a1e3f710fcb0b24dff8913e6e5df0d36f0693b7f3ed7c0a9a43b08372b08eb90""",
-            True,
-        ),
-        (
-            """splunktaucclib==5.0.7; python_version >= "3.7" and python_version < "4.0" \
-        --hash=sha256:3ddc1276c41c809c16ae810cb20e9eb4abd2f94dba5ddf460cf9c49b50f659ac \
-        --hash=sha256:a1e3f710fcb0b24dff8913e6e5df0d36f0693b7f3ed7c0a9a43b08372b08eb90""",
-            True,
-        ),
-        (
-            """sortedcontainers==2.4.0; python_version >= "3.7" and python_version < "4.0" \
-        --hash=sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0 \
-        --hash=sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88
-    splunk-sdk==1.7.1 \
-        --hash=sha256:4d0de12a87395f28f2a0c90b179882072a39a1f09a3ec9e79ce0de7a16220fe1""",
-            False,
-        ),
-    ],
-)
-def test_check_ucc_library_in_requirements_file(
-    tmp_path, requirements_content, expected_result
-):
-    tmp_lib_path = tmp_path / "lib"
-    tmp_lib_path.mkdir()
-    tmp_lib_reqs_file = tmp_lib_path / "requirements.txt"
-    tmp_lib_reqs_file.write_text(requirements_content)
-
-    assert (
-        _check_ucc_library_in_requirements_file(str(tmp_lib_reqs_file))
-        == expected_result
-    )
 
 
 @mock.patch("subprocess.call", autospec=True)


### PR DESCRIPTION
**Issue number:** N/A

## Summary

Remove unused `_check_ucc_library_in_requirements_file` function from `install_python_libraries.py`. Now we check for `splunktaucclib` after we install all Python packages from `requirements.txt`, not by reading what's inside of `requirements.txt` file.

### Changes

> Please provide a summary of what's being changed

Removing unused function and corresponding test cases.

### User experience

> Please describe what the user experience looks like before and after this change

N/A

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)
