### PR TITLE
refactor: introduce GlobalConfig.from_file method to init GlobalConfig

### DIFF
--- a/splunk_add_on_ucc_framework/commands/build.py
+++ b/splunk_add_on_ucc_framework/commands/build.py
@@ -444,7 +444,7 @@ def generate(
     gc_path = _get_and_check_global_config_path(source, config_path)
     if gc_path:
         logger.info(f"Using globalConfig file located @ {gc_path}")
-        global_config = global_config_lib.GlobalConfig(gc_path)
+        global_config = global_config_lib.GlobalConfig.from_file(gc_path)
         global_config.cleanup_unwanted_params()
         # handle the update of globalConfig before validating
         global_config_update.handle_global_config_update(global_config)

--- a/splunk_add_on_ucc_framework/global_config.py
+++ b/splunk_add_on_ucc_framework/global_config.py
@@ -60,19 +60,26 @@ class OSDependentLibraryConfig:
 
 
 class GlobalConfig:
-    def __init__(self, global_config_path: str) -> None:
+    def __init__(
+        self,
+        content: Dict[str, Any],
+        is_yaml: bool,
+        original_path: str,
+    ) -> None:
+        self._content = content
+        self._is_global_config_yaml = is_yaml
+        self._original_path = original_path
+        self.user_defined_handlers = UserDefinedRestHandlers()
+
+    @classmethod
+    def from_file(cls, global_config_path: str) -> "GlobalConfig":
         with open(global_config_path) as f_config:
             config_raw = f_config.read()
-        self._is_global_config_yaml = (
-            True if global_config_path.endswith(".yaml") else False
+        is_global_config_yaml = True if global_config_path.endswith(".yaml") else False
+        content = (
+            yaml_load(config_raw) if is_global_config_yaml else json.loads(config_raw)
         )
-        self._content = (
-            yaml_load(config_raw)
-            if self._is_global_config_yaml
-            else json.loads(config_raw)
-        )
-        self._original_path = global_config_path
-        self.user_defined_handlers = UserDefinedRestHandlers()
+        return GlobalConfig(content, is_global_config_yaml, global_config_path)
 
     def parse_user_defined_handlers(self) -> None:
         """Parse user-defined REST handlers from globalConfig["options"]["restHandlers"]"""

--- a/tests/unit/commands/rest_builder/test_generate_import_declare_test.py
+++ b/tests/unit/commands/rest_builder/test_generate_import_declare_test.py
@@ -46,7 +46,7 @@ def test_generate_import_declare_test_with_os_lib(tmp_path):
     global_config_path = helpers.get_testdata_file_path(
         "valid_config_with_os_libraries.json"
     )
-    global_config = gc.GlobalConfig(global_config_path)
+    global_config = gc.GlobalConfig.from_file(global_config_path)
 
     tmp_lib_path = tmp_path / "output"
     run_rest_builder_build(global_config, tmp_lib_path)
@@ -60,7 +60,7 @@ def test_generate_import_declare_test_without_os_lib(tmp_path):
     global_config_path = helpers.get_testdata_file_path(
         "valid_config_only_configuration.json"
     )
-    global_config = gc.GlobalConfig(global_config_path)
+    global_config = gc.GlobalConfig.from_file(global_config_path)
 
     tmp_lib_path = tmp_path / "output"
     run_rest_builder_build(global_config, tmp_lib_path)

--- a/tests/unit/commands/test_build.py
+++ b/tests/unit/commands/test_build.py
@@ -96,7 +96,7 @@ def test_add_modular_input(GlobalConfig, tmp_path):
     (tmp_path / ta_name / "bin").mkdir(parents=True)
     (tmp_path / ta_name / "default").mkdir(parents=True)
 
-    gc = GlobalConfig("", False)
+    gc = GlobalConfig.from_file("", False)
     gc.inputs = [
         {
             "name": "example_input_three",

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -33,7 +33,7 @@ def ta_name():
 
 @pytest.fixture
 def global_config_for_alerts():
-    return global_config_lib.GlobalConfig(
+    return global_config_lib.GlobalConfig.from_file(
         helpers.get_testdata_file_path("valid_config_all_alerts.json")
     )
 
@@ -54,13 +54,13 @@ def global_config_all_json_content():
 @pytest.fixture
 def global_config_all_json() -> global_config_lib.GlobalConfig:
     global_config_path = helpers.get_testdata_file_path("valid_config.json")
-    global_config = global_config_lib.GlobalConfig(global_config_path)
+    global_config = global_config_lib.GlobalConfig.from_file(global_config_path)
     return global_config
 
 
 @pytest.fixture
 def global_config_no_configuration() -> global_config_lib.GlobalConfig:
-    return global_config_lib.GlobalConfig(
+    return global_config_lib.GlobalConfig.from_file(
         helpers.get_testdata_file_path("global_config_no_configuration.json")
     )
 
@@ -68,7 +68,7 @@ def global_config_no_configuration() -> global_config_lib.GlobalConfig:
 @pytest.fixture
 def global_config_all_yaml() -> global_config_lib.GlobalConfig:
     global_config_path = helpers.get_testdata_file_path("valid_config.yaml")
-    global_config = global_config_lib.GlobalConfig(global_config_path)
+    global_config = global_config_lib.GlobalConfig.from_file(global_config_path)
     return global_config
 
 
@@ -77,7 +77,7 @@ def global_config_only_configuration() -> global_config_lib.GlobalConfig:
     global_config_path = helpers.get_testdata_file_path(
         "valid_config_only_configuration.json"
     )
-    global_config = global_config_lib.GlobalConfig(global_config_path)
+    global_config = global_config_lib.GlobalConfig.from_file(global_config_path)
     return global_config
 
 
@@ -86,7 +86,7 @@ def global_config_for_conf_only_TA() -> global_config_lib.GlobalConfig:
     global_config_path = helpers.get_testdata_file_path(
         "valid_global_config_conf_only_TA.json"
     )
-    global_config = global_config_lib.GlobalConfig(global_config_path)
+    global_config = global_config_lib.GlobalConfig.from_file(global_config_path)
     return global_config
 
 
@@ -95,7 +95,7 @@ def global_config_only_logging() -> global_config_lib.GlobalConfig:
     global_config_path = helpers.get_testdata_file_path(
         "valid_config_only_logging.json"
     )
-    global_config = global_config_lib.GlobalConfig(global_config_path)
+    global_config = global_config_lib.GlobalConfig.from_file(global_config_path)
     return global_config
 
 
@@ -104,7 +104,7 @@ def global_config_multiple_account() -> global_config_lib.GlobalConfig:
     global_config_path = helpers.get_testdata_file_path(
         "valid_config_multiple_account.json"
     )
-    global_config = global_config_lib.GlobalConfig(global_config_path)
+    global_config = global_config_lib.GlobalConfig.from_file(global_config_path)
     return global_config
 
 
@@ -113,7 +113,7 @@ def global_config_single_authentication() -> global_config_lib.GlobalConfig:
     global_config_path = helpers.get_testdata_file_path(
         "valid_single_authentication_config.json"
     )
-    global_config = global_config_lib.GlobalConfig(global_config_path)
+    global_config = global_config_lib.GlobalConfig.from_file(global_config_path)
     return global_config
 
 

--- a/tests/unit/generators/conf_files/test_create_account_conf_spec.py
+++ b/tests/unit/generators/conf_files/test_create_account_conf_spec.py
@@ -9,7 +9,7 @@ TA_NAME = "test_addon"
 
 @fixture
 def global_config():
-    gc = GlobalConfig(get_testdata_file_path("valid_config.json"))
+    gc = GlobalConfig.from_file(get_testdata_file_path("valid_config.json"))
     gc._content["meta"]["restRoot"] = TA_NAME
     return gc
 

--- a/tests/unit/generators/conf_files/test_create_inputs_conf.py
+++ b/tests/unit/generators/conf_files/test_create_inputs_conf.py
@@ -322,7 +322,7 @@ def test_inputs_conf_content_input_with_conf(input_dir, output_dir, ta_name, tmp
     config.write_text(json.dumps(config_content))
 
     inputs_conf = InputsConf(
-        GlobalConfig(str(config)),
+        GlobalConfig.from_file(str(config)),
         input_dir,
         output_dir,
         ucc_dir=UCC_DIR,

--- a/tests/unit/generators/conf_files/test_create_settings_conf.py
+++ b/tests/unit/generators/conf_files/test_create_settings_conf.py
@@ -9,7 +9,7 @@ TA_NAME = "test_addon"
 
 @fixture
 def global_config():
-    gc = GlobalConfig(get_testdata_file_path("valid_config.json"))
+    gc = GlobalConfig.from_file(get_testdata_file_path("valid_config.json"))
     gc._content["meta"]["restRoot"] = TA_NAME
     return gc
 

--- a/tests/unit/test_dashboard.py
+++ b/tests/unit/test_dashboard.py
@@ -63,7 +63,7 @@ def setup(tmp_path):
     global_config_path = helpers.get_testdata_file_path(
         "valid_config_with_custom_dashboard.json"
     )
-    global_config = gc.GlobalConfig(global_config_path)
+    global_config = gc.GlobalConfig.from_file(global_config_path)
     tmp_ta_path = tmp_path / "test_ta"
     os.makedirs(tmp_ta_path)
     custom_dash_path = os.path.join(tmp_ta_path, "custom_dashboard.json")
@@ -106,7 +106,7 @@ def test_generate_dashboard_only_custom_components(setup, tmp_path):
     global_config_path = helpers.get_testdata_file_path(
         "valid_config_only_custom_dashboard.json"
     )
-    global_config = gc.GlobalConfig(global_config_path)
+    global_config = gc.GlobalConfig.from_file(global_config_path)
 
     with open(custom_dash_path, "w") as file:
         file.write(json.dumps(custom_definition))

--- a/tests/unit/test_global_config.py
+++ b/tests/unit/test_global_config.py
@@ -20,7 +20,7 @@ from splunk_add_on_ucc_framework import global_config as global_config_lib
 )
 def test_global_config_parse(filename):
     global_config_path = helpers.get_testdata_file_path(filename)
-    global_config = global_config_lib.GlobalConfig(global_config_path)
+    global_config = global_config_lib.GlobalConfig.from_file(global_config_path)
 
     assert global_config.namespace == "splunk_ta_uccexample"
     assert global_config.product == "Splunk_TA_UCCExample"
@@ -102,7 +102,7 @@ def test_global_config_update_addon_version(global_config_only_configuration):
 def test_global_config_expand(tmp_path):
     global_config_path = helpers.get_testdata_file_path("valid_config_expand.json")
 
-    global_config = global_config_lib.GlobalConfig(global_config_path)
+    global_config = global_config_lib.GlobalConfig.from_file(global_config_path)
 
     assert {"type": "loggingTab"} in global_config.configuration
     assert count_tabs(global_config, name="logging") == 0
@@ -130,7 +130,7 @@ def test_global_config_cleanup_unwanted_params(global_config_only_logging, tmp_p
     with open(new_path, "w") as fp:
         json.dump(content, fp)
 
-    global_config = global_config_lib.GlobalConfig(new_path)
+    global_config = global_config_lib.GlobalConfig.from_file(new_path)
 
     assert global_config.content["meta"].get("_uccVersion") == "1.0.0"
 
@@ -141,7 +141,7 @@ def test_global_config_cleanup_unwanted_params(global_config_only_logging, tmp_p
 
 def test_global_config_add_ucc_version(global_config_only_logging, tmp_path):
     global_config_path = helpers.get_testdata_file_path("valid_config.json")
-    global_config = global_config_lib.GlobalConfig(global_config_path)
+    global_config = global_config_lib.GlobalConfig.from_file(global_config_path)
 
     assert "_uccVersion" not in global_config.content["meta"]
     global_config.add_ucc_version("1.0.0")

--- a/tests/unit/test_global_config_update.py
+++ b/tests/unit/test_global_config_update.py
@@ -40,7 +40,7 @@ def test_version_tuple(version, expected):
 )
 def test_handle_biased_terms_update(filename):
     global_config_path = helpers.get_testdata_file_path(filename)
-    global_config = global_config_lib.GlobalConfig(global_config_path)
+    global_config = global_config_lib.GlobalConfig.from_file(global_config_path)
     _handle_biased_terms_update(global_config)
     expected_schema_version = "0.0.1"
     assert expected_schema_version == global_config.schema_version
@@ -71,7 +71,7 @@ def test_handle_biased_terms_update(filename):
 )
 def test_handle_dropping_api_version_update(filename):
     global_config_path = helpers.get_testdata_file_path(filename)
-    global_config = global_config_lib.GlobalConfig(global_config_path)
+    global_config = global_config_lib.GlobalConfig.from_file(global_config_path)
     _handle_dropping_api_version_update(global_config)
     expected_schema_version = "0.0.3"
     assert expected_schema_version == global_config.schema_version
@@ -82,7 +82,7 @@ def test_handle_alert_action_updates(tmp_path, caplog):
     tmp_file_gc = tmp_path / "globalConfig.json"
     # a new globalConfig with minimal configs for input and configuration
     helpers.copy_testdata_gc_to_tmp_file(tmp_file_gc, "valid_config_all_alerts.json")
-    global_config = global_config_lib.GlobalConfig(str(tmp_file_gc))
+    global_config = global_config_lib.GlobalConfig.from_file(str(tmp_file_gc))
 
     _handle_alert_action_updates(global_config)
 
@@ -111,7 +111,7 @@ def test_migrate_old_dashboard(tmp_path, caplog):
     tmp_file_gc = tmp_path / "globalConfig.json"
     helpers.copy_testdata_gc_to_tmp_file(tmp_file_gc, "valid_config_old_dashboard.json")
 
-    global_config = global_config_lib.GlobalConfig(str(tmp_file_gc))
+    global_config = global_config_lib.GlobalConfig.from_file(str(tmp_file_gc))
     _handle_xml_dashboard_update(global_config)
 
     expected_schema_version = "0.0.5"
@@ -132,7 +132,7 @@ def test_tab_migration(tmp_path):
     helpers.copy_testdata_gc_to_tmp_file(tmp_file_gc, "valid_config_only_logging.json")
     assert "loggingTab" not in tmp_file_gc.read_text()
 
-    global_config = global_config_lib.GlobalConfig(str(tmp_file_gc))
+    global_config = global_config_lib.GlobalConfig.from_file(str(tmp_file_gc))
     _dump_with_migrated_tabs(global_config, global_config.original_path)
 
     assert "loggingTab" in tmp_file_gc.read_text()
@@ -153,7 +153,7 @@ def test_entity_migration(tmp_path):
     )
     assert '"type": "interval"' not in tmp_file_gc.read_text()
 
-    global_config = global_config_lib.GlobalConfig(str(tmp_file_gc))
+    global_config = global_config_lib.GlobalConfig.from_file(str(tmp_file_gc))
     _dump_with_migrated_entities(
         global_config, global_config.original_path, [IntervalEntity]
     )
@@ -189,7 +189,7 @@ def test_config_validation_when_placeholder_is_absent(tmp_path, caplog):
     tmp_file_gc = tmp_path / "globalConfig.json"
 
     helpers.copy_testdata_gc_to_tmp_file(tmp_file_gc, "valid_config.json")
-    global_config = global_config_lib.GlobalConfig(str(tmp_file_gc))
+    global_config = global_config_lib.GlobalConfig.from_file(str(tmp_file_gc))
     expected_schema_version = "0.0.8"
 
     _stop_build_on_placeholder_usage(global_config)
@@ -204,7 +204,7 @@ def test_config_validation_when_placeholder_is_present(tmp_path, caplog):
     helpers.copy_testdata_gc_to_tmp_file(
         tmp_file_gc, "valid_config_renounced_placeholder_usage.json"
     )
-    global_config = global_config_lib.GlobalConfig(str(tmp_file_gc))
+    global_config = global_config_lib.GlobalConfig.from_file(str(tmp_file_gc))
     error_log = (
         "`placeholder` option found for input service 'example_input_one' -> entity field 'name'. "
         "We recommend to use `help` instead (https://splunk.github.io/addonfactory-ucc-generator/entity/)."
@@ -229,7 +229,7 @@ def test_dump_enable_from_global_config_enable_present(tmp_path, caplog):
     helpers.copy_testdata_gc_to_tmp_file(
         tmp_file_gc, "valid_config_input_with_enable_action.json"
     )
-    global_config = global_config_lib.GlobalConfig(str(tmp_file_gc))
+    global_config = global_config_lib.GlobalConfig.from_file(str(tmp_file_gc))
     expected_schema_version = "0.0.9"
 
     _dump_enable_from_global_config(global_config)
@@ -242,7 +242,7 @@ def test_dump_enable_from_global_config_enable_absent(tmp_path, caplog):
     tmp_file_gc = tmp_path / "globalConfig.yaml"
 
     helpers.copy_testdata_gc_to_tmp_file(tmp_file_gc, "valid_config.yaml")
-    global_config = global_config_lib.GlobalConfig(str(tmp_file_gc))
+    global_config = global_config_lib.GlobalConfig.from_file(str(tmp_file_gc))
     expected_schema_version = "0.0.9"
 
     _dump_enable_from_global_config(global_config)
@@ -255,7 +255,7 @@ def test_handle_global_config_update_when_valid_config(tmp_path):
     tmp_file_gc = tmp_path / "globalConfig.json"
 
     helpers.copy_testdata_gc_to_tmp_file(tmp_file_gc, "valid_config.json")
-    global_config = global_config_lib.GlobalConfig(str(tmp_file_gc))
+    global_config = global_config_lib.GlobalConfig.from_file(str(tmp_file_gc))
     expected_schema_version = "0.0.9"
 
     handle_global_config_update(global_config)

--- a/tests/unit/test_global_config_validator.py
+++ b/tests/unit/test_global_config_validator.py
@@ -27,7 +27,7 @@ from splunk_add_on_ucc_framework import global_config as global_config_lib
 )
 def test_config_validation_when_valid(filename):
     global_config_path = helpers.get_testdata_file_path(filename)
-    global_config = global_config_lib.GlobalConfig(global_config_path)
+    global_config = global_config_lib.GlobalConfig.from_file(global_config_path)
 
     validator = GlobalConfigValidator(helpers.get_path_to_source_dir(), global_config)
 
@@ -40,7 +40,7 @@ def test_autocompletefields_support_integer_values():
     global_config_path = helpers.get_testdata_file_path(
         "invalid_config_configuration_autoCompleteFields_integer_values.json"
     )
-    global_config = global_config_lib.GlobalConfig(global_config_path)
+    global_config = global_config_lib.GlobalConfig.from_file(global_config_path)
 
     validator = GlobalConfigValidator(helpers.get_path_to_source_dir(), global_config)
 
@@ -53,7 +53,7 @@ def test_autocompletefields_children_support_integer_values():
     global_config_path = helpers.get_testdata_file_path(
         "invalid_config_configuration_autoCompleteFields_children_integer_values.json"
     )
-    global_config = global_config_lib.GlobalConfig(global_config_path)
+    global_config = global_config_lib.GlobalConfig.from_file(global_config_path)
 
     validator = GlobalConfigValidator(helpers.get_path_to_source_dir(), global_config)
 
@@ -334,7 +334,7 @@ def test_autocompletefields_children_support_integer_values():
 )
 def test_config_validation_when_error(filename, exception_message):
     global_config_path = helpers.get_testdata_file_path(filename)
-    global_config = global_config_lib.GlobalConfig(global_config_path)
+    global_config = global_config_lib.GlobalConfig.from_file(global_config_path)
 
     validator = GlobalConfigValidator(helpers.get_path_to_source_dir(), global_config)
     with pytest.raises(GlobalConfigValidatorException) as exc_info:
@@ -348,7 +348,7 @@ def test_config_validation_modifications_on_change():
     global_config_path = helpers.get_testdata_file_path(
         "valid_config_with_modification_on_value_change.json"
     )
-    global_config = global_config_lib.GlobalConfig(global_config_path)
+    global_config = global_config_lib.GlobalConfig.from_file(global_config_path)
 
     validator = GlobalConfigValidator(helpers.get_path_to_source_dir(), global_config)
 
@@ -375,7 +375,7 @@ def test_config_validation_modifications_on_change():
 )
 def test_invalid_config_modifications_correct_raises(filename, raise_message):
     global_config_path = helpers.get_testdata_file_path(filename)
-    global_config = global_config_lib.GlobalConfig(global_config_path)
+    global_config = global_config_lib.GlobalConfig.from_file(global_config_path)
 
     validator = GlobalConfigValidator(helpers.get_path_to_source_dir(), global_config)
 
@@ -399,7 +399,7 @@ def test_validate_against_schema_regardless_of_the_default_encoding(
         return open._old(*args, **kwargs)
 
     global_config_path = helpers.get_testdata_file_path("valid_config.json")
-    global_config = global_config_lib.GlobalConfig(global_config_path)
+    global_config = global_config_lib.GlobalConfig.from_file(global_config_path)
 
     validator = GlobalConfigValidator(helpers.get_path_to_source_dir(), global_config)
     validator._validate_config_against_schema()
@@ -609,7 +609,7 @@ def test_config_validation_status_toggle_confirmation():
     global_config_path = helpers.get_testdata_file_path(
         "valid_config_with_input_status_confirmation.json"
     )
-    global_config = global_config_lib.GlobalConfig(global_config_path)
+    global_config = global_config_lib.GlobalConfig.from_file(global_config_path)
 
     validator = GlobalConfigValidator(helpers.get_path_to_source_dir(), global_config)
 

--- a/tests/unit/test_install_python_libraries.py
+++ b/tests/unit/test_install_python_libraries.py
@@ -293,7 +293,7 @@ def test_install_python_libraries_invalid_os_libraries(
     global_config_path = helpers.get_testdata_file_path(
         "valid_config_with_invalid_os_libraries.json"
     )
-    global_config = gc.GlobalConfig(global_config_path)
+    global_config = gc.GlobalConfig.from_file(global_config_path)
 
     tmp_ucc_lib_target = tmp_path / "ucc-lib-target"
     tmp_lib_path = tmp_path / "lib"
@@ -324,7 +324,7 @@ def test_install_libraries_valid_os_libraries(
     global_config_path = helpers.get_testdata_file_path(
         "valid_config_with_os_libraries.json"
     )
-    global_config = gc.GlobalConfig(global_config_path)
+    global_config = gc.GlobalConfig.from_file(global_config_path)
     mock_subprocess_run.side_effect = [
         MockSubprocessResult(0),  # mock subprocess.run from _pip_install
         MockSubprocessResult(0),  # mock subprocess.run from _pip_install
@@ -419,7 +419,7 @@ def test_install_libraries_version_mismatch(
     global_config_path = helpers.get_testdata_file_path(
         "valid_config_with_os_libraries.json"
     )
-    global_config = gc.GlobalConfig(global_config_path)
+    global_config = gc.GlobalConfig.from_file(global_config_path)
 
     tmp_ucc_lib_target = tmp_path / "ucc-lib-target"
     ucc_lib_target = str(tmp_ucc_lib_target)


### PR DESCRIPTION
**Issue number:** ADDON-78488

### PR Type

**What kind of change does this PR introduce?**
* [ ] Feature
* [ ] Bug Fix
* [x] Refactoring (no functional or API changes)
* [ ] Documentation Update
* [ ] Maintenance (dependency updates, CI, etc.)

## Summary

### Changes

This PR introduces a new method to initialize `GlobalConfig` instance - `from_file`. It accepts a path to the globalConfig file (can be JSON or YAML) and returns an instance of `GlobalConfig`.

It's a preparation work for #1625 PR.

### User experience

N/A

## Checklist

If an item doesn't apply to your changes, leave it unchecked.

### Review

* [x] self-review - I have performed a self-review of this change according to the [development guidelines](https://splunk.github.io/addonfactory-ucc-generator/contributing/#development-guidelines)
* [ ] Changes are documented. The documentation is understandable, examples work [(more info)](https://splunk.github.io/addonfactory-ucc-generator/contributing/#documentation-guidelines)
* [x] PR title and description follows the [contributing principles](https://splunk.github.io/addonfactory-ucc-generator/contributing/#pull-requests)
* [ ] meeting - I have scheduled a meeting or recorded a demo to explain these changes (if there is a video, put a link below and in the ticket)

### Tests

See [the testing doc](https://splunk.github.io/addonfactory-ucc-generator/contributing/#build-and-test).

* [x] Unit - tests have been added/modified to cover the changes
* [ ] Smoke - tests have been added/modified to cover the changes
* [ ] UI - tests have been added/modified to cover the changes
* [ ] coverage - I have checked the code coverage of my changes [(see more)](https://splunk.github.io/addonfactory-ucc-generator/contributing/#checking-the-code-coverage)

**Demo/meeting:**

*Reviewers are encouraged to request meetings or demos if any part of the change is unclear*
