### PR TITLE
ci(ui-tests): specify cache to node_modules folder

### DIFF
--- a/ui/jest.config.ts
+++ b/ui/jest.config.ts
@@ -9,6 +9,7 @@ export default {
     setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
     modulePathIgnorePatterns: ['<rootDir>/src/main/resources'],
     restoreMocks: true,
+    cacheDirectory: '<rootDir>/node_modules/.cache/jest',
     // Coverage
     collectCoverage: true,
     collectCoverageFrom: ['src/**/*.{js,jsx,ts,tsx}'],


### PR DESCRIPTION
**Issue number:** -

## Summary

### Changes

Previously, the cache directory defaulted to a temporary system path (e.g., `/private/var/folders/9f/6x2t200d1_x96f4nr5cb6m4c0000gp/T/jest_dy`). This cache was lost between runs as GitHub's ephemeral runners start fresh each time.

This PR moves the Jest cache location to `node_modules/.cache/jest`, which is included in GitHub's cache action. This change improves UI unit test execution speed by enabling cache preservation between workflow runs.

### User experience

No changes

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)
