### PR TITLE
chore(pyproject): explicitly specify supported Python versions

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -135,6 +135,7 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
+          - "3.12"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -168,6 +169,7 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
+          - "3.12"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4

--- a/poetry.lock
+++ b/poetry.lock
@@ -1767,5 +1767,5 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.7"
-content-hash = "8a01c2a730b73b14bfd3a826d7a5926a82e36d28675e7d74494bb65d25ad73c2"
+python-versions = ">=3.7,<3.13"
+content-hash = "f0072f7b472f7556af341f351358bed09701afd1b0b014e296a4c5fec118c4c6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,14 +32,20 @@ classifiers = [
     "Intended Audience :: Developers",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Topic :: Software Development :: Code Generators",
-    "License :: OSI Approved :: Apache Software License"
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
 ]
 
 [tool.poetry.urls]
 "Bug Tracker" = "https://github.com/splunk/addonfactory-ucc-generator/issues"
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = ">=3.7,<3.13"
 jinja2 = ">=2,<4"
 addonfactory-splunk-conf-parser-lib = "^0.4.3"
 dunamai = "^1.22.0"


### PR DESCRIPTION
**Issue number:** N/A

## Summary

### Changes

Adding an explicit support for Python 3.12.

(I tested Python 3.13 but it does not work yet because of `lxml` does not support 3.13 yet).

### User experience

N/A

## Checklist

If your change doesn't seem to apply, please leave them unchecked.

* [x] I have performed a self-review of this change
* [x] Changes have been tested
* [ ] Changes are documented
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0/)
