### PR TITLE
fix: correctly display status in more info

### DIFF
--- a/ui/src/components/table/TableExpansionRowData.jsx
+++ b/ui/src/components/table/TableExpansionRowData.jsx
@@ -16,11 +16,12 @@ export function getExpansionRowData(row, moreInfo) {
         moreInfo?.reduce((definitionLists, val) => {
             const label = _(val.label);
             const cellValue = getTableCellValue(row, val.field, val.mapping);
+
             // Remove extra rows which are empty in moreInfo and default value is not provided
-            if (cellValue) {
+            if (cellValue !== undefined && cellValue !== null && cellValue !== '') {
                 definitionLists.push(<DL.Term key={val.field}>{label}</DL.Term>);
                 definitionLists.push(
-                    <DL.Description key={`${val.field}_decr`}>{cellValue}</DL.Description>
+                    <DL.Description key={`${val.field}_decr`}>{String(cellValue)}</DL.Description>
                 );
             }
             return definitionLists;

--- a/ui/src/components/table/tests/TableExpansionRowData.test.tsx
+++ b/ui/src/components/table/tests/TableExpansionRowData.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { getExpansionRowData } from '../TableExpansionRowData';
 import { LABEL_FOR_DEFAULT_TABLE_CELL_VALUE } from '../TableConsts';
+import { AcceptableFormValueOrNullish } from '../../../types/components/shareableTypes';
 
 const moreInfo = [
     { label: 'Name', field: 'name', mapping: { [LABEL_FOR_DEFAULT_TABLE_CELL_VALUE]: 'Unknown' } },
@@ -11,6 +12,7 @@ const moreInfo = [
         field: 'country',
         mapping: { [LABEL_FOR_DEFAULT_TABLE_CELL_VALUE]: 'N/A' },
     },
+    { label: 'Status', field: 'disabled' },
 ];
 
 const getTermByText = (content: string) =>
@@ -39,6 +41,83 @@ it('correctly processes non-empty moreInfo and returns expected React elements',
     expect(getDefinitionByText('30')).toBeInTheDocument();
 });
 it('excludes fields when not present in row and no default value is provided', async () => {
+    const row = { name: 'Jane Doe', country: 'Canada' };
+    render(<div>{getExpansionRowData(row, moreInfo)}</div>);
+
+    const userAge = screen.queryByText('30');
+    const ageTag = screen.queryByText('Age');
+
+    expect(userAge).not.toBeInTheDocument();
+    expect(ageTag).not.toBeInTheDocument();
+});
+
+it.each([
+    { disabled: false, name: 'Jane Doe', country: 'Canada' },
+    { disabled: true, name: 'Jane Doe', country: 'Canada' },
+])(
+    'display status correctly in more info',
+    ({
+        disabled,
+        name,
+        country,
+    }: {
+        disabled: AcceptableFormValueOrNullish;
+        name: string;
+        country: string;
+    }) => {
+        const row = { name, country, disabled };
+        render(<div>{getExpansionRowData(row, moreInfo)}</div>);
+
+        const nameText = screen.queryByText(name);
+        const countryText = screen.queryByText(country);
+        const statusText = screen.queryByText(String(disabled));
+
+        expect(nameText).toBeInTheDocument();
+        expect(countryText).toBeInTheDocument();
+        expect(statusText).toBeInTheDocument();
+    }
+);
+
+it.each([
+    { disabled: undefined, name: 'Jane Doe', country: undefined },
+    { disabled: undefined, name: 'Jane Doe', country: null },
+    { disabled: null, name: 'Jane Doe', country: undefined },
+    { disabled: null, name: 'Jane Doe', country: null },
+    { disabled: '', name: 'Jane Doe', country: null },
+])(
+    'Do not display nullish data',
+    async ({
+        disabled,
+        name,
+        country,
+    }: {
+        disabled: AcceptableFormValueOrNullish;
+        name: string;
+        country: AcceptableFormValueOrNullish;
+    }) => {
+        const row = { name, country, disabled };
+        render(<div>{getExpansionRowData(row, moreInfo)}</div>);
+
+        const nameText = screen.queryByText(name);
+
+        const countryText = screen.queryByText(String(country));
+        const countryTextDefault = screen.queryByText('N/A');
+
+        const statusLabel = screen.queryByRole(String(disabled));
+
+        // name displayed correctly
+        expect(nameText).toBeInTheDocument();
+
+        // country with default value so value text is not displayed
+        expect(countryText).not.toBeInTheDocument();
+        expect(countryTextDefault).toBeInTheDocument();
+
+        // status is not displayed at all
+        expect(statusLabel).not.toBeInTheDocument();
+    }
+);
+
+it('display status correctly', async () => {
     const row = { name: 'Jane Doe', country: 'Canada' };
     render(<div>{getExpansionRowData(row, moreInfo)}</div>);
 

--- a/ui/src/components/table/tests/TableExpansionRowData.test.tsx
+++ b/ui/src/components/table/tests/TableExpansionRowData.test.tsx
@@ -26,7 +26,7 @@ it('returns an empty array when moreInfo is undefined or empty', () => {
 });
 
 it('correctly processes non-empty moreInfo and returns expected React elements', async () => {
-    const row = { name: 'John Doe', age: 30, country: 'USA' };
+    const row = { name: 'John Doe', age: 30, country: 'USA', disabled: false };
     render(<div>{getExpansionRowData(row, moreInfo)}</div>);
 
     expect(screen.getAllByRole('definition')).toHaveLength(moreInfo.length);


### PR DESCRIPTION
**Issue number:**

### PR Type

**What kind of change does this PR introduce?**
* [ ] Feature
* [x] Bug Fix
* [ ] Refactoring (no functional or API changes)
* [ ] Documentation Update
* [ ] Maintenance (dependency updates, CI, etc.)

## Summary

### Changes

Correctly verify status value.

Before:
Status is `true` as input is disabled: true
<img width="969" alt="Screenshot 2025-02-14 at 13 07 21" src="https://github.com/user-attachments/assets/995a4b58-b24a-40a9-93ad-1fc3eb846c70" />

Status is `false` as input is disabled: false
<img width="978" alt="Screenshot 2025-02-14 at 13 07 30" src="https://github.com/user-attachments/assets/9ef1ae33-4c61-4a1c-ad54-a82d4596cf29" />:

After:
Status is `true` as input is disabled: true
<img width="1019" alt="Screenshot 2025-02-14 at 13 16 52" src="https://github.com/user-attachments/assets/644ae013-e3eb-4d87-8b96-eaba17e6f813" />

Status is `false` as input is disabled: false
<img width="1060" alt="Screenshot 2025-02-14 at 13 16 43" src="https://github.com/user-attachments/assets/ec7bf902-70b1-4d48-a204-f745affe6a00" />


### User experience

User can see status value.

## Checklist

If an item doesn't apply to your changes, leave it unchecked.

* [x] I have performed a self-review of this change according to the [development guidelines](https://splunk.github.io/addonfactory-ucc-generator/contributing/#development-guidelines)
* [x] Tests have been added/modified to cover the changes [(testing doc)](https://splunk.github.io/addonfactory-ucc-generator/contributing/#build-and-test)
* [ ] Changes are documented
* [x] PR title and description follows the [contributing principles](https://splunk.github.io/addonfactory-ucc-generator/contributing/#pull-requests)
