### PR TITLE
chore(renovate): ignore python update

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -36,6 +36,12 @@
       "enabled": false
     },
     {
+      "description": "Ignore Python version updates",
+      "matchManagers": ["poetry"],
+      "matchPackageNames": ["python"],
+      "enabled": false
+    },
+    {
       "matchPackageNames": ["urllib3"],
       "allowedVersions": "<2.0.0"
     },


### PR DESCRIPTION
**Issue number:** - 

### PR Type

**What kind of change does this PR introduce?**
* [ ] Feature
* [ ] Bug Fix
* [ ] Refactoring (no functional or API changes)
* [ ] Documentation Update
* [x] Maintenance (dependency updates, CI, etc.)

## Summary

### Changes

Set renovate to ignore bumping python version (like in #1478). Specifically, this change
```toml
[tool.poetry.dependencies]
python = ">=3.13,<3.14"
```

### User experience

No changes

## Checklist

If an item doesn't apply to your changes, leave it unchecked.

* [x] I have performed a self-review of this change according to the [development guidelines](https://splunk.github.io/addonfactory-ucc-generator/contributing/#development-guidelines)
* [ ] Tests have been added/modified to cover the changes [(testing doc)](https://splunk.github.io/addonfactory-ucc-generator/contributing/#build-and-test)
* [ ] Changes are documented
* [x] PR title and description follows the [contributing principles](https://splunk.github.io/addonfactory-ucc-generator/contributing/#pull-requests)
