### PR TITLE
fix: required star visibility when using modify prop

### DIFF
--- a/ui/src/components/ControlWrapper/ControlWrapper.tsx
+++ b/ui/src/components/ControlWrapper/ControlWrapper.tsx
@@ -26,7 +26,7 @@ const ControlGroupWrapper = styled(ControlGroup).attrs((props: { dataName: strin
     }
 `;
 
-interface ControlWrapperProps {
+export interface ControlWrapperProps {
     mode: Mode;
     utilityFuncts: UtilControlWrapper;
     value: AcceptableFormValueOrNullish;

--- a/ui/src/components/ControlWrapper/ControlWrapper.tsx
+++ b/ui/src/components/ControlWrapper/ControlWrapper.tsx
@@ -128,12 +128,17 @@ class ControlWrapper extends React.PureComponent<ControlWrapperProps> {
             </>
         );
 
-        const isFieldRequired = // modifiedEntitiesData takes precedence over entity
-            this.props?.modifiedEntitiesData?.required || this.props.entity?.required === undefined
-                ? 'oauth_field' in (this.props.entity || {}) // if required is undefined use true for oauth fields and false for others
-                : this.props.entity?.required; // if required present use required
-        const label = this.props?.modifiedEntitiesData?.label || this?.props?.entity?.label || '';
+        const isRequiredModified =
+            typeof this.props?.modifiedEntitiesData?.required === 'boolean'
+                ? this.props?.modifiedEntitiesData?.required
+                : this.props.entity?.required;
 
+        const isFieldRequired =
+            isRequiredModified === undefined // // if oauth_field exists field required by default
+                ? 'oauth_field' in (this.props.entity || {}) // if oauth_field does not exists not required by default
+                : isRequiredModified;
+
+        const label = this.props?.modifiedEntitiesData?.label || this?.props?.entity?.label || '';
         return (
             this.props.display && (
                 <ControlGroupWrapper

--- a/ui/src/components/ControlWrapper/stories/ControlWrapper.stories.ts
+++ b/ui/src/components/ControlWrapper/stories/ControlWrapper.stories.ts
@@ -49,3 +49,69 @@ export const Base: Story = {
         fileNameToDisplay: 'Previous File',
     },
 };
+
+export const WithModifications: Story = {
+    args: {
+        utilityFuncts: {
+            utilCustomFunctions: {
+                setState: () => {},
+                setErrorFieldMsg: () => {},
+                clearAllErrorMsg: () => {},
+                setErrorMsg: () => {},
+            },
+            handleChange: () => {},
+            addCustomValidator: () => {},
+        },
+        value: '',
+        display: true,
+        error: false,
+        entity: {
+            field: 'url',
+            label: 'URL',
+            type: 'text',
+            help: 'Enter the URL, for example',
+            required: true,
+            encrypted: false,
+        },
+        serviceName: 'settings',
+        mode: 'config',
+        disabled: false,
+        dependencyValues: null,
+        modifiedEntitiesData: { required: false, label: 'Modified URL', help: 'Modified help' },
+    },
+};
+
+export const WithModificationsMakeRequired: Story = {
+    args: {
+        utilityFuncts: {
+            utilCustomFunctions: {
+                setState: () => {},
+                setErrorFieldMsg: () => {},
+                clearAllErrorMsg: () => {},
+                setErrorMsg: () => {},
+            },
+            handleChange: () => {},
+            addCustomValidator: () => {},
+        },
+        value: '',
+        display: true,
+        error: false,
+        entity: {
+            field: 'url',
+            label: 'URL',
+            type: 'text',
+            help: 'Enter the URL, for example',
+            required: false,
+            encrypted: false,
+        },
+        serviceName: 'settings',
+        mode: 'config',
+        disabled: false,
+        dependencyValues: null,
+        modifiedEntitiesData: {
+            required: true,
+            label: 'Modified URL',
+            help: 'Modified help required',
+        },
+    },
+};

--- a/ui/src/components/ControlWrapper/stories/ControlWrapper.stories.ts
+++ b/ui/src/components/ControlWrapper/stories/ControlWrapper.stories.ts
@@ -52,19 +52,7 @@ export const Base: Story = {
 
 export const WithModifications: Story = {
     args: {
-        utilityFuncts: {
-            utilCustomFunctions: {
-                setState: () => {},
-                setErrorFieldMsg: () => {},
-                clearAllErrorMsg: () => {},
-                setErrorMsg: () => {},
-            },
-            handleChange: () => {},
-            addCustomValidator: () => {},
-        },
-        value: '',
-        display: true,
-        error: false,
+        ...Base.args,
         entity: {
             field: 'url',
             label: 'URL',
@@ -73,29 +61,13 @@ export const WithModifications: Story = {
             required: true,
             encrypted: false,
         },
-        serviceName: 'settings',
-        mode: 'config',
-        disabled: false,
-        dependencyValues: null,
         modifiedEntitiesData: { required: false, label: 'Modified URL', help: 'Modified help' },
     },
 };
 
 export const WithModificationsMakeRequired: Story = {
     args: {
-        utilityFuncts: {
-            utilCustomFunctions: {
-                setState: () => {},
-                setErrorFieldMsg: () => {},
-                clearAllErrorMsg: () => {},
-                setErrorMsg: () => {},
-            },
-            handleChange: () => {},
-            addCustomValidator: () => {},
-        },
-        value: '',
-        display: true,
-        error: false,
+        ...Base.args,
         entity: {
             field: 'url',
             label: 'URL',
@@ -104,10 +76,6 @@ export const WithModificationsMakeRequired: Story = {
             required: false,
             encrypted: false,
         },
-        serviceName: 'settings',
-        mode: 'config',
-        disabled: false,
-        dependencyValues: null,
         modifiedEntitiesData: {
             required: true,
             label: 'Modified URL',

--- a/ui/src/components/ControlWrapper/stories/__images__/ControlWrapper-with-modifications-chromium.png
+++ b/ui/src/components/ControlWrapper/stories/__images__/ControlWrapper-with-modifications-chromium.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4e72b95fe11dd76434351e3094a6a1760453d66d575ec2626ffc6a53e2c52222
+size 5193

--- a/ui/src/components/ControlWrapper/stories/__images__/ControlWrapper-with-modifications-make-required-chromium.png
+++ b/ui/src/components/ControlWrapper/stories/__images__/ControlWrapper-with-modifications-make-required-chromium.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:62a4a0b035421679e26638d8406db1d23c07cdfe292a730c1ef3319be6e41491
+size 6130

--- a/ui/src/components/ControlWrapper/test/ControlWrapper.test.tsx
+++ b/ui/src/components/ControlWrapper/test/ControlWrapper.test.tsx
@@ -43,13 +43,13 @@ const renderControlWrapper = (props: Partial<ControlWrapperProps>) => {
     );
 };
 
-it('check if required start displayed correctly', () => {
+it('check if required star displayed correctly', () => {
     renderControlWrapper({});
     const requiredStar = screen.queryByText('*');
     expect(requiredStar).toBeInTheDocument();
 });
 
-it('check if required start not displayed', () => {
+it('check if required star not displayed', () => {
     renderControlWrapper({
         entity: {
             field: 'url',
@@ -62,7 +62,7 @@ it('check if required start not displayed', () => {
     expect(requiredStar).not.toBeInTheDocument();
 });
 
-it('check if required start displayed correctly from modifiedEntitiesData', () => {
+it('check if required star displayed correctly from modifiedEntitiesData', () => {
     renderControlWrapper({
         entity: {
             field: 'url',
@@ -76,7 +76,7 @@ it('check if required start displayed correctly from modifiedEntitiesData', () =
     expect(requiredStar).toBeInTheDocument();
 });
 
-it('check if required start not displayed due to modifiedEntitiesData', () => {
+it('check if required star not displayed due to modifiedEntitiesData', () => {
     renderControlWrapper({
         entity: {
             field: 'url',

--- a/ui/src/components/ControlWrapper/test/ControlWrapper.test.tsx
+++ b/ui/src/components/ControlWrapper/test/ControlWrapper.test.tsx
@@ -1,0 +1,129 @@
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import ControlWrapper, { ControlWrapperProps } from '../ControlWrapper';
+
+const renderControlWrapper = (props: Partial<ControlWrapperProps>) => {
+    render(
+        <ControlWrapper
+            mode="create"
+            utilityFuncts={{
+                utilCustomFunctions: {
+                    setState: () => {},
+                    setErrorFieldMsg: () => {},
+                    clearAllErrorMsg: () => {},
+                    setErrorMsg: () => {},
+                },
+                handleChange: () => {},
+                addCustomValidator: () => {},
+            }}
+            value=""
+            display
+            error={false}
+            disabled={false}
+            serviceName="testServiceName"
+            dependencyValues={undefined}
+            entity={{
+                field: 'url',
+                label: 'URL',
+                type: 'text',
+                help: 'Enter the URL, for example',
+                required: true,
+                validators: [
+                    {
+                        errorMsg:
+                            "Invalid URL provided. URL should start with 'https' as only secure URLs are supported. Provide URL in this format",
+                        type: 'regex',
+                        pattern: '^(https://)[^/]+/?$',
+                    },
+                ],
+                encrypted: false,
+            }}
+            {...props}
+        />
+    );
+};
+
+it('check if required start displayed correctly', () => {
+    renderControlWrapper({});
+    const requiredStar = screen.queryByText('*');
+    expect(requiredStar).toBeInTheDocument();
+});
+
+it('check if required start not displayed', () => {
+    renderControlWrapper({
+        entity: {
+            field: 'url',
+            label: 'URL',
+            type: 'text',
+            required: false,
+        },
+    });
+    const requiredStar = screen.queryByText('*');
+    expect(requiredStar).not.toBeInTheDocument();
+});
+
+it('check if required start displayed correctly from modifiedEntitiesData', () => {
+    renderControlWrapper({
+        entity: {
+            field: 'url',
+            label: 'URL',
+            type: 'text',
+            required: false,
+        },
+        modifiedEntitiesData: { required: true },
+    });
+    const requiredStar = screen.queryByText('*');
+    expect(requiredStar).toBeInTheDocument();
+});
+
+it('check if required start not displayed due to modifiedEntitiesData', () => {
+    renderControlWrapper({
+        entity: {
+            field: 'url',
+            label: 'URL',
+            type: 'text',
+            required: true,
+        },
+        modifiedEntitiesData: { required: false },
+    });
+
+    const requiredStar = screen.queryByText('*');
+    expect(requiredStar).not.toBeInTheDocument();
+});
+
+it('check if label and help updated due to modifiedEntitiesData', () => {
+    const modifications = { required: false, label: 'Modified URL', help: 'Modified help' };
+    renderControlWrapper({
+        entity: {
+            field: 'url',
+            label: 'URL',
+            help: 'Enter the URL, for example',
+            type: 'text',
+            required: true,
+        },
+        modifiedEntitiesData: modifications,
+    });
+
+    const label = screen.getByTestId('label'); // label replaced
+    expect(label).toHaveTextContent(modifications.label);
+
+    const help = screen.getByTestId('help'); // help replaced
+    expect(help).toHaveTextContent(modifications.help);
+});
+
+it('check if help added due to modifiedEntitiesData', () => {
+    const modifications = { help: 'Modified help' };
+
+    renderControlWrapper({
+        entity: {
+            field: 'url',
+            label: 'URL',
+            type: 'text',
+            required: true,
+        },
+        modifiedEntitiesData: modifications,
+    });
+
+    const help = screen.getByTestId('help');
+    expect(help).toHaveTextContent(modifications.help);
+});


### PR DESCRIPTION
**Issue number:**
https://splunk.atlassian.net/browse/ADDON-77024 
### PR Type

**What kind of change does this PR introduce?**
* [ ] Feature
* [x] Bug Fix
* [ ] Refactoring (no functional or API changes)
* [ ] Documentation Update
* [ ] Maintenance (dependency updates, CI, etc.)

## Summary

Correctly reflects component required property after modifications on value change are applied.

### Changes

Fixes error that verified if required start should be displayed.

### User experience

Users see required star correct next to elements that are required currently.


## Checklist

If an item doesn't apply to your changes, leave it unchecked.

* [x] I have performed a self-review of this change according to the [development guidelines](https://splunk.github.io/addonfactory-ucc-generator/contributing/#development-guidelines)
* [x] Tests have been added/modified to cover the changes [(testing doc)](https://splunk.github.io/addonfactory-ucc-generator/contributing/#build-and-test)
* [ ] Changes are documented
* [x] PR title and description follows the [contributing principles](https://splunk.github.io/addonfactory-ucc-generator/contributing/#pull-requests)
