### PR TITLE
docs: use Admonition instead of details in modifications description

### DIFF
--- a/docs/entity/modifyFieldsOnValue.md
+++ b/docs/entity/modifyFieldsOnValue.md
@@ -36,217 +36,211 @@ This feature allows to specify conditions to modify other fields based on curren
 
 ### Usage
 
-<details>
-  <summary>Checkbox</summary>
+??? Checkbox
 
-```json
-{
-    "type": "checkbox",
-    "label": "Example Checkbox",
-    "field": "account_checkbox",
-    "help": "This is an example checkbox for the account entity",
-    "modifyFieldsOnValue": [
-        {
-            "fieldValue": 1,
-            "fieldsToModify": [
-                {
-                    "fieldId": "account_radio",
-                    "disabled": false
-                },
-                {
-                    "fieldId": "endpoint",
-                    "display": true
-                }
-            ]
-        },
-        {
-            "fieldValue": 0,
-            "mode": "edit",
-            "fieldsToModify": [
-                {
-                    "fieldId": "account_radio",
-                    "disabled": true
-                },
-                {
-                    "fieldId": "endpoint",
-                    "display": false
-                }
-            ]
-        }
-    ]
-},
-```
-
-</details>
-
-<details>
-  <summary>Text input</summary>
-
-```json
-{
-    "label": "Username",
-    "type": "text",
-    "help": "Enter the username for this account.",
-    "field": "username",
-    "modifyFieldsOnValue": [
-        {
-            "fieldValue": "[[any_other_value]]",
-            "fieldsToModify": [
-                {
-                    "fieldId": "some_other_field",
-                    "disabled": false,
-                    "display": true,
-                    "label": "New label for other values",
-                    "value": "New value for other values",
-                    "help": "New help for other values",
-                    "markdownMessage": {
-                        "markdownType": "text",
-                        "text": "New markdown message for other values",
-                        "color": "red"
+    ```json
+    {
+        "type": "checkbox",
+        "label": "Example Checkbox",
+        "field": "account_checkbox",
+        "help": "This is an example checkbox for the account entity",
+        "modifyFieldsOnValue": [
+            {
+                "fieldValue": 1,
+                "fieldsToModify": [
+                    {
+                        "fieldId": "account_radio",
+                        "disabled": false
                     },
-                    "required": false
-                }
-            ]
-        },
-        {
-            "fieldValue": "a",
-            "fieldsToModify": [
-                {
-                    "fieldId": "some_other_field",
-                    "display": true,
-                    "disabled": true,
-                    "label": "New label for value 'a' as username",
-                    "value": "New value for value 'a' as username",
-                    "help": "New help for value 'a' as username",
-                    "markdownMessage": {
-                        "markdownType": "link",
-                        "text": "New markdown message for value 'a' as username",
-                        "link": "https://splunk.github.io/addonfactory-ucc-generator/"
+                    {
+                        "fieldId": "endpoint",
+                        "display": true
+                    }
+                ]
+            },
+            {
+                "fieldValue": 0,
+                "mode": "edit",
+                "fieldsToModify": [
+                    {
+                        "fieldId": "account_radio",
+                        "disabled": true
                     },
-                    "required": true
-                }
-            ]
-        },
-        {
-            "fieldValue": "aa",
-            "fieldsToModify": [
-                {
-                    "fieldId": "some_other_field",
-                    "disabled": false,
-                    "display": false,
-                    "label": "New label for value 'aa' as username",
-                    "value":"New value for value 'aa' as username",
-                    "help": "New help for value 'aa' as username",
-                    "required": true
-                }
-            ]
-        },
-        {
-            "fieldValue": "aaa",
-            "fieldsToModify": [
-                {
-                    "fieldId": "some_other_field",
-                    "disabled": true,
-                    "display": true,
-                    "label": "New label for value 'aaa' as username",
-                    "value": "New value for value 'aaa' as username",
-                    "help":  "New help for value 'aaa' as username",
-                    "markdownMessage": {
-                        "markdownType": "hybrid",
-                        "text": "New markdown message token 'aaa' as username",
-                        "link": "https://splunk.github.io/addonfactory-ucc-generator/",
-                        "token": "token",
-                        "linkText": "for value"
-                    },
-                    "required": true
-                }
-            ]
-        },
-        {
-            "fieldValue": "aaaa",
-            "mode": "edit",
-            "fieldsToModify": [
-                {
-                    "fieldId": "some_other_field",
-                    "disabled": false,
-                    "display": false,
-                    "label": "New label for value 'aaaa' as username used only when editing entity",
-                    "value": "New value for value 'aaaa' as username used only when editing entity",
-                    "help":  "New help for value 'aaaa' as username used only when editing entity",
-                    "markdownMessage": {
-                        "markdownType": "text",
-                        "text": "markdown message plain text used only when editing entity"
-                    },
-                    "required": false
-                }
-            ]
-        }
-    ]
-},
-```
+                    {
+                        "fieldId": "endpoint",
+                        "display": false
+                    }
+                ]
+            }
+        ]
+    },
+    ```
 
-</details>
+
+??? "Text input"
+
+    ```json
+    {
+        "label": "Username",
+        "type": "text",
+        "help": "Enter the username for this account.",
+        "field": "username",
+        "modifyFieldsOnValue": [
+            {
+                "fieldValue": "[[any_other_value]]",
+                "fieldsToModify": [
+                    {
+                        "fieldId": "some_other_field",
+                        "disabled": false,
+                        "display": true,
+                        "label": "New label for other values",
+                        "value": "New value for other values",
+                        "help": "New help for other values",
+                        "markdownMessage": {
+                            "markdownType": "text",
+                            "text": "New markdown message for other values",
+                            "color": "red"
+                        },
+                        "required": false
+                    }
+                ]
+            },
+            {
+                "fieldValue": "a",
+                "fieldsToModify": [
+                    {
+                        "fieldId": "some_other_field",
+                        "display": true,
+                        "disabled": true,
+                        "label": "New label for value 'a' as username",
+                        "value": "New value for value 'a' as username",
+                        "help": "New help for value 'a' as username",
+                        "markdownMessage": {
+                            "markdownType": "link",
+                            "text": "New markdown message for value 'a' as username",
+                            "link": "https://splunk.github.io/addonfactory-ucc-generator/"
+                        },
+                        "required": true
+                    }
+                ]
+            },
+            {
+                "fieldValue": "aa",
+                "fieldsToModify": [
+                    {
+                        "fieldId": "some_other_field",
+                        "disabled": false,
+                        "display": false,
+                        "label": "New label for value 'aa' as username",
+                        "value":"New value for value 'aa' as username",
+                        "help": "New help for value 'aa' as username",
+                        "required": true
+                    }
+                ]
+            },
+            {
+                "fieldValue": "aaa",
+                "fieldsToModify": [
+                    {
+                        "fieldId": "some_other_field",
+                        "disabled": true,
+                        "display": true,
+                        "label": "New label for value 'aaa' as username",
+                        "value": "New value for value 'aaa' as username",
+                        "help":  "New help for value 'aaa' as username",
+                        "markdownMessage": {
+                            "markdownType": "hybrid",
+                            "text": "New markdown message token 'aaa' as username",
+                            "link": "https://splunk.github.io/addonfactory-ucc-generator/",
+                            "token": "token",
+                            "linkText": "for value"
+                        },
+                        "required": true
+                    }
+                ]
+            },
+            {
+                "fieldValue": "aaaa",
+                "mode": "edit",
+                "fieldsToModify": [
+                    {
+                        "fieldId": "some_other_field",
+                        "disabled": false,
+                        "display": false,
+                        "label": "New label for value 'aaaa' as username used only when editing entity",
+                        "value": "New value for value 'aaaa' as username used only when editing entity",
+                        "help":  "New help for value 'aaaa' as username used only when editing entity",
+                        "markdownMessage": {
+                            "markdownType": "text",
+                            "text": "markdown message plain text used only when editing entity"
+                        },
+                        "required": false
+                    }
+                ]
+            }
+        ]
+    },
+    ```
+
 
 ### Troubleshooting
 
 Examples of issue you might encounter
 
-<details>
-  <summary>Usage Modification with Checkbox component</summary>
+??? "Usage Modification with Checkbox component"
 
-Make sure the fieldValue fields are declared as `1` for any `truthy`(checked) value and `0` for any `falsy`(unchecked) value as it is mapped considering those values. Checkbox by default do not have any value at all, so if you want to consider also this state use `[[any_other_value]]` as it will also consider basic state.
+    Make sure the fieldValue fields are declared as `1` for any `truthy`(checked) value and `0` for any `falsy`(unchecked) value as it is mapped considering those values. Checkbox by default do not have any value at all, so if you want to consider also this state use `[[any_other_value]]` as it will also consider basic state.
 
-```json
-{
-    "type": "checkbox",
-    "label": "Example Checkbox",
-    "field": "account_checkbox",
-    "help": "This is an example checkbox for the account entity",
-    "modifyFieldsOnValue": [
-        {
-            "fieldValue": 1,
-            "fieldsToModify": [
-                {
-                    "fieldId": "account_radio",
-                    "disabled": false
-                },
-                {
-                    "fieldId": "endpoint",
-                    "display": true
-                }
-            ]
-        },
-        {
-            "fieldValue": 0,
-            "mode": "edit",
-            "fieldsToModify": [
-                {
-                    "fieldId": "account_radio",
-                    "disabled": true
-                },
-                {
-                    "fieldId": "endpoint",
-                    "display": false
-                }
-            ]
-        },
-        {
-            "fieldValue": "[[any_other_value]]",
-            "fieldsToModify": [
-                {
-                    "fieldId": "account_radio",
-                    "disabled": true,
-                    "display": true
-                },
-                {
-                    "fieldId": "endpoint",
-                    "display": true,
-                    "display": true
-                }
-            ]
-        }
-    ]
-},
-```
+    ```json
+    {
+        "type": "checkbox",
+        "label": "Example Checkbox",
+        "field": "account_checkbox",
+        "help": "This is an example checkbox for the account entity",
+        "modifyFieldsOnValue": [
+            {
+                "fieldValue": 1,
+                "fieldsToModify": [
+                    {
+                        "fieldId": "account_radio",
+                        "disabled": false
+                    },
+                    {
+                        "fieldId": "endpoint",
+                        "display": true
+                    }
+                ]
+            },
+            {
+                "fieldValue": 0,
+                "mode": "edit",
+                "fieldsToModify": [
+                    {
+                        "fieldId": "account_radio",
+                        "disabled": true
+                    },
+                    {
+                        "fieldId": "endpoint",
+                        "display": false
+                    }
+                ]
+            },
+            {
+                "fieldValue": "[[any_other_value]]",
+                "fieldsToModify": [
+                    {
+                        "fieldId": "account_radio",
+                        "disabled": true,
+                        "display": true
+                    },
+                    {
+                        "fieldId": "endpoint",
+                        "display": true,
+                        "display": true
+                    }
+                ]
+            }
+        ]
+    },
+    ```
 
-</details>


### PR DESCRIPTION
**Issue number:**

### PR Type

**What kind of change does this PR introduce?**
* [ ] Feature
* [ ] Bug Fix
* [ ] Refactoring (no functional or API changes)
* [ ] Documentation Update
* [x] Maintenance (dependency updates, CI, etc.)

## Summary

### Changes

Update documentation of modifications regarding to comments in previous PR.

### User experience
N/A
## Checklist

If an item doesn't apply to your changes, leave it unchecked.

* [ ] I have performed a self-review of this change according to the [development guidelines](https://splunk.github.io/addonfactory-ucc-generator/contributing/#development-guidelines)
* [ ] Tests have been added/modified to cover the changes [(testing doc)](https://splunk.github.io/addonfactory-ucc-generator/contributing/#build-and-test)
* [x] Changes are documented
* [ ] PR title and description follows the [contributing principles](https://splunk.github.io/addonfactory-ucc-generator/contributing/#pull-requests)
