### PR TITLE
revert: "feat: skip help links in inputs.conf.spec"

### DIFF
--- a/splunk_add_on_ucc_framework/generators/conf_files/create_inputs_conf.py
+++ b/splunk_add_on_ucc_framework/generators/conf_files/create_inputs_conf.py
@@ -45,9 +45,8 @@ class InputsConf(ConfGenerator):
                     )
                     continue
                 for entity in service.get("entity", {"field": "name"}):
+                    # TODO: add the details and updates on what to skip and process
                     if entity["field"] == "name":
-                        continue
-                    if entity.get("type") == "helpLink":
                         continue
                     nl = "\n"  # hack for `f-string expression part cannot include a backslash`
                     # TODO: enhance the message formation for inputs.conf.spec file

--- a/tests/testdata/expected_addons/expected_output_global_config_everything/Splunk_TA_UCCExample/README/inputs.conf.spec
+++ b/tests/testdata/expected_addons/expected_output_global_config_everything/Splunk_TA_UCCExample/README/inputs.conf.spec
@@ -1,5 +1,6 @@
 [example_input_one://<name>]
-account =
+account = 
+example_help_link = 
 example_textarea_field = Help message
 hard_disabled = 
 hide_in_ui = 
@@ -18,7 +19,8 @@ use_existing_checkpoint = Data input already exists. Select `No` if you want to 
 
 [example_input_two://<name>]
 account = 
-apis =
+apis = 
+example_help_link = 
 hard_disabled = 
 hide_in_ui = 
 index = Default: default

--- a/tests/unit/generators/conf_files/test_create_inputs_conf.py
+++ b/tests/unit/generators/conf_files/test_create_inputs_conf.py
@@ -270,13 +270,6 @@ def test_inputs_conf_content(global_config, input_dir, output_dir, ta_name):
         ).lstrip()
     )
 
-    generated_specs = inputs_conf.generate_conf_spec()
-    assert generated_specs is not None
-    assert generated_specs.keys() == {"inputs.conf.spec"}
-    assert (
-        "example_help_link" not in Path(generated_specs["inputs.conf.spec"]).read_text()
-    )
-
 
 def test_inputs_conf_content_input_with_conf(input_dir, output_dir, ta_name, tmp_path):
     config_content = json.loads(


### PR DESCRIPTION
Reverts splunk/addonfactory-ucc-generator#1630

The PR was merged due to lack of required checks, this caused test-ui failing in develop