### PR TITLE
ci(ta-tests): add retry logic poetry install

### DIFF
--- a/.github/workflows/ta-tests.yml
+++ b/.github/workflows/ta-tests.yml
@@ -116,20 +116,39 @@ jobs:
           # https://github.com/python-poetry/poetry/issues/7491#issuecomment-1423763839
           git config --global --add url."https://${{ secrets.GH_TOKEN_ADMIN }}@github.com".insteadOf https://github.com
           git config --global --add url."https://${{ secrets.GH_TOKEN_ADMIN }}@github.com".insteadOf ssh://git@github.com
-          poetry add ../UCC/$UCC_WHL --group dev
           
-          # Install splunktaucclib either from GitHub or PyPI based on input
-          if [[ -n "${{ github.event.inputs.splunktaucclib_branch }}" ]]; then
-            echo "Installing splunktaucclib from branch ${{ github.event.inputs.splunktaucclib_branch }}"
-            poetry add git+https://github.com/splunk/addonfactory-ucc-library.git@${{ github.event.inputs.splunktaucclib_branch }}
-          else
-            echo "Installing latest splunktaucclib from PyPI"
-            poetry add splunktaucclib@latest
-          fi
+          poetry cache clear --all pypi
+          
+          # Retry logic for poetry install
+          MAX_RETRIES=3
+          RETRY_COUNT=0
+          
+          until [ $RETRY_COUNT -ge $MAX_RETRIES ]
+          do
+            poetry add ../UCC/$UCC_WHL --group dev && break
+            RETRY_COUNT=$((RETRY_COUNT+1))
+            echo "Poetry install failed, retry attempt $RETRY_COUNT of $MAX_RETRIES"
+            sleep 5
+          done
+          
+          # Install splunktaucclib with retries
+          RETRY_COUNT=0
+          until [ $RETRY_COUNT -ge $MAX_RETRIES ]
+          do
+            if [[ -n "${{ github.event.inputs.splunktaucclib_branch }}" ]]; then
+              echo "Installing splunktaucclib from branch ${{ github.event.inputs.splunktaucclib_branch }}"
+              poetry add git+https://github.com/splunk/addonfactory-ucc-library.git@${{ github.event.inputs.splunktaucclib_branch }} && break
+            else
+              echo "Installing latest splunktaucclib from PyPI"
+              poetry add splunktaucclib@latest && break
+            fi
+            RETRY_COUNT=$((RETRY_COUNT+1))
+            echo "splunktaucclib install failed, retry attempt $RETRY_COUNT of $MAX_RETRIES"
+            sleep 5
+          done
           
           mkdir -p package/lib
           poetry export --without-hashes -o package/lib/requirements.txt
-
       - name: Run ucc-gen build in Target Add-on
         working-directory: TA
         run: |

--- a/.github/workflows/ta-tests.yml
+++ b/.github/workflows/ta-tests.yml
@@ -117,8 +117,6 @@ jobs:
           git config --global --add url."https://${{ secrets.GH_TOKEN_ADMIN }}@github.com".insteadOf https://github.com
           git config --global --add url."https://${{ secrets.GH_TOKEN_ADMIN }}@github.com".insteadOf ssh://git@github.com
           
-          poetry cache clear --all pypi
-          
           # Retry logic for poetry install
           MAX_RETRIES=3
           RETRY_COUNT=0


### PR DESCRIPTION
**Issue number:**

### PR Type

**What kind of change does this PR introduce?**
* [ ] Feature
* [ ] Bug Fix
* [ ] Refactoring (no functional or API changes)
* [ ] Documentation Update
* [x] Maintenance (dependency updates, CI, etc.)

> [!WARNING]
> Code was generated entirely by GAI

## Summary

This PR enhances the reliability of the TA-tests GitHub Actions workflow by implementing retry logic for Poetry dependency installation commands. These changes address intermittent "Package Not Found" errors that occur during dependency resolution, which previously required manual workflow re-runs.

### Changes

- Added retry logic with a fixed number of attempts to the Poetry dependency installation steps
- Set a maximum of 3 retry attempts for each Poetry command that involves dependency resolution
- Implemented separate retry blocks for UCC framework installation and splunktaucclib installation
- Added short fixed-interval delays between retries to allow for network/CDN stabilization

### User experience

**Before:**
<img width="246" alt="image" src="https://github.com/user-attachments/assets/95db2e00-48f1-4600-b742-ca6da3b4ac6c" />

- CI pipeline would randomly fail with "PackageNotFound" errors for various dependencies
- Required manual intervention to restart the workflow
- Caused delays in the development process and PR reviews
- Error messages were confusing and did not indicate a clear resolution path

**After:**
<img width="241" alt="image" src="https://github.com/user-attachments/assets/0b511d4b-fc92-46db-831c-d43431330290" />

- Automatic retry of failed dependency installation steps
- Reduced frequency of workflow failures due to transient network/PyPI issues
- Clear error messages if all retry attempts are exhausted
- More reliable CI pipeline with fewer manual interventions needed
- Developers can focus on addressing actual code issues rather than CI infrastructure problems

## Checklist

If an item doesn't apply to your changes, leave it unchecked.

### Review

* [x] self-review - I have performed a self-review of this change according to the [development guidelines](https://splunk.github.io/addonfactory-ucc-generator/contributing/#development-guidelines)
* [ ] Changes are documented. The documentation is understandable, examples work [(more info)](https://splunk.github.io/addonfactory-ucc-generator/contributing/#documentation-guidelines)
* [x] PR title and description follows the [contributing principles](https://splunk.github.io/addonfactory-ucc-generator/contributing/#pull-requests)
* [ ] meeting - I have scheduled a meeting or recorded a demo to explain these changes (if there is a video, put a link below and in the ticket)

### Tests

See [the testing doc](https://splunk.github.io/addonfactory-ucc-generator/contributing/#build-and-test).

* [ ] Unit - tests have been added/modified to cover the changes
* [ ] Smoke - tests have been added/modified to cover the changes
* [ ] UI - tests have been added/modified to cover the changes
* [ ] coverage - I have checked the code coverage of my changes [(see more)](https://splunk.github.io/addonfactory-ucc-generator/contributing/#checking-the-code-coverage)

**Demo/meeting:**

*Reviewers are encouraged to request meetings or demos if any part of the change is unclear*
