### PR TITLE
chore(renovate): ignore mkdocs update

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -24,7 +24,7 @@
       "matchManagers": [
         "poetry"
       ],
-      "matchPackagePrefixes": [
+      "matchPackageNames": [
         "importlib-metadata",
         "pytest",
         "pytest-cov",
@@ -39,6 +39,17 @@
       "description": "Ignore Python version updates",
       "matchManagers": ["poetry"],
       "matchPackageNames": ["python"],
+      "enabled": false
+    },
+    {
+      "description": "Ignore mkdocs and its plugins that drop Python 3.7 support",
+      "matchPackageNames": [
+        "/^mkdocs"
+      ],
+      "matchUpdateTypes": [
+        "major",
+        "minor"
+      ],
       "enabled": false
     },
     {


### PR DESCRIPTION
**Issue number:**

### PR Type

**What kind of change does this PR introduce?**
* [ ] Feature
* [ ] Bug Fix
* [ ] Refactoring (no functional or API changes)
* [ ] Documentation Update
* [x] Maintenance (dependency updates, CI, etc.)

## Summary

### Changes

Ask renovate to ignore all mkdocs* packages from bumping minor and major versions.

### User experience

Please describe the user experience before and after this change. Screenshots are welcome for additional context.

## Checklist

If an item doesn't apply to your changes, leave it unchecked.

* [x] I have performed a self-review of this change according to the [development guidelines](https://splunk.github.io/addonfactory-ucc-generator/contributing/#development-guidelines)
* [ ] Tests have been added/modified to cover the changes [(testing doc)](https://splunk.github.io/addonfactory-ucc-generator/contributing/#build-and-test)
* [ ] Changes are documented
* [x] PR title and description follows the [contributing principles](https://splunk.github.io/addonfactory-ucc-generator/contributing/#pull-requests)
