### PR TITLE
chore(storybook): waitForPageReady for CI

### DIFF
--- a/ui/.storybook/preview-head.html
+++ b/ui/.storybook/preview-head.html
@@ -1,3 +1,20 @@
+<!--
+  ~ Copyright 2025 Splunk Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+-->
+
 <link rel="preload" as="font" type="font/woff" href="/fonts/splunkdatasansmono-regular.woff" />
 <link rel="preload" as="font" type="font/woff" href="/fonts/splunkdatasans-bold.woff" />
 <link rel="preload" as="font" type="font/woff" href="/fonts/splunkdatasans-medium.woff" />

--- a/ui/.storybook/preview-head.html
+++ b/ui/.storybook/preview-head.html
@@ -1,0 +1,4 @@
+<link rel="preload" as="font" type="font/woff" href="/fonts/splunkdatasansmono-regular.woff" />
+<link rel="preload" as="font" type="font/woff" href="/fonts/splunkdatasans-bold.woff" />
+<link rel="preload" as="font" type="font/woff" href="/fonts/splunkdatasans-medium.woff" />
+<link rel="preload" as="font" type="font/woff" href="/fonts/splunkdatasans-regular.woff" />

--- a/ui/.storybook/test-runner.ts
+++ b/ui/.storybook/test-runner.ts
@@ -5,7 +5,6 @@ const config: TestRunnerConfig = {
     setup() {
         expect.extend({ toMatchImageSnapshot });
     },
-    logLevel: 'verbose',
     async preVisit(page, context) {
         const storyContext = await getStoryContext(page, context);
         const parameters = storyContext.parameters;
@@ -39,28 +38,14 @@ const config: TestRunnerConfig = {
         const customReceivedDir = `${process.cwd()}/test-reports/visual/image_snapshot_received/`;
 
         // can't use waitForPageReady because networkidle never fires due to HMR for locally running Storybook
-        console.log('Starting to wait for .woff requests');
-        console.time('Waiting for .woff requests');
-        await page.waitForResponse((request) => {
-            return request.url().includes('.woff');
-        });
-        console.log('Stopped waiting for .woff requests');
-        console.timeEnd('Waiting for .woff requests');
-
         if (process.env.CI) {
-            console.log('Waiting for page ready');
-            console.time('Waiting for page ready');
             await waitForPageReady(page);
-            console.timeEnd('Waiting for page ready');
         } else {
             await page.waitForLoadState('domcontentloaded');
             await page.waitForLoadState('load');
         }
 
-        console.log('Waiting for fonts to be ready');
-        console.time('Waiting for fonts to be ready');
         await page.evaluate(() => document.fonts.ready);
-        console.timeEnd('Waiting for fonts to be ready');
 
         const image = await page.screenshot({ animations: 'disabled', scale: 'css' });
         expect(image).toMatchImageSnapshot({

--- a/ui/.storybook/test-runner.ts
+++ b/ui/.storybook/test-runner.ts
@@ -38,15 +38,16 @@ const config: TestRunnerConfig = {
         const customReceivedDir = `${process.cwd()}/test-reports/visual/image_snapshot_received/`;
 
         // can't use waitForPageReady because networkidle never fires due to HMR for locally running Storybook
+        await page.waitForResponse((request) => {
+            return request.url().includes('.woff');
+        });
         if (process.env.CI) {
             await waitForPageReady(page);
         } else {
             await page.waitForLoadState('domcontentloaded');
             await page.waitForLoadState('load');
         }
-        await page.waitForResponse((request) => {
-            return request.url().includes('.woff');
-        });
+
         await page.evaluate(() => document.fonts.ready);
 
         const image = await page.screenshot({ animations: 'disabled', scale: 'css' });

--- a/ui/.storybook/test-runner.ts
+++ b/ui/.storybook/test-runner.ts
@@ -1,4 +1,4 @@
-import { getStoryContext, TestRunnerConfig } from '@storybook/test-runner';
+import { getStoryContext, TestRunnerConfig, waitForPageReady } from '@storybook/test-runner';
 import { toMatchImageSnapshot } from 'jest-image-snapshot';
 
 const config: TestRunnerConfig = {
@@ -38,8 +38,15 @@ const config: TestRunnerConfig = {
         const customReceivedDir = `${process.cwd()}/test-reports/visual/image_snapshot_received/`;
 
         // can't use waitForPageReady because networkidle never fires due to HMR for locally running Storybook
-        await page.waitForLoadState('domcontentloaded');
-        await page.waitForLoadState('load');
+        if (process.env.CI) {
+            await waitForPageReady(page);
+        } else {
+            await page.waitForLoadState('domcontentloaded');
+            await page.waitForLoadState('load');
+        }
+        await page.waitForResponse((request) => {
+            return request.url().includes('.woff');
+        });
         await page.evaluate(() => document.fonts.ready);
 
         const image = await page.screenshot({ animations: 'disabled', scale: 'css' });

--- a/ui/.storybook/test-runner.ts
+++ b/ui/.storybook/test-runner.ts
@@ -5,6 +5,7 @@ const config: TestRunnerConfig = {
     setup() {
         expect.extend({ toMatchImageSnapshot });
     },
+    logLevel: 'verbose',
     async preVisit(page, context) {
         const storyContext = await getStoryContext(page, context);
         const parameters = storyContext.parameters;
@@ -38,17 +39,28 @@ const config: TestRunnerConfig = {
         const customReceivedDir = `${process.cwd()}/test-reports/visual/image_snapshot_received/`;
 
         // can't use waitForPageReady because networkidle never fires due to HMR for locally running Storybook
+        console.log('Starting to wait for .woff requests');
+        console.time('Waiting for .woff requests');
         await page.waitForResponse((request) => {
             return request.url().includes('.woff');
         });
+        console.log('Stopped waiting for .woff requests');
+        console.timeEnd('Waiting for .woff requests');
+
         if (process.env.CI) {
+            console.log('Waiting for page ready');
+            console.time('Waiting for page ready');
             await waitForPageReady(page);
+            console.timeEnd('Waiting for page ready');
         } else {
             await page.waitForLoadState('domcontentloaded');
             await page.waitForLoadState('load');
         }
 
+        console.log('Waiting for fonts to be ready');
+        console.time('Waiting for fonts to be ready');
         await page.evaluate(() => document.fonts.ready);
+        console.timeEnd('Waiting for fonts to be ready');
 
         const image = await page.screenshot({ animations: 'disabled', scale: 'css' });
         expect(image).toMatchImageSnapshot({


### PR DESCRIPTION
**Issue number:**

### PR Type

**What kind of change does this PR introduce?**
* [ ] Feature
* [ ] Bug Fix
* [ ] Refactoring (no functional or API changes)
* [ ] Documentation Update
* [x] Maintenance (dependency updates, CI, etc.)

## Summary

Sometimes Storybook takes a screenshot before the font is loaded. That results in the screen without any text on it. Then it commits this screenshot.
The problem is that the font loads far after the page load finish 

### Changes

I added waitForPageReady that includes networkidle. I am not sure if this solve the problem, but let's see.

### User experience

No changes

## Checklist

If an item doesn't apply to your changes, leave it unchecked.

* [x] I have performed a self-review of this change according to the [development guidelines](https://splunk.github.io/addonfactory-ucc-generator/contributing/#development-guidelines)
* [ ] Tests have been added/modified to cover the changes [(testing doc)](https://splunk.github.io/addonfactory-ucc-generator/contributing/#build-and-test)
* [ ] Changes are documented
* [x] PR title and description follows the [contributing principles](https://splunk.github.io/addonfactory-ucc-generator/contributing/#pull-requests)
