### PR TITLE
chore(renovate): ignore ubuntu updates for GitHub Actions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -89,6 +89,12 @@
       "matchManagers": ["npm"],
       "matchDepTypes": [ "engines" ],
       "enabled": false
+    },
+    {
+      "description": "Ignore updates for ubuntu in GitHub (ref #1374)",
+      "matchPackageNames": ["ubuntu"],
+      "matchManagers": ["github-actions"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
**Issue number:**

## Summary

Renovate should not update ubuntu versions, related to #1374

### Changes

Disable updates for ubuntu

### User experience

No changes

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented
* [ ] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)
