### PR TITLE
fix(validation): correctly display error in save validator fnc

### DIFF
--- a/ui/src/components/BaseFormView/BaseFormView.tsx
+++ b/ui/src/components/BaseFormView/BaseFormView.tsx
@@ -25,6 +25,7 @@ import Group from '../Group/Group';
 import {
     AcceptableFormValueOrNull,
     AcceptableFormValueOrNullish,
+    NullishFormRecord,
 } from '../../types/components/shareableTypes';
 import {
     CustomHookError,
@@ -104,7 +105,7 @@ class BaseFormView extends PureComponent<BaseFormProps, BaseFormState> {
 
     oauthConf?: OauthConfiguration;
 
-    datadict: Record<string, AcceptableFormValueOrNullish>;
+    datadict: NullishFormRecord;
 
     hook?: CustomHookInstance;
 
@@ -514,13 +515,13 @@ class BaseFormView extends PureComponent<BaseFormProps, BaseFormState> {
             string,
             {
                 dependencyValues: {
-                    $set: Record<string, AcceptableFormValueOrNullish>;
+                    $set: NullishFormRecord;
                 };
             }
         > = {};
         Object.keys(flattenedMap).forEach((field) => {
             const values = flattenedMap[field];
-            const data: Record<string, AcceptableFormValueOrNullish> = {};
+            const data: NullishFormRecord = {};
             let load = true;
 
             values.forEach((dependency) => {
@@ -948,7 +949,7 @@ class BaseFormView extends PureComponent<BaseFormProps, BaseFormState> {
             if (this.dependencyMap.has(field)) {
                 const value = this.dependencyMap.get(field);
                 Object.keys(value || {}).forEach((loadField) => {
-                    const data: Record<string, AcceptableFormValueOrNullish> = {};
+                    const data: NullishFormRecord = {};
                     let load = true;
 
                     value?.[loadField].forEach((dependency) => {
@@ -1146,7 +1147,7 @@ class BaseFormView extends PureComponent<BaseFormProps, BaseFormState> {
         const url = baseUrl.toString();
 
         const code = decodeURIComponent(message.code);
-        const data: Record<string, AcceptableFormValueOrNullish> = {
+        const data: NullishFormRecord = {
             method: 'POST',
             url,
             grant_type: 'authorization_code',

--- a/ui/src/types/components/BaseFormTypes.ts
+++ b/ui/src/types/components/BaseFormTypes.ts
@@ -3,6 +3,7 @@ import { Mode } from '../../constants/modes';
 import {
     AcceptableFormValueOrNull,
     AcceptableFormValueOrNullish,
+    NullishFormRecord,
     StandardPages,
 } from './shareableTypes';
 import { MarkdownMessageProps } from '../../components/MarkdownMessage/MarkdownMessage';
@@ -155,5 +156,5 @@ export interface BasicEntity {
 export interface ChangeRecord {
     display?: { $set: boolean };
     value?: { $set: AcceptableFormValueOrNullish };
-    dependencyValues?: { $set: Record<string, AcceptableFormValueOrNullish> };
+    dependencyValues?: { $set: NullishFormRecord };
 }

--- a/ui/src/types/components/CustomHookClass.ts
+++ b/ui/src/types/components/CustomHookClass.ts
@@ -1,6 +1,6 @@
 import { GlobalConfig } from '../globalConfig/globalConfig';
 import { Mode } from '../../constants/modes';
-import { AcceptableFormValueOrNullish } from './shareableTypes';
+import { AcceptableFormValueOrNullish, NullishFormRecord } from './shareableTypes';
 import { BaseFormState, UtilBaseForm } from './BaseFormTypes';
 
 export type CustomHookInstance<T extends typeof CustomHookClass = typeof CustomHookClass> =
@@ -51,9 +51,9 @@ export abstract class CustomHookClass {
 
     onEditLoad?(): void;
 
-    onSave?(datadict?: Record<string, AcceptableFormValueOrNullish>): Promise<boolean>;
+    onSave?(datadict?: NullishFormRecord): Promise<boolean>;
 
-    onSave?(datadict?: Record<string, AcceptableFormValueOrNullish>): boolean;
+    onSave?(datadict?: NullishFormRecord): boolean;
 
     onSaveSuccess?(): void;
 

--- a/ui/src/types/components/shareableTypes.ts
+++ b/ui/src/types/components/shareableTypes.ts
@@ -3,6 +3,7 @@ export type AcceptableFormValueOrNull = AcceptableFormValue | null;
 export type AcceptableFormValueOrNullish = AcceptableFormValueOrNull | undefined;
 
 export type AcceptableFormRecord = Record<string, AcceptableFormValueOrNull>;
+export type NullishFormRecord = Record<string, AcceptableFormValueOrNullish>;
 
 export type StandardPages = 'configuration' | 'inputs';
 export type AllPossiblePages = StandardPages | 'dashboard';

--- a/ui/src/util/Validator.js
+++ b/ui/src/util/Validator.js
@@ -17,21 +17,30 @@ import { getFormattedMessage } from './messageUtil';
  * @property {string} [errorMsg]
  */
 
-const parseFunctionRawStr = (rawStr) => {
-    let err;
+/**
+ * @param {string} rawStr
+ * @returns {{ error:string, result:Function }}
+ */
+export const parseFunctionRawStr = (rawStr) => {
+    let error;
     let result;
 
     try {
         // eslint-disable-next-line no-eval
         result = eval(`(${rawStr})`);
     } catch (e) {
-        err = getFormattedMessage(11, rawStr);
+        error = getFormattedMessage(11, [rawStr]);
     }
 
-    return { err, result };
+    return { error, result };
 };
 
 // Validate provided saveValidator function
+/**
+ * @param {string} validatorFunc
+ * @param {NullishFormRecord} formData
+ * @returns {{ errorMsg: string }}
+ */
 export function SaveValidator(validatorFunc, formData) {
     const { error, result } = parseFunctionRawStr(validatorFunc);
     if (error) {
@@ -43,6 +52,11 @@ export function SaveValidator(validatorFunc, formData) {
     }
 }
 
+/**
+ *
+ * @param {[start: number, end: number]} range
+ * @returns {{ error: string | undefined }}
+ */
 const parseNumberValidator = (range) => {
     const isRangeLegal =
         range.length === 2 && _.isNumber(range[0]) && _.isNumber(range[1]) && range[0] <= range[1];
@@ -52,6 +66,11 @@ const parseNumberValidator = (range) => {
     return { error };
 };
 
+/**
+ *
+ * @param {string} rawStr
+ * @returns {{ error: string | undefined, result: RegExp | undefined }}
+ */
 const parseRegexRawStr = (rawStr) => {
     let error;
     let result;
@@ -67,12 +86,28 @@ const parseRegexRawStr = (rawStr) => {
 };
 
 class Validator {
+    /**
+     * @type {AnyEntity[] | undefined}
+     */
+    entities;
+
+    /**
+     * @type {AnyEntity | undefined}
+     */
+    isName;
+
+    /**
+     * @param {AnyEntity[] | undefined} entities
+     */
     constructor(entities) {
         this.entities = entities;
         this.isName = entities.find((e) => e.field === 'name');
     }
 
-    // eslint-disable-next-line class-methods-use-this
+    /**
+     * @param {AcceptableFormValueOrNullish} attrValue
+     * @returns {boolean}
+     */
     static checkIsFieldHasInput = (attrValue) =>
         attrValue !== undefined &&
         attrValue !== null &&
@@ -156,6 +191,13 @@ class Validator {
     }
 
     // Validate the custom component
+    /**
+     *
+     * @param {*} validatorFunc
+     * @param {string} field
+     * @param {*} data
+     * @returns
+     */
     static CustomValidator(validatorFunc, field, data) {
         const ret = validatorFunc(field, data);
         if (typeof ret === 'string') {
@@ -165,6 +207,16 @@ class Validator {
     }
 
     // Validate the field should match predefined Regexes
+    /**
+     *
+     * @param {string} field
+     * @param {string} label
+     * @param {NumberValidator | StringValidator | RegexValidator | EmailValidator | Ipv4Validator | UrlValidator | DateValidator } validator
+     * @param {AcceptableFormValueOrNullish} data
+     * @param {string} pattern
+     * @param {string} inputValueType
+     * @returns {Error|false}
+     */
     static PreDefinedRegexValidator(field, label, validator, data, pattern, inputValueType) {
         const { error, result: regex } = parseRegexRawStr(pattern);
         if (error) {
@@ -192,7 +244,7 @@ class Validator {
      * @param {string} field
      * @param {string|number} label
      * @param {NumberValidatorOptions} validator
-     * @param {string|number} [data]
+     * @param {NullishFormRecord} data
      * @returns {Error|false}
      */
     // Validate the range of numeric field
@@ -232,6 +284,11 @@ class Validator {
         return false;
     }
 
+    /**
+     *
+     * @param {NullishFormRecord} data
+     * @returns {Error|false}
+     */
     doValidation(data) {
         if (this.isName) {
             const targetValue = data.name;
@@ -262,7 +319,14 @@ class Validator {
         }
 
         let ret;
+
+        /**
+         * @type {number}
+         */
         let i;
+        /**
+         * @type {number}
+         */
         let j;
 
         for (i = 0; i < this.entities.length; i += 1) {


### PR DESCRIPTION
**Issue number:**

### PR Type

**What kind of change does this PR introduce?**
* [ ] Feature
* [x] Bug Fix
* [ ] Refactoring (no functional or API changes)
* [ ] Documentation Update
* [ ] Maintenance (dependency updates, CI, etc.)

## Summary

### Changes

Small change:
instead of 
```
        error = getFormattedMessage(11, rawStr);
```
use rawStr with []
```
        error = getFormattedMessage(11, [rawStr]);
```

+ add js doc types to validation function

### User experience

Display error for incorrect validator correctly

## Checklist

If an item doesn't apply to your changes, leave it unchecked.

* [ ] I have performed a self-review of this change according to the [development guidelines](https://splunk.github.io/addonfactory-ucc-generator/contributing/#development-guidelines)
* [x] Tests have been added/modified to cover the changes [(testing doc)](https://splunk.github.io/addonfactory-ucc-generator/contributing/#build-and-test)
* [ ] Changes are documented
* [x] PR title and description follows the [contributing principles](https://splunk.github.io/addonfactory-ucc-generator/contributing/#pull-requests)
