### PR TITLE
Revert "ci: add expected failure for appinspect-api check"

### DIFF
--- a/tests/testdata/expected_addons/expected_output_global_config_everything/.appinspect_api.expect.yaml
+++ b/tests/testdata/expected_addons/expected_output_global_config_everything/.appinspect_api.expect.yaml
@@ -1,4 +1,2 @@
 check_for_compiled_python:
   comment: 'Expected failure as compiled python file was detected in your build.'
-check_for_search_v1_endpoint:
-  comment: 'The error is generated from splunklib, hence will be fixed once fixed in the library'


### PR DESCRIPTION
Reverts splunk/addonfactory-ucc-generator#1427

It is not expected anymore, causing ci failures
https://github.com/splunk/addonfactory-ucc-generator/actions/runs/11820162390/job/32932305072