### PR TITLE
ci(npm): allow to publish prerelease with manual workflow run

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -3,14 +3,20 @@ name: NPM Publish
 on:
   workflow_dispatch:
     inputs:
-      tag:
-        description: "Git tag to publish"
+      branch:
+        description: "Branch to publish"
         required: true
+        default: "develop"
       dry_run:
         description: "Perform a dry run of the npm publish"
         required: false
         default: true
         type: boolean
+      version_type:
+        description: "Type of version bump (prerelease or specific version like 1.2.3-dev.0)"
+        required: false
+        default: "prerelease"
+        type: string
 
 permissions:
   id-token: write
@@ -27,10 +33,18 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.inputs.tag }}
+          ref: ${{ github.event.inputs.branch }}
 
       - name: Install deps
         uses: ./.github/actions/cached-ui-deps
+
+      - name: Bump version
+        run: |
+          if [ "${{ github.event.inputs.version_type }}" = "prerelease" ]; then
+            npm version prerelease --preid=dev --no-git-tag-version
+          else
+            npm version ${{ github.event.inputs.version_type }} --no-git-tag-version
+          fi
 
       - name: Publish NPM package
         run: |


### PR DESCRIPTION
**Issue number:**

### PR Type

**What kind of change does this PR introduce?**
* [ ] Feature
* [ ] Bug Fix
* [ ] Refactoring (no functional or API changes)
* [ ] Documentation Update
* [x] Maintenance (dependency updates, CI, etc.)

## Summary

I want to publish pre-release versions of npm package before actual release to let me test the package from other repositories

### Changes

Add ability to bump a version of package.json. The bumped version would not be commited

<img width="381" alt="image" src="https://github.com/user-attachments/assets/8383c56b-093c-4512-9473-1beb1388ab4c" />

https://www.npmjs.com/package/@splunk/add-on-ucc-framework?activeTab=versions

### User experience

No changes

## Checklist

If an item doesn't apply to your changes, leave it unchecked.

* [x] I have performed a self-review of this change according to the [development guidelines](https://splunk.github.io/addonfactory-ucc-generator/contributing/#development-guidelines)
* [ ] Tests have been added/modified to cover the changes [(testing doc)](https://splunk.github.io/addonfactory-ucc-generator/contributing/#build-and-test)
* [ ] Changes are documented
* [x] PR title and description follows the [contributing principles](https://splunk.github.io/addonfactory-ucc-generator/contributing/#pull-requests)
