### PR TITLE
fix(api): cancelled requests don't emit user facing errors

### DIFF
--- a/ui/src/components/MultiInputComponent/MultiInputComponent.tsx
+++ b/ui/src/components/MultiInputComponent/MultiInputComponent.tsx
@@ -78,7 +78,7 @@ function MultiInputComponent(props: MultiInputComponentProps) {
             return;
         }
 
-        let current = true;
+        let mounted = true;
         const abortController = new AbortController();
 
         const url = referenceName
@@ -102,7 +102,7 @@ function MultiInputComponent(props: MultiInputComponentProps) {
             setLoading(true);
             getRequest<{ entry: FilterResponseParams }>(apiCallOptions)
                 .then((data) => {
-                    if (current) {
+                    if (mounted) {
                         setOptions(
                             generateOptions(
                                 filterResponse(
@@ -117,15 +117,15 @@ function MultiInputComponent(props: MultiInputComponentProps) {
                     }
                 })
                 .finally(() => {
-                    if (current) {
+                    if (mounted) {
                         setLoading(false);
                     }
                 });
         }
         // eslint-disable-next-line consistent-return
         return () => {
-            abortController.abort('Operation canceled.');
-            current = false;
+            mounted = false;
+            abortController.abort();
         };
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [dependencyValues]);

--- a/ui/src/components/SingleInputComponent/SingleInputComponent.tsx
+++ b/ui/src/components/SingleInputComponent/SingleInputComponent.tsx
@@ -128,7 +128,7 @@ function SingleInputComponent(props: SingleInputComponentProps) {
             return;
         }
 
-        let current = true;
+        let mounted = true;
         const abortController = new AbortController();
 
         const backendCallOptions = {
@@ -145,7 +145,7 @@ function SingleInputComponent(props: SingleInputComponentProps) {
         setLoading(true);
         getRequest<{ entry: FilterResponseParams }>(backendCallOptions)
             .then((data) => {
-                if (current) {
+                if (mounted) {
                     setOptions(
                         generateOptions(
                             filterResponse(data.entry, labelField, valueField, allowList, denyList)
@@ -155,16 +155,16 @@ function SingleInputComponent(props: SingleInputComponentProps) {
                 }
             })
             .catch(() => {
-                if (current) {
+                if (mounted) {
                     setLoading(false);
+                    setOptions([]);
                 }
-                setOptions([]);
             });
 
         // eslint-disable-next-line consistent-return
         return () => {
-            abortController.abort('Operation canceled.');
-            current = false;
+            mounted = false;
+            abortController.abort();
         };
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [dependencyValues]);

--- a/ui/src/util/api.ts
+++ b/ui/src/util/api.ts
@@ -58,7 +58,8 @@ async function fetchWithErrorHandling<TData>(
         }
         return await response.json();
     } catch (error) {
-        if (handleError) {
+        const isAborted = error instanceof DOMException && error.name === 'AbortError';
+        if (handleError && !isAborted) {
             const errorMsg = parseErrorMsg(error);
             generateToast(errorMsg, 'error');
             if (callbackOnError) {


### PR DESCRIPTION
**Issue number:** [ADDON-76739](https://splunk.atlassian.net/browse/ADDON-76739)

### PR Type

**What kind of change does this PR introduce?**
* [ ] Feature
* [x] Bug Fix
* [ ] Refactoring (no functional or API changes)
* [ ] Documentation Update
* [ ] Maintenance (dependency updates, CI, etc.)

## Summary

### Changes

In the error handler, the check is added if the promise rejected because the request was cancelled

### User experience

Users would not see error messages every time the request is cancelled

## Checklist

If an item doesn't apply to your changes, leave it unchecked.

* [x] I have performed a self-review of this change according to the [development guidelines](https://splunk.github.io/addonfactory-ucc-generator/contributing/#development-guidelines)
* [ ] Tests have been added/modified to cover the changes [(testing doc)](https://splunk.github.io/addonfactory-ucc-generator/contributing/#build-and-test)

Partially. The changes in api.ts are covered, but I don't know how to reproduce memory leak caused by changing state after it was unmounted


* [ ] Changes are documented
* [x] PR title and description follows the [contributing principles](https://splunk.github.io/addonfactory-ucc-generator/contributing/#pull-requests)
