### PR TITLE
chore(button,menu): remove deprecated appearance and icon properties

### DIFF
--- a/ui/src/components/CheckboxGroup/CheckboxGroup.tsx
+++ b/ui/src/components/CheckboxGroup/CheckboxGroup.tsx
@@ -96,12 +96,12 @@ function CheckboxGroup(props: CheckboxGroupProps) {
             <div>
                 <Button
                     label="Select All"
-                    appearance="pill"
+                    appearance="subtle"
                     onClick={() => handleCheckboxToggleAll(true)}
                 />
                 <Button
                     label="Clear All"
-                    appearance="pill"
+                    appearance="subtle"
                     onClick={() => handleCheckboxToggleAll(false)}
                 />
             </div>

--- a/ui/src/components/CheckboxTree/CheckboxTree.tsx
+++ b/ui/src/components/CheckboxTree/CheckboxTree.tsx
@@ -129,12 +129,12 @@ function CheckboxTree(props: CheckboxTreeProps) {
             <div>
                 <Button
                     label="Select All"
-                    appearance="pill"
+                    appearance="subtle"
                     onClick={() => handleCheckboxToggleAll(true)}
                 />
                 <Button
                     label="Clear All"
-                    appearance="pill"
+                    appearance="subtle"
                     onClick={() => handleCheckboxToggleAll(false)}
                 />
             </div>

--- a/ui/src/components/MenuInput/MenuInput.tsx
+++ b/ui/src/components/MenuInput/MenuInput.tsx
@@ -120,7 +120,7 @@ function MenuInput({ handleRequestOpen }: MenuInputProps) {
     const getBackButton = () => (
         <>
             <Menu.Item
-                icon={<ChevronLeft />}
+                startAdornment={<ChevronLeft />}
                 onClick={() => {
                     setActivePanelId(ROOT_GROUP_NAME);
                     setSlidingPanelsTransition('backward');

--- a/ui/src/components/table/CustomTableRow.tsx
+++ b/ui/src/components/table/CustomTableRow.tsx
@@ -82,7 +82,6 @@ function CustomTableRow(props: CustomTableRowProps) {
                     {!props.readonly && rowActions.includes('edit') && (
                         <Tooltip content={_('Edit')}>
                             <ActionButtonComponent
-                                appearance="flat"
                                 aria-label={_('Edit')}
                                 icon={<Pencil />}
                                 onClick={() => handleEditActionClick(selectedRow)}
@@ -93,7 +92,6 @@ function CustomTableRow(props: CustomTableRowProps) {
                     {rowActions.includes('clone') && (
                         <Tooltip content={_('Clone')}>
                             <ActionButtonComponent
-                                appearance="flat"
                                 aria-label={_('Clone')}
                                 icon={<Clone size={1} />}
                                 onClick={() => handleCloneActionClick(selectedRow)}
@@ -111,7 +109,6 @@ function CustomTableRow(props: CustomTableRowProps) {
                                 aria-label={_(
                                     `Go to search for events associated with ${selectedRow.name}`
                                 )}
-                                appearance="flat"
                                 icon={<Magnifier />}
                                 to={`/app/search/search?q=search%20index%3D_internal%20source%3D*${selectedRow.name}*`}
                                 className="searchBtn"
@@ -123,7 +120,6 @@ function CustomTableRow(props: CustomTableRowProps) {
                     {!props.readonly && rowActions.includes('delete') && (
                         <Tooltip content={_('Delete')}>
                             <ActionButtonComponent
-                                appearance="flat"
                                 aria-label={_('Delete')}
                                 icon={<Trash size={1} />}
                                 onClick={() => handleDeleteActionClick(selectedRow)}


### PR DESCRIPTION
**Issue number:** ADDON-78814

### PR Type

**What kind of change does this PR introduce?**
* [ ] Feature
* [ ] Bug Fix
* [ ] Refactoring (no functional or API changes)
* [ ] Documentation Update
* [x] Maintenance (dependency updates, CI, etc.)

## Summary

SUI 5 deprecated some props

### Changes

- icon -> startAdornment for Menu.Item
- removed appearance="flat" since it is deprecated, and it is a default anyway
- "pill" to "subtle"


### User experience

No visual changes

## Checklist

If an item doesn't apply to your changes, leave it unchecked.

### Review

* [x] self-review - I have performed a self-review of this change according to the [development guidelines](https://splunk.github.io/addonfactory-ucc-generator/contributing/#development-guidelines)
* [ ] Changes are documented. The documentation is understandable, examples work [(more info)](https://splunk.github.io/addonfactory-ucc-generator/contributing/#documentation-guidelines)
* [x] PR title and description follows the [contributing principles](https://splunk.github.io/addonfactory-ucc-generator/contributing/#pull-requests)
* [ ] meeting - I have scheduled a meeting or recorded a demo to explain these changes (if there is a video, put a link below and in the ticket)

### Tests

See [the testing doc](https://splunk.github.io/addonfactory-ucc-generator/contributing/#build-and-test).

* [ ] Unit - tests have been added/modified to cover the changes
* [ ] Smoke - tests have been added/modified to cover the changes
* [ ] UI - tests have been added/modified to cover the changes
* [ ] coverage - I have checked the code coverage of my changes [(see more)](https://splunk.github.io/addonfactory-ucc-generator/contributing/#checking-the-code-coverage)

**Demo/meeting:**

*Reviewers are encouraged to request meetings or demos if any part of the change is unclear*
