### PR TITLE
ci: simplify GitHub workflow for caching Yarn deps

### DIFF
--- a/.github/actions/cached-ui-deps/action.yml
+++ b/.github/actions/cached-ui-deps/action.yml
@@ -8,21 +8,10 @@ inputs:
 runs:
   using: composite
   steps:
-    - run: npm install --global yarn
-      shell: bash
-    - name: Get yarn cache directory path
-      id: yarn-cache-dir-path
-      run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
-      shell: bash
-    - name: Cache Dependencies
-      uses: actions/cache@v4
-      id: yarn-cache
+    - uses: actions/setup-node@v4
       with:
-        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-        key: ${{ runner.os }}-yarn-${{ hashFiles('ui/yarn.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-yarn-${{ inputs.node-version }}
-
+        cache: 'yarn'
+        node-version: ${{ inputs.node-version }}
     - name: Install Dependencies
       working-directory: ui
       run: yarn install --frozen-lockfile

--- a/.github/actions/cached-ui-deps/action.yml
+++ b/.github/actions/cached-ui-deps/action.yml
@@ -11,6 +11,7 @@ runs:
     - uses: actions/setup-node@v4
       with:
         cache: 'yarn'
+        cache-dependency-path: 'ui/yarn.lock'
         node-version: ${{ inputs.node-version }}
     - name: Install Dependencies
       working-directory: ui

--- a/.github/workflows/build-ui.yml
+++ b/.github/workflows/build-ui.yml
@@ -15,9 +15,6 @@ jobs:
         shell: bash
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: ${{ inputs.node-version }}
       - name: install deps
         uses: ./.github/actions/cached-ui-deps
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,9 +21,6 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: 3.7
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "20"
       - name: install deps
         uses: ./.github/actions/cached-ui-deps
         with:

--- a/.github/workflows/storybook-visual.yml
+++ b/.github/workflows/storybook-visual.yml
@@ -20,9 +20,6 @@ jobs:
         with:
           lfs: true
           ref: ${{ github.event.pull_request.head.ref }}
-      - uses: actions/setup-node@v4
-        with:
-          node-version: ${{ inputs.node-version }}
       - name: install deps
         uses: ./.github/actions/cached-ui-deps
         with:


### PR DESCRIPTION
**Issue number:**

## Summary

### Changes

This PR updates the GitHub workflow for caching Yarn dependencies. The previous workflow involved manually installing Yarn, determining the cache directory, and using the actions/cache action to cache dependencies. The updated workflow simplifies this process by leveraging the actions/setup-node action with built-in Yarn caching support.

Reference: https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#caching-packages-data

### User experience

No changes

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)
