### PR TITLE
ci: parse node version from package.json

### DIFF
--- a/.github/actions/cached-ui-deps/action.yml
+++ b/.github/actions/cached-ui-deps/action.yml
@@ -1,9 +1,5 @@
 name: "Get & Cache Yarn Dependencies"
 description: "Get & Cache Yarn Dependencies"
-inputs:
-  node-version:
-    description: "Node version"
-    required: true
 
 runs:
   using: composite
@@ -12,7 +8,7 @@ runs:
       with:
         cache: 'yarn'
         cache-dependency-path: 'ui/yarn.lock'
-        node-version: ${{ inputs.node-version }}
+        node-version-file: 'ui/package.json'
     - name: Install Dependencies
       working-directory: ui
       run: yarn install --frozen-lockfile

--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -75,13 +75,7 @@ jobs:
 
   build-ui:
     name: Build UCC UI
-    strategy:
-      matrix:
-        node-version:
-          - "20"
     uses: ./.github/workflows/build-ui.yml
-    with:
-      node-version: ${{ matrix.node-version }}
 
   storybook-screenshots:
     name: Update storybook screenshots
@@ -89,8 +83,6 @@ jobs:
       contents: write
     secrets: inherit
     uses: ./.github/workflows/storybook-visual.yml
-    with:
-      node-version: "20"
   bot-updates:
     name: Generates Documentation
     permissions:

--- a/.github/workflows/build-ui.yml
+++ b/.github/workflows/build-ui.yml
@@ -1,10 +1,6 @@
 name: "Build UI"
 on:
   workflow_call:
-    inputs:
-      node-version:
-        required: true
-        type: string
 
 jobs:
   build-ui:
@@ -17,8 +13,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: install deps
         uses: ./.github/actions/cached-ui-deps
-        with:
-          node-version: ${{ inputs.node-version }}
       - name: Code linting
         run: yarn run lint
       - name: Unit test

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,8 +23,6 @@ jobs:
           python-version: 3.7
       - name: install deps
         uses: ./.github/actions/cached-ui-deps
-        with:
-          node-version: "20"
       - name: Build Storybook
         run: |
           cd ui

--- a/.github/workflows/storybook-visual.yml
+++ b/.github/workflows/storybook-visual.yml
@@ -1,10 +1,6 @@
 name: "Storybook Visual"
 on:
   workflow_call:
-    inputs:
-      node-version:
-        required: true
-        type: string
 
 jobs:
   update-screenshots:
@@ -22,8 +18,6 @@ jobs:
           ref: ${{ github.event.pull_request.head.ref }}
       - name: install deps
         uses: ./.github/actions/cached-ui-deps
-        with:
-          node-version: ${{ inputs.node-version }}
       - name: Install Playwright
         run: yarn playwright install
       - name: Build Storybook


### PR DESCRIPTION
**Issue number:**

## Summary

### Changes

Remove all hardcoded values from CI jobs and specify a path to package.json

<details><summary>Log</summary>
<p>

Resolved ui/package.json as >=20.10.0
Found in cache @ /opt/hostedtoolcache/node/20.18.0/x64
Environment details
  node: v20.18.0
  npm: 10.8.2
  yarn: 1.22.22

</p>
</details> 

### User experience

No changes

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)
