### PR TITLE
chore(webpack): ignore ResizeObserver error

### DIFF
--- a/ui/webpack.config.js
+++ b/ui/webpack.config.js
@@ -51,6 +51,20 @@ module.exports = merge(baseConfig, {
     },
     devServer: {
         hot: false,
+        client: {
+            overlay: {
+                runtimeErrors: (error) => {
+                    // No idea how to fix it
+                    if (
+                        error?.message ===
+                        'ResizeObserver loop completed with undelivered notifications.'
+                    ) {
+                        return false;
+                    }
+                    return true;
+                },
+            },
+        },
         proxy: [
             {
                 target: proxyTargetUrl,


### PR DESCRIPTION
**Issue number:** -

## Summary

### Changes

Ignore pop up of webpack overlay for the issue related to ResizeObserver  that happens on the dashboard page.
<img width="1593" alt="image" src="https://github.com/user-attachments/assets/16402ece-4399-483d-81f2-95ddd416fdc0">


### User experience

No changes

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [ ] I have performed a self-review of this change
* [ ] Changes have been tested
* [ ] Changes are documented
* [ ] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)
