### PR TITLE
ci: rollback splunk-appinspect to 3.8.1

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -387,7 +387,7 @@ jobs:
           mkdir packaged
           poetry run ucc-gen package --path output/demo_addon_for_splunk -o packaged
       - run: |
-          python3 -m pip install splunk-appinspect
+          python3 -m pip install splunk-appinspect==3.8.1
       - run: |
           splunk-appinspect inspect packaged/demo_addon_for_splunk-0.0.1.tar.gz --mode test --included-tags cloud          
 


### PR DESCRIPTION
**Issue number:**

### PR Type

**What kind of change does this PR introduce?**
* [ ] Feature
* [ ] Bug Fix
* [ ] Refactoring (no functional or API changes)
* [ ] Documentation Update
* [x] Maintenance (dependency updates, CI, etc.)

## Summary

### Changes

Rollback plunk-appinspect from the latest 3.9.0 to 3.8.1. 
3.9.0 does not support Python 3.7

### User experience

No changes

## Checklist

If an item doesn't apply to your changes, leave it unchecked.

* [x] I have performed a self-review of this change according to the [development guidelines](https://splunk.github.io/addonfactory-ucc-generator/contributing/#development-guidelines)
* [ ] Tests have been added/modified to cover the changes [(testing doc)](https://splunk.github.io/addonfactory-ucc-generator/contributing/#build-and-test)
* [ ] Changes are documented
* [x] PR title and description follows the [contributing principles](https://splunk.github.io/addonfactory-ucc-generator/contributing/#pull-requests)
