### PR TITLE
fix(select): fetching options when some dependency is null

### DIFF
--- a/ui/src/components/SingleInputComponent/SingleInputComponent.test.tsx
+++ b/ui/src/components/SingleInputComponent/SingleInputComponent.test.tsx
@@ -49,8 +49,8 @@ const renderFeature = (additionalProps?: Partial<SingleInputComponentProps>) => 
 const mockedEntries = [
     { name: 'dataApiTest1', content: { testLabel: 'firstLabel', testValue: 'firstValue' } },
     { name: 'dataApiTest2', content: { testLabel: 'secondLabel', testValue: 'secondValue' } },
-    { name: 'dataApiTest3', content: { testLabel: 'thirdLabel', testValue: 'thirdValue' } },
-    { name: 'dataApiTest4', content: { testLabel: 'fourthLabel', testValue: 'fourthValue' } },
+    { name: 'true', content: { testLabel: 'thirdLabel', testValue: 'thirdValue' } },
+    { name: '0', content: { testLabel: 'fourthLabel', testValue: 'fourthValue' } },
 ];
 
 const MOCK_API_URL = '/demo_addon_for_splunk/some_API_endpint_for_select_data';
@@ -199,25 +199,35 @@ it('should fetch options from API when endpointUrl is provided', async () => {
     await screen.findByRole('menuitem', { name: 'No matches' });
 
     // undefined value must be omitted
+    const firstEntry = mockedEntries[0];
     rerender(
         <SingleInputComponent
             {...baseProps}
-            dependencyValues={{ name: 'dataApiTest1', region: undefined }}
+            dependencyValues={{ name: firstEntry.name, region: undefined }}
         />
     );
     await userEvent.click(screen.getByRole('combobox'));
-    await screen.findByRole('option', { name: 'firstLabel' });
+    await screen.findByRole('option', { name: firstEntry.content.testLabel });
 
-    rerender(<SingleInputComponent {...baseProps} dependencyValues={{ name: 'dataApiTest2' }} />);
-    await userEvent.click(screen.getByRole('combobox'));
-    await screen.findByRole('option', { name: 'secondLabel' });
-
+    const secondEntry = mockedEntries[1];
     rerender(
         <SingleInputComponent
             {...baseProps}
-            dependencyValues={{ name: undefined, region: undefined }}
+            dependencyValues={{ name: secondEntry.name, region: 1 }}
         />
     );
     await userEvent.click(screen.getByRole('combobox'));
-    await screen.findByRole('menuitem', { name: 'No matches' });
+    await screen.findByRole('option', { name: secondEntry.content.testLabel });
+
+    const thirdEntry = mockedEntries[2];
+    rerender(
+        <SingleInputComponent {...baseProps} dependencyValues={{ name: true, region: false }} />
+    );
+    await userEvent.click(screen.getByRole('combobox'));
+    await screen.findByRole('option', { name: thirdEntry.content.testLabel });
+
+    const fourthEntry = mockedEntries[3];
+    rerender(<SingleInputComponent {...baseProps} dependencyValues={{ name: 0, region: 0 }} />);
+    await userEvent.click(screen.getByRole('combobox'));
+    await screen.findByRole('option', { name: fourthEntry.content.testLabel });
 });

--- a/ui/src/components/SingleInputComponent/SingleInputComponent.test.tsx
+++ b/ui/src/components/SingleInputComponent/SingleInputComponent.test.tsx
@@ -185,12 +185,9 @@ it('should fetch options from API when endpointUrl is provided', async () => {
     const baseProps = {
         ...defaultInputProps,
         value: '',
-        dependencyValues: {
-            account: undefined,
-        },
         controlOptions: {
             createSearchChoice: true,
-            dependencies: ['account', 'region'],
+            dependencies: ['name', 'region'],
             endpointUrl: MOCK_API_URL,
             labelField: 'testLabel',
             valueField: 'testValue',

--- a/ui/src/util/api.ts
+++ b/ui/src/util/api.ts
@@ -5,9 +5,11 @@ import { generateToast, getUnifiedConfigs } from './util';
 import { parseErrorMsg } from './messageUtil';
 import { ResponseError } from './ResponseError';
 
+type ParamsRecord = Record<string, string | number>;
+
 export interface RequestParams {
     endpointUrl: string;
-    params?: Record<string, string | number>;
+    params?: ParamsRecord;
     signal?: AbortSignal;
     body?: BodyInit;
     handleError: boolean;
@@ -21,14 +23,14 @@ export function generateEndPointUrl(name: string) {
 
 const DEFAULT_PARAMS = { output_mode: 'json' };
 
-function createUrl(endpointUrl: string, params: Record<string, string | number>): URL {
+function createUrl(endpointUrl: string, params: ParamsRecord): URL {
     const url = new URL(
         createRESTURL(endpointUrl, { app, owner: 'nobody' }),
         window.location.origin
     );
-    Object.entries({ ...DEFAULT_PARAMS, ...params }).forEach(([key, value]) =>
-        url.searchParams.append(key, value.toString())
-    );
+    Object.entries({ ...DEFAULT_PARAMS, ...params })
+        .filter(([, value]) => value !== undefined && value !== null)
+        .forEach(([key, value]) => url.searchParams.append(key, value.toString()));
     return url;
 }
 

--- a/ui/src/util/api.ts
+++ b/ui/src/util/api.ts
@@ -5,7 +5,7 @@ import { generateToast, getUnifiedConfigs } from './util';
 import { parseErrorMsg } from './messageUtil';
 import { ResponseError } from './ResponseError';
 
-type ParamsRecord = Record<string, string | number>;
+type ParamsRecord = Record<string, string | number | undefined>;
 
 export interface RequestParams {
     endpointUrl: string;


### PR DESCRIPTION
**Issue number:** ADDON-76586

### PR Type

**What kind of change does this PR introduce?**
* [ ] Feature
* [x] Bug Fix
* [ ] Refactoring (no functional or API changes)
* [ ] Documentation Update
* [ ] Maintenance (dependency updates, CI, etc.)

## Summary

## Root cause

Regression from #1424. There was a Null Pointer Exception due to `undefined` values of `dependencyValues` and calling `.toString()` on `undefined`. NPE itself is not a problem since it is silenced, but the request is not made due to this and "No manches" is shown

### Changes

- Filter out null and undefined values (as `axios` does)
- Add tests covering this bug

### User experience

Ability to see options fetching from the server

## Checklist

If an item doesn't apply to your changes, leave it unchecked.

* [x] I have performed a self-review of this change according to the [development guidelines](https://splunk.github.io/addonfactory-ucc-generator/contributing/#development-guidelines)
* [x] Tests have been added/modified to cover the changes [(testing doc)](https://splunk.github.io/addonfactory-ucc-generator/contributing/#build-and-test)
* [ ] Changes are documented
* [x] PR title and description follows the [contributing principles](https://splunk.github.io/addonfactory-ucc-generator/contributing/#pull-requests)
