### PR TITLE
chore(renovate): disable react-router-dom updates and types/node

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -85,15 +85,22 @@
     },
     {
       "description": "Ignore NodeJS",
-      "matchPackageNames": ["node"],
+      "matchPackageNames": ["node", "@types/node"],
       "matchManagers": ["npm"],
-      "matchDepTypes": [ "engines" ],
+      "matchDepTypes": [ "engines", "devDependencies" ],
       "enabled": false
     },
     {
       "description": "Ignore updates for ubuntu in GitHub (ref #1374)",
       "matchPackageNames": ["ubuntu"],
       "matchManagers": ["github-actions"],
+      "enabled": false
+    },
+    {
+      "description": "react-router-dom throws not-dismissible warnings",
+      "matchPackageNames": ["react-router-dom"],
+      "matchManagers": ["npm"],
+      "matchUpdateTypes": ["minor"],
       "enabled": false
     }
   ]


### PR DESCRIPTION
**Issue number:**

## Summary

### Changes

Ignore updating `react-router-dom` (https://github.com/remix-run/react-router/issues/12250) and `@types/node` 

### User experience

No changes

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have performed a self-review of this change
* [] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)
