### PR TITLE
feat: require splunktaucclib 6.4.0 during the build phase

### DIFF
--- a/splunk_add_on_ucc_framework/install_python_libraries.py
+++ b/splunk_add_on_ucc_framework/install_python_libraries.py
@@ -28,7 +28,7 @@ from splunk_add_on_ucc_framework.global_config import OSDependentLibraryConfig
 logger = logging.getLogger("ucc_gen")
 
 
-LIBS_REQUIRED_FOR_UI = {"splunktaucclib": "6.4"}
+LIBS_REQUIRED_FOR_UI = {"splunktaucclib": "6.4.0"}
 
 
 class SplunktaucclibNotFound(Exception):

--- a/splunk_add_on_ucc_framework/install_python_libraries.py
+++ b/splunk_add_on_ucc_framework/install_python_libraries.py
@@ -28,6 +28,9 @@ from splunk_add_on_ucc_framework.global_config import OSDependentLibraryConfig
 logger = logging.getLogger("ucc_gen")
 
 
+LIBS_REQUIRED_FOR_UI = {"splunktaucclib": "6.4"}
+
+
 class SplunktaucclibNotFound(Exception):
     pass
 
@@ -118,25 +121,26 @@ def _pip_is_lib_installed(
 def _check_libraries_required_for_ui(
     python_binary_name: str, ucc_lib_target: str, path_to_requirements_file: str
 ) -> None:
-    if not _pip_is_lib_installed(
-        installer=python_binary_name,
-        target=ucc_lib_target,
-        libname="splunktaucclib",
-    ):
-        raise SplunktaucclibNotFound(
-            f"This add-on has an UI, so the splunktaucclib is required but not found in "
-            f"{path_to_requirements_file}. Please add it there and make sure it is at least version 6.4."
-        )
-    if not _pip_is_lib_installed(
-        installer=python_binary_name,
-        target=ucc_lib_target,
-        libname="splunktaucclib",
-        version="6.4",
-        allow_higher_version=True,
-    ):
-        raise WrongSplunktaucclibVersion(
-            "Splunktaucclib found but has the wrong version. Please make sure it is at least version 6.4."
-        )
+    for lib, version in LIBS_REQUIRED_FOR_UI.items():
+        if not _pip_is_lib_installed(
+            installer=python_binary_name,
+            target=ucc_lib_target,
+            libname=lib,
+        ):
+            raise SplunktaucclibNotFound(
+                f"This add-on has an UI, so the {lib} is required but not found in "
+                f"{path_to_requirements_file}. Please add it there and make sure it is at least version {version}."
+            )
+        if not _pip_is_lib_installed(
+            installer=python_binary_name,
+            target=ucc_lib_target,
+            libname=lib,
+            version=version,
+            allow_higher_version=True,
+        ):
+            raise WrongSplunktaucclibVersion(
+                f"{lib} found but has the wrong version. Please make sure it is at least version {version}."
+            )
 
 
 def install_python_libraries(

--- a/splunk_add_on_ucc_framework/install_python_libraries.py
+++ b/splunk_add_on_ucc_framework/install_python_libraries.py
@@ -115,6 +115,30 @@ def _pip_is_lib_installed(
         raise CouldNotInstallRequirements from e
 
 
+def _check_libraries_required_for_ui(
+    python_binary_name: str, ucc_lib_target: str, path_to_requirements_file: str
+) -> None:
+    if not _pip_is_lib_installed(
+        installer=python_binary_name,
+        target=ucc_lib_target,
+        libname="splunktaucclib",
+    ):
+        raise SplunktaucclibNotFound(
+            f"This add-on has an UI, so the splunktaucclib is required but not found in "
+            f"{path_to_requirements_file}. Please add it there and make sure it is at least version 6.4."
+        )
+    if not _pip_is_lib_installed(
+        installer=python_binary_name,
+        target=ucc_lib_target,
+        libname="splunktaucclib",
+        version="6.4",
+        allow_higher_version=True,
+    ):
+        raise WrongSplunktaucclibVersion(
+            "Splunktaucclib found but has the wrong version. Please make sure it is at least version 6.4."
+        )
+
+
 def install_python_libraries(
     source_path: str,
     ucc_lib_target: str,
@@ -136,14 +160,9 @@ def install_python_libraries(
             pip_version=pip_version,
             pip_legacy_resolver=pip_legacy_resolver,
         )
-        if includes_ui and not _pip_is_lib_installed(
-            installer=python_binary_name,
-            target=ucc_lib_target,
-            libname="splunktaucclib",
-        ):
-            raise SplunktaucclibNotFound(
-                f"splunktaucclib is not found in {path_to_requirements_file}. "
-                f"Please add it there because this add-on has UI."
+        if includes_ui:
+            _check_libraries_required_for_ui(
+                python_binary_name, ucc_lib_target, path_to_requirements_file
             )
 
         cleanup_libraries = install_os_dependent_libraries(

--- a/tests/unit/test_install_python_libraries.py
+++ b/tests/unit/test_install_python_libraries.py
@@ -15,6 +15,7 @@ from splunk_add_on_ucc_framework.install_python_libraries import (
     remove_execute_bit,
     remove_packages,
     validate_conflicting_paths,
+    WrongSplunktaucclibVersion,
     InvalidArguments,
     _pip_is_lib_installed,
 )
@@ -151,11 +152,30 @@ def test_install_libraries_when_no_splunktaucclib_is_present_but_has_ui(tmp_path
     tmp_lib_reqs_file.write_text("solnlib\nsplunk-sdk\n")
 
     expected_msg = (
-        f"splunktaucclib is not found in {tmp_lib_reqs_file}. "
-        f"Please add it there because this add-on has UI."
+        f"This add-on has an UI, so the splunktaucclib is required but not found in {tmp_lib_reqs_file}. "
+        f"Please add it there and make sure it is at least version 6.4."
     )
 
     with pytest.raises(SplunktaucclibNotFound) as exc:
+        install_python_libraries(
+            str(tmp_path),
+            str(tmp_ucc_lib_target),
+            python_binary_name="python3",
+            includes_ui=True,
+        )
+    assert expected_msg in str(exc.value)
+
+
+def test_install_libraries_when_wrong_splunktaucclib_is_present_but_has_ui(tmp_path):
+    tmp_ucc_lib_target = tmp_path / "ucc-lib-target"
+    tmp_lib_path = tmp_path / "lib"
+    tmp_lib_path.mkdir()
+    tmp_lib_reqs_file = tmp_lib_path / "requirements.txt"
+    tmp_lib_reqs_file.write_text("splunktaucclib==6.3\n")
+
+    expected_msg = "Splunktaucclib found but has the wrong version. Please make sure it is at least version 6.4."
+
+    with pytest.raises(WrongSplunktaucclibVersion) as exc:
         install_python_libraries(
             str(tmp_path),
             str(tmp_ucc_lib_target),

--- a/tests/unit/test_install_python_libraries.py
+++ b/tests/unit/test_install_python_libraries.py
@@ -18,7 +18,6 @@ from splunk_add_on_ucc_framework.install_python_libraries import (
     WrongSplunktaucclibVersion,
     InvalidArguments,
     _pip_is_lib_installed,
-    LIBS_REQUIRED_FOR_UI,
 )
 
 from splunk_add_on_ucc_framework import global_config as gc
@@ -152,12 +151,9 @@ def test_install_libraries_when_no_splunktaucclib_is_present_but_has_ui(tmp_path
     tmp_lib_reqs_file = tmp_lib_path / "requirements.txt"
     tmp_lib_reqs_file.write_text("solnlib\nsplunk-sdk\n")
 
-    lib = list(LIBS_REQUIRED_FOR_UI)[0]
-    ver = LIBS_REQUIRED_FOR_UI[lib]
-
     expected_msg = (
-        f"This add-on has an UI, so the {lib} is required but not found in {tmp_lib_reqs_file}. "
-        f"Please add it there and make sure it is at least version {ver}."
+        f"This add-on has an UI, so the splunktaucclib is required but not found in {tmp_lib_reqs_file}. "
+        f"Please add it there and make sure it is at least version 6.4.0."
     )
 
     with pytest.raises(SplunktaucclibNotFound) as exc:
@@ -177,9 +173,7 @@ def test_install_libraries_when_wrong_splunktaucclib_is_present_but_has_ui(tmp_p
     tmp_lib_reqs_file = tmp_lib_path / "requirements.txt"
     tmp_lib_reqs_file.write_text("splunktaucclib==6.3\n")
 
-    lib = list(LIBS_REQUIRED_FOR_UI)[0]
-    ver = LIBS_REQUIRED_FOR_UI[lib]
-    expected_msg = f"{lib} found but has the wrong version. Please make sure it is at least version {ver}."
+    expected_msg = "splunktaucclib found but has the wrong version. Please make sure it is at least version 6.4.0."
 
     with pytest.raises(WrongSplunktaucclibVersion) as exc:
         install_python_libraries(

--- a/tests/unit/test_install_python_libraries.py
+++ b/tests/unit/test_install_python_libraries.py
@@ -18,6 +18,7 @@ from splunk_add_on_ucc_framework.install_python_libraries import (
     WrongSplunktaucclibVersion,
     InvalidArguments,
     _pip_is_lib_installed,
+    LIBS_REQUIRED_FOR_UI,
 )
 
 from splunk_add_on_ucc_framework import global_config as gc
@@ -151,9 +152,12 @@ def test_install_libraries_when_no_splunktaucclib_is_present_but_has_ui(tmp_path
     tmp_lib_reqs_file = tmp_lib_path / "requirements.txt"
     tmp_lib_reqs_file.write_text("solnlib\nsplunk-sdk\n")
 
+    lib = list(LIBS_REQUIRED_FOR_UI)[0]
+    ver = LIBS_REQUIRED_FOR_UI[lib]
+
     expected_msg = (
-        f"This add-on has an UI, so the splunktaucclib is required but not found in {tmp_lib_reqs_file}. "
-        f"Please add it there and make sure it is at least version 6.4."
+        f"This add-on has an UI, so the {lib} is required but not found in {tmp_lib_reqs_file}. "
+        f"Please add it there and make sure it is at least version {ver}."
     )
 
     with pytest.raises(SplunktaucclibNotFound) as exc:
@@ -173,7 +177,9 @@ def test_install_libraries_when_wrong_splunktaucclib_is_present_but_has_ui(tmp_p
     tmp_lib_reqs_file = tmp_lib_path / "requirements.txt"
     tmp_lib_reqs_file.write_text("splunktaucclib==6.3\n")
 
-    expected_msg = "Splunktaucclib found but has the wrong version. Please make sure it is at least version 6.4."
+    lib = list(LIBS_REQUIRED_FOR_UI)[0]
+    ver = LIBS_REQUIRED_FOR_UI[lib]
+    expected_msg = f"{lib} found but has the wrong version. Please make sure it is at least version {ver}."
 
     with pytest.raises(WrongSplunktaucclibVersion) as exc:
         install_python_libraries(


### PR DESCRIPTION
**Issue number:[ADDON-74237](https://splunk.atlassian.net/browse/ADDON-74237)**

## Summary

Added splunktaucclib version checking.

### Changes

* new method _check_libraries_required_for_ui was added to check if splunktaucclib is installed and has proper version

### User experience

The build process will be canceled if an incorrect version of the splunktaucclib library is used.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)
