### PR TITLE
ci(test): ignore errors caused by RUM scripts

### DIFF
--- a/tests/ui/conftest.py
+++ b/tests/ui/conftest.py
@@ -33,7 +33,10 @@ def pytest_runtest_call(item: pytest.Item) -> Iterator[Any]:
     yield
 
     # sometimes RUM is down and we get a lot of severe logs
-    IGNORED: List[str] = ["https://rum-ingest.us1.signalfx.com"]
+    IGNORED: List[str] = [
+        "https://rum-ingest.us1.signalfx.com",
+        "https://cdn.signalfx.com/o11y-gdi-rum",
+    ]
 
     browser_logs = s_utils.get_browser_logs(item.selenium_helper.browser)
     severe_logs = [


### PR DESCRIPTION
**Issue number:**

### PR Type

**What kind of change does this PR introduce?**
* [ ] Feature
* [ ] Bug Fix
* [ ] Refactoring (no functional or API changes)
* [ ] Documentation Update
* [x] Maintenance (dependency updates, CI, etc.)

## Summary


Internal issues from RUM script causes CIs fails
```
LogSource.CONSOLE_API - https://cdn.signalfx.com/o11y-gdi-rum/v0.16.5/splunk-otel-web.js 0:124824 TypeError: Failed to fetch
E               at https://cdn.signalfx.com/o11y-gdi-rum/v0.16.5/splunk-otel-web.js:1:[105](https://github.com/splunk/addonfactory-ucc-generator/actions/runs/13048620722/job/36404051731#step:8:106)313
```

https://github.com/splunk/addonfactory-ucc-generator/actions/runs/13048620722/job/36404051731

### Changes

Add part of the error to ignore list to not fail e2e tests

### User experience

No changes

## Checklist

If an item doesn't apply to your changes, leave it unchecked.

* [x] I have performed a self-review of this change according to the [development guidelines](https://splunk.github.io/addonfactory-ucc-generator/contributing/#development-guidelines)
* [ ] Tests have been added/modified to cover the changes [(testing doc)](https://splunk.github.io/addonfactory-ucc-generator/contributing/#build-and-test)
* [ ] Changes are documented
* [x] PR title and description follows the [contributing principles](https://splunk.github.io/addonfactory-ucc-generator/contributing/#pull-requests)
