### PR TITLE
feat: skip help links in inputs.conf.spec

### DIFF
--- a/splunk_add_on_ucc_framework/generators/conf_files/create_inputs_conf.py
+++ b/splunk_add_on_ucc_framework/generators/conf_files/create_inputs_conf.py
@@ -45,8 +45,9 @@ class InputsConf(ConfGenerator):
                     )
                     continue
                 for entity in service.get("entity", {"field": "name"}):
-                    # TODO: add the details and updates on what to skip and process
                     if entity["field"] == "name":
+                        continue
+                    if entity.get("type") == "helpLink":
                         continue
                     nl = "\n"  # hack for `f-string expression part cannot include a backslash`
                     # TODO: enhance the message formation for inputs.conf.spec file

--- a/tests/testdata/expected_addons/expected_output_global_config_everything/Splunk_TA_UCCExample/README/inputs.conf.spec
+++ b/tests/testdata/expected_addons/expected_output_global_config_everything/Splunk_TA_UCCExample/README/inputs.conf.spec
@@ -1,6 +1,5 @@
 [example_input_one://<name>]
-account = 
-example_help_link = 
+account =
 example_textarea_field = Help message
 hard_disabled = 
 hide_in_ui = 
@@ -19,8 +18,7 @@ use_existing_checkpoint = Data input already exists. Select `No` if you want to 
 
 [example_input_two://<name>]
 account = 
-apis = 
-example_help_link = 
+apis =
 hard_disabled = 
 hide_in_ui = 
 index = Default: default

--- a/tests/unit/generators/conf_files/test_create_inputs_conf.py
+++ b/tests/unit/generators/conf_files/test_create_inputs_conf.py
@@ -270,6 +270,13 @@ def test_inputs_conf_content(global_config, input_dir, output_dir, ta_name):
         ).lstrip()
     )
 
+    generated_specs = inputs_conf.generate_conf_spec()
+    assert generated_specs is not None
+    assert generated_specs.keys() == {"inputs.conf.spec"}
+    assert (
+        "example_help_link" not in Path(generated_specs["inputs.conf.spec"]).read_text()
+    )
+
 
 def test_inputs_conf_content_input_with_conf(input_dir, output_dir, ta_name, tmp_path):
     config_content = json.loads(


### PR DESCRIPTION
**Issue number:** [ADDON-78536](https://splunk.atlassian.net/browse/ADDON-78536)

### PR Type

**What kind of change does this PR introduce?**
* [x] Feature
* [ ] Bug Fix
* [ ] Refactoring (no functional or API changes)
* [ ] Documentation Update
* [ ] Maintenance (dependency updates, CI, etc.)

## Summary

### Changes

Help links will no longer be written in inputs.spec files as those parameters cannot be set anyway.

### User experience

Changes in generated spec files but no functionality is changed. I.e. we are skipping parameters that do nothing anyway.

## Checklist

If an item doesn't apply to your changes, leave it unchecked.

* [x] I have performed a self-review of this change according to the [development guidelines](https://splunk.github.io/addonfactory-ucc-generator/contributing/#development-guidelines)
* [x] Tests have been added/modified to cover the changes [(testing doc)](https://splunk.github.io/addonfactory-ucc-generator/contributing/#build-and-test)
* [ ] Changes are documented
* [x] PR title and description follows the [contributing principles](https://splunk.github.io/addonfactory-ucc-generator/contributing/#pull-requests)
