### PR TITLE
ci(npm): fix release publish command

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -472,6 +472,9 @@ jobs:
       - pre-commit
       - all-checks
     runs-on: ubuntu-22.04
+    permissions:
+      id-token: write
+      contents: read
     if: "! github.event.pull_request.head.repo.fork "
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -39,12 +39,12 @@ jobs:
         uses: ./.github/actions/cached-ui-deps
 
       - name: Bump version
-        if: github.event.inputs.version_type
+
         run: |
           if [ "${{ github.event.inputs.version_type }}" = "prerelease" ]; then
             npm version prerelease --preid=dev --no-git-tag-version
           else
-            npm version ${{ github.event.inputs.version_type }} --no-git-tag-version
+            npm version ${{ github.event.inputs.version_type }} --no-git-tag-version --allow-same-version
           fi
 
       - name: Publish NPM package

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -39,6 +39,7 @@ jobs:
         uses: ./.github/actions/cached-ui-deps
 
       - name: Bump version
+        if: github.event.inputs.version_type
         run: |
           if [ "${{ github.event.inputs.version_type }}" = "prerelease" ]; then
             npm version prerelease --preid=dev --no-git-tag-version


### PR DESCRIPTION
**Issue number:**

### PR Type

**What kind of change does this PR introduce?**
* [ ] Feature
* [ ] Bug Fix
* [ ] Refactoring (no functional or API changes)
* [ ] Documentation Update
* [x] Maintenance (dependency updates, CI, etc.)

## Summary

- The publish job is failed with an error
```
npm notice Publishing to https://registry.npmjs.org/ with tag latest and public access
npm error code EUSAGE
npm error Provenance generation in GitHub Actions requires "write" access to the "id-token" permission
npm error A complete log of this run can be found in: /home/runner/.npm/_logs/2025-02-18T16_29_20_197Z-debug-0.log
```
- It is now allowed to manually publish NPM package without a bump

### Changes

- Give permissions for NPM publish during a regular build
- Add ability to publish version from the repository without a bump for a manual workflow

### User experience

No changes

## Checklist

If an item doesn't apply to your changes, leave it unchecked.

* [x] I have performed a self-review of this change according to the [development guidelines](https://splunk.github.io/addonfactory-ucc-generator/contributing/#development-guidelines)
* [ ] Tests have been added/modified to cover the changes [(testing doc)](https://splunk.github.io/addonfactory-ucc-generator/contributing/#build-and-test)
* [ ] Changes are documented
* [x] PR title and description follows the [contributing principles](https://splunk.github.io/addonfactory-ucc-generator/contributing/#pull-requests)
