### PR TITLE
feat: do not create __pycache__ in lib dir

### DIFF
--- a/splunk_add_on_ucc_framework/install_python_libraries.py
+++ b/splunk_add_on_ucc_framework/install_python_libraries.py
@@ -105,6 +105,10 @@ def _pip_is_lib_installed(
     try:
         my_env = os.environ.copy()
         my_env["PYTHONPATH"] = target
+
+        # Disable writing of .pyc files (__pycache__)
+        my_env["PYTHONDONTWRITEBYTECODE"] = "1"
+
         if allow_higher_version:
             result = _subprocess_run(command=cmd, env=my_env)
             if result.returncode != 0:

--- a/tests/smoke/test_ucc_build.py
+++ b/tests/smoke/test_ucc_build.py
@@ -189,6 +189,7 @@ def test_ucc_generate_with_everything(caplog):
             ("appserver", "static", "alerticon.png"),
             ("bin", "splunk_ta_uccexample", "modalert_test_alert_helper.py"),
             ("appserver", "static", "js", "build", "entry_page.js.map"),
+            ("lib", "__pycache__"),
         ]
         for af in files_should_be_absent:
             actual_file_path = path.join(actual_folder, *af)


### PR DESCRIPTION
**Issue number:** [ADDON-76503](https://splunk.atlassian.net/browse/ADDON-76503)

### PR Type

**What kind of change does this PR introduce?**
* [x] Feature
* [ ] Bug Fix
* [ ] Refactoring (no functional or API changes)
* [ ] Documentation Update
* [ ] Maintenance (dependency updates, CI, etc.)

## Summary

### Changes

Compiled Python files are created when UCC checks using pip whether a library is installed.

This prevents it from doing that.

### User experience

Output directory with lib dir that does not contain `__pycache__`.

## Checklist

If an item doesn't apply to your changes, leave it unchecked.

* [x] I have performed a self-review of this change according to the [development guidelines](https://splunk.github.io/addonfactory-ucc-generator/contributing/#development-guidelines)
* [x] Tests have been added/modified to cover the changes [(testing doc)](https://splunk.github.io/addonfactory-ucc-generator/contributing/#build-and-test)
* [ ] Changes are documented
* [x] PR title and description follows the [contributing principles](https://splunk.github.io/addonfactory-ucc-generator/contributing/#pull-requests)
