### PR TITLE
fix: prevent unnecessary updates to the globalConfig file

### DIFF
--- a/splunk_add_on_ucc_framework/global_config_update.py
+++ b/splunk_add_on_ucc_framework/global_config_update.py
@@ -16,6 +16,7 @@
 import logging
 from typing import Any, Dict, Tuple, List, Optional
 
+from splunk_add_on_ucc_framework import __version__ as ucc_version
 from splunk_add_on_ucc_framework import global_config as global_config_lib, utils
 from splunk_add_on_ucc_framework.entity import (
     collapse_entity,
@@ -30,12 +31,12 @@ logger = logging.getLogger("ucc_gen")
 
 def _version_tuple(version: str) -> Tuple[str, ...]:
     """
-    convert string into tuple to compare version
+    Convert string into tuple to compare versions.
 
     Args:
-        version_str : raw string
+        version: raw string
     Returns:
-        tuple : version into tupleformat
+        tuple: version into tuple format
     """
     filled = []
     for point in version.split("."):
@@ -127,10 +128,7 @@ def handle_global_config_update(global_config: global_config_lib.GlobalConfig) -
 
     logger.info(f"Current globalConfig schema version is {current_schema_version}")
 
-    if _version_tuple(global_config.meta.get("_uccVersion", "0.0.0")) >= _version_tuple(
-        "5.52.0"
-    ):
-        # we hard-code the value of 5.52.0 as this feature would be shipped in that version
+    if _version_tuple(ucc_version) >= _version_tuple("5.52.0"):
         version = current_schema_version
     else:
         version = "0.0.0"

--- a/splunk_add_on_ucc_framework/global_config_update.py
+++ b/splunk_add_on_ucc_framework/global_config_update.py
@@ -16,7 +16,6 @@
 import logging
 from typing import Any, Dict, Tuple, List, Optional
 
-from splunk_add_on_ucc_framework import __version__ as ucc_version
 from splunk_add_on_ucc_framework import global_config as global_config_lib, utils
 from splunk_add_on_ucc_framework.entity import (
     collapse_entity,
@@ -124,13 +123,26 @@ def _handle_xml_dashboard_update(global_config: global_config_lib.GlobalConfig) 
 
 def handle_global_config_update(global_config: global_config_lib.GlobalConfig) -> None:
     """Handle changes in globalConfig file."""
-    current_schema_version = global_config.schema_version or "0.0.0"
+    version = global_config.schema_version or "0.0.0"
+    logger.info(f"Current globalConfig schema version is {version}")
 
-    logger.info(f"Current globalConfig schema version is {current_schema_version}")
+    allowed_versions_of_schema_version = {
+        "0.0.0",
+        "0.0.1",
+        "0.0.2",
+        "0.0.3",
+        "0.0.4",
+        "0.0.5",
+        "0.0.6",
+        "0.0.7",
+        "0.0.8",
+        "0.0.9",
+    }
 
-    if _version_tuple(ucc_version) >= _version_tuple("5.52.0"):
-        version = current_schema_version
-    else:
+    if version not in allowed_versions_of_schema_version:
+        logger.warning(
+            "Schema version is not in the allowed versions, setting it to 0.0.0"
+        )
         version = "0.0.0"
 
     if _version_tuple(version) < _version_tuple("0.0.1"):

--- a/tests/testdata/test_addons/package_files_conflict_test/globalConfig.json
+++ b/tests/testdata/test_addons/package_files_conflict_test/globalConfig.json
@@ -199,7 +199,7 @@
     "meta": {
         "name": "test_addon",
         "restRoot": "test_addon",
-        "version": "5.55.0+dcdb201e",
+        "version": "5.56.0+12f4cd8cd",
         "displayName": "This is my add-on",
         "schemaVersion": "0.0.9"
     }

--- a/tests/testdata/test_addons/package_global_config_everything/globalConfig.json
+++ b/tests/testdata/test_addons/package_global_config_everything/globalConfig.json
@@ -1822,7 +1822,7 @@
     "meta": {
         "name": "Splunk_TA_UCCExample",
         "restRoot": "splunk_ta_uccexample",
-        "version": "5.55.0+36810ea3",
+        "version": "5.56.0+12f4cd8cd",
         "displayName": "Splunk UCC test Add-on",
         "schemaVersion": "0.0.9",
         "supportedThemes": [

--- a/tests/testdata/test_addons/package_global_config_everything_uccignore/globalConfig.json
+++ b/tests/testdata/test_addons/package_global_config_everything_uccignore/globalConfig.json
@@ -1171,7 +1171,7 @@
     "meta": {
         "name": "Splunk_TA_UCCExample",
         "restRoot": "splunk_ta_uccexample",
-        "version": "5.55.0+dcdb201e",
+        "version": "5.56.0+12f4cd8cd",
         "displayName": "Splunk UCC test Add-on",
         "schemaVersion": "0.0.9"
     }

--- a/tests/testdata/test_addons/package_global_config_multi_input/globalConfig.json
+++ b/tests/testdata/test_addons/package_global_config_multi_input/globalConfig.json
@@ -694,7 +694,7 @@
     "meta": {
         "name": "Splunk_TA_UCCExample",
         "restRoot": "splunk_ta_uccexample",
-        "version": "5.55.0+dcdb201e",
+        "version": "5.56.0+12f4cd8cd",
         "displayName": "Splunk UCC test Add-on",
         "schemaVersion": "0.0.9"
     }

--- a/tests/testdata/test_addons/package_global_config_only_one_tab/globalConfig.json
+++ b/tests/testdata/test_addons/package_global_config_only_one_tab/globalConfig.json
@@ -36,7 +36,7 @@
     "meta": {
         "name": "Splunk_TA_UCCExample",
         "restRoot": "splunk_ta_uccexample",
-        "version": "5.55.0+dcdb201e",
+        "version": "5.56.0+12f4cd8cd",
         "displayName": "Splunk UCC test Add-on",
         "schemaVersion": "0.0.9"
     }

--- a/tests/unit/test_global_config_update.py
+++ b/tests/unit/test_global_config_update.py
@@ -4,6 +4,7 @@ import pytest
 
 import tests.unit.helpers as helpers
 from splunk_add_on_ucc_framework.global_config_update import (
+    _version_tuple,
     _handle_biased_terms_update,
     _handle_dropping_api_version_update,
     _handle_xml_dashboard_update,
@@ -12,10 +13,22 @@ from splunk_add_on_ucc_framework.global_config_update import (
     _dump_with_migrated_entities,
     _stop_build_on_placeholder_usage,
     _dump_enable_from_global_config,
+    handle_global_config_update,
 )
 from splunk_add_on_ucc_framework.entity import IntervalEntity
 from splunk_add_on_ucc_framework import global_config as global_config_lib
 from splunk_add_on_ucc_framework.exceptions import GlobalConfigValidatorException
+
+
+@pytest.mark.parametrize(
+    "version, expected",
+    [
+        ("5.52.0", ("00000005", "00000052", "00000000")),
+        ("0.0.9", ("00000000", "00000000", "00000009")),
+    ],
+)
+def test_version_tuple(version, expected):
+    assert _version_tuple(version) == expected
 
 
 @pytest.mark.parametrize(
@@ -236,3 +249,15 @@ def test_dump_enable_from_global_config_enable_absent(tmp_path, caplog):
 
     assert expected_schema_version == global_config.schema_version
     assert caplog.text == ""
+
+
+def test_handle_global_config_update_when_valid_config(tmp_path):
+    tmp_file_gc = tmp_path / "globalConfig.json"
+
+    helpers.copy_testdata_gc_to_tmp_file(tmp_file_gc, "valid_config.json")
+    global_config = global_config_lib.GlobalConfig(str(tmp_file_gc))
+    expected_schema_version = "0.0.9"
+
+    handle_global_config_update(global_config)
+
+    assert global_config.schema_version == expected_schema_version


### PR DESCRIPTION
**Issue number:** ADDON-77791

### PR Type

**What kind of change does this PR introduce?**
* [ ] Feature
* [x] Bug Fix
* [ ] Refactoring (no functional or API changes)
* [ ] Documentation Update
* [ ] Maintenance (dependency updates, CI, etc.)

## Summary

### Changes

Prevent unnecessary updates to the globalConfig file. To reproduce it - create a fresh add-on using `init -> build` commands and you shall see multiple log lines with "Updated globalConfig schema to version <version>" which should not be needed as it is a completely fresh add-on which should already use the latest version of the globalConfig file.

The old logic relies on `_uccVersion` field which is also no longer present (#1519) in the globalConfig file.

The new logic explicitly declares a list of supported schema versions (which is not the most elegant solution) and uses "0.0.0" in case `schemaVersion` is not known (this is possible in add-ons built with older versions of Add-on Builder).

### User experience

No unnecessary updates to the globalConfig file.

## Checklist

If an item doesn't apply to your changes, leave it unchecked.

* [x] I have performed a self-review of this change according to the [development guidelines](https://splunk.github.io/addonfactory-ucc-generator/contributing/#development-guidelines)
* [x] Tests have been added/modified to cover the changes [(testing doc)](https://splunk.github.io/addonfactory-ucc-generator/contributing/#build-and-test)
* [ ] Changes are documented
* [x] PR title and description follows the [contributing principles](https://splunk.github.io/addonfactory-ucc-generator/contributing/#pull-requests)
