### PR TITLE
chore: single select with default empty string value

### DIFF
--- a/ui/src/components/ControlWrapper/ControlWrapper.tsx
+++ b/ui/src/components/ControlWrapper/ControlWrapper.tsx
@@ -72,7 +72,6 @@ class ControlWrapper extends React.PureComponent<ControlWrapperProps> {
         const { text, link, color, markdownType, token, linkText } =
             this.props.markdownMessage || {};
         let rowView;
-        // console.log('render custom component', this.props);
 
         if (this.props?.entity?.type === 'custom') {
             const data = {

--- a/ui/src/components/SingleInputComponent/SingleInputComponent.tsx
+++ b/ui/src/components/SingleInputComponent/SingleInputComponent.tsx
@@ -174,11 +174,15 @@ function SingleInputComponent(props: SingleInputComponentProps) {
     // hideClearBtn=true only passed for OAuth else its undefined
     // effectiveIsClearable button will be visible only for the required=false and createSearchChoice=false single-select fields.
     const effectiveIsClearable = !(effectiveDisabled || restProps.required || hideClearBtn);
-
     return createSearchChoice ? (
         <StyledDiv className="dropdownBox">
             <ComboBox
-                value={props.value}
+                value={
+                    // if value is empty use empty string as ComboBox accepts only string
+                    props.value === null || typeof props.value === 'undefined'
+                        ? ''
+                        : props.value.toString()
+                }
                 name={field}
                 error={error}
                 disabled={effectiveDisabled}
@@ -195,7 +199,10 @@ function SingleInputComponent(props: SingleInputComponentProps) {
                 inputId={props.id}
                 className="dropdownBox"
                 data-test-loading={loading}
-                value={props.value}
+                value={
+                    // if value is empty use empty string as Select accepts only string
+                    props.value === null || typeof props.value === 'undefined' ? '' : props.value
+                }
                 name={field}
                 error={error}
                 disabled={effectiveDisabled}


### PR DESCRIPTION
**Issue number:**

## Summary

### Changes

> Use empty string when single select does not have value.

### User experience

> No changes. It removes error from console.

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)
