### PR TITLE
fix: allow packaging from 23.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1782,4 +1782,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.7,<3.13"
-content-hash = "1d370a95e06234e554f7459f274deb9f98a7df6e6a6f17cc8df998ea80530a80"
+content-hash = "ec35c6372a95df5d2d6e94ae22b949438cbcddfb05737c643c6990a79a32e140"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ jsonschema = "^4.4.0"
 PyYAML = "^6.0"
 defusedxml = "^0.7.1"
 colorama = "^0.4.6"
-packaging = "24.0"
+packaging = ">=23.0"
 
 [tool.poetry.group.dev.dependencies]
 mkdocs = "^1.4.2"


### PR DESCRIPTION
**Issue number:** N/A

### PR Type

**What kind of change does this PR introduce?**
* [ ] Feature
* [x] Bug Fix
* [ ] Refactoring (no functional or API changes)
* [ ] Documentation Update
* [ ] Maintenance (dependency updates, CI, etc.)

## Summary

### Changes

Allow `packaging` from a version "23.0".

To reproduce the issue run

```bash
pip install splunk-add-on-ucc-framework==5.53.1
pip install splunk-appinspect==3.8.1
```

You should see

```
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
splunk-add-on-ucc-framework 5.53.1 requires packaging==24.0, but you have packaging 23.0 which is incompatible.
```

in your console.

### User experience

Developers can install latest version of both UCC and Splunk AppInspect CLI in the same virtual environment.

## Checklist

If an item doesn't apply to your changes, leave it unchecked.

* [x] I have performed a self-review of this change according to the [development guidelines](https://splunk.github.io/addonfactory-ucc-generator/contributing/#development-guidelines)
* [ ] Tests have been added/modified to cover the changes [(testing doc)](https://splunk.github.io/addonfactory-ucc-generator/contributing/#build-and-test)
* [ ] Changes are documented
* [x] PR title and description follows the [contributing principles](https://splunk.github.io/addonfactory-ucc-generator/contributing/#pull-requests)
