### PR TITLE
revert: "ci: rollback splunk-appinspect to 3.8.1"

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -387,7 +387,7 @@ jobs:
           mkdir packaged
           poetry run ucc-gen package --path output/demo_addon_for_splunk -o packaged
       - run: |
-          python3 -m pip install splunk-appinspect==3.8.1
+          python3 -m pip install splunk-appinspect
       - run: |
           splunk-appinspect inspect packaged/demo_addon_for_splunk-0.0.1.tar.gz --mode test --included-tags cloud          
 


### PR DESCRIPTION
Reverts splunk/addonfactory-ucc-generator#1527

New version of `splunk-appinspect` was released and it fixes the issue introduced in 3.9.0 so we can revert this change.