### PR TITLE
refactor: remove original_path parameter from GlobalConfig

### DIFF
--- a/splunk_add_on_ucc_framework/commands/build.py
+++ b/splunk_add_on_ucc_framework/commands/build.py
@@ -447,7 +447,7 @@ def generate(
         global_config = global_config_lib.GlobalConfig.from_file(gc_path)
         global_config.cleanup_unwanted_params()
         # handle the update of globalConfig before validating
-        global_config_update.handle_global_config_update(global_config)
+        global_config_update.handle_global_config_update(global_config, gc_path)
         try:
             validator = global_config_validator.GlobalConfigValidator(
                 internal_root_dir, global_config
@@ -458,7 +458,7 @@ def generate(
             logger.error(f"globalConfig file is not valid. Error: {e}")
             sys.exit(1)
         global_config.update_addon_version(addon_version)
-        global_config.dump(global_config.original_path)
+        global_config.dump(gc_path)
         logger.info(
             f"Updated and saved add-on version in the globalConfig file to {addon_version}"
         )
@@ -553,7 +553,7 @@ def generate(
                 "custom",
             )
             dashboard.generate_dashboard(
-                global_config, ta_name, dashboard_definition_json_path
+                global_config, gc_path, ta_name, dashboard_definition_json_path
             )
 
     else:

--- a/splunk_add_on_ucc_framework/dashboard.py
+++ b/splunk_add_on_ucc_framework/dashboard.py
@@ -333,6 +333,7 @@ def generate_dashboard_content(
 
 def generate_dashboard(
     global_config: global_config_lib.GlobalConfig,
+    global_config_path: str,
     addon_name: str,
     definition_json_path: str,
 ) -> None:
@@ -366,7 +367,7 @@ def generate_dashboard(
     if PANEL_CUSTOM in panel_names:
         dashboard_components_path = os.path.abspath(
             os.path.join(
-                global_config.original_path,
+                global_config_path,
                 os.pardir,
                 "custom_dashboard.json",
             )

--- a/splunk_add_on_ucc_framework/global_config.py
+++ b/splunk_add_on_ucc_framework/global_config.py
@@ -64,11 +64,9 @@ class GlobalConfig:
         self,
         content: Dict[str, Any],
         is_yaml: bool,
-        original_path: str,
     ) -> None:
         self._content = content
         self._is_global_config_yaml = is_yaml
-        self._original_path = original_path
         self.user_defined_handlers = UserDefinedRestHandlers()
 
     @classmethod
@@ -79,7 +77,7 @@ class GlobalConfig:
         content = (
             yaml_load(config_raw) if is_global_config_yaml else json.loads(config_raw)
         )
-        return GlobalConfig(content, is_global_config_yaml, global_config_path)
+        return GlobalConfig(content, is_global_config_yaml)
 
     def parse_user_defined_handlers(self) -> None:
         """Parse user-defined REST handlers from globalConfig["options"]["restHandlers"]"""
@@ -201,10 +199,6 @@ class GlobalConfig:
     @property
     def ucc_version(self) -> str:
         return self.meta["_uccVersion"]
-
-    @property
-    def original_path(self) -> str:
-        return self._original_path
 
     @property
     def schema_version(self) -> Optional[str]:

--- a/splunk_add_on_ucc_framework/global_config_update.py
+++ b/splunk_add_on_ucc_framework/global_config_update.py
@@ -77,7 +77,9 @@ def _handle_dropping_api_version_update(
     global_config.update_schema_version("0.0.3")
 
 
-def _handle_alert_action_updates(global_config: global_config_lib.GlobalConfig) -> None:
+def _handle_alert_action_updates(
+    global_config: global_config_lib.GlobalConfig, global_config_path: str
+) -> None:
     if global_config.has_alerts():
         updated_alerts = []
         for alert in global_config.alerts:
@@ -98,11 +100,13 @@ def _handle_alert_action_updates(global_config: global_config_lib.GlobalConfig) 
             # in either case, we create a new list and fill it with updated alerts, if any
             updated_alerts.append(modified_alert)
         global_config._content["alerts"] = updated_alerts
-        global_config.dump(global_config.original_path)
+        global_config.dump(global_config_path)
     global_config.update_schema_version("0.0.4")
 
 
-def _handle_xml_dashboard_update(global_config: global_config_lib.GlobalConfig) -> None:
+def _handle_xml_dashboard_update(
+    global_config: global_config_lib.GlobalConfig, global_config_path: str
+) -> None:
     panels_to_migrate = [
         "addon_version",
         "events_ingested_by_sourcetype",
@@ -117,11 +121,13 @@ def _handle_xml_dashboard_update(global_config: global_config_lib.GlobalConfig) 
                 f"Instead, use just one panel: \"'name': 'default'\""
             )
             global_config.dashboard["panels"] = [{"name": "default"}]
-            global_config.dump(global_config.original_path)
+            global_config.dump(global_config_path)
     global_config.update_schema_version("0.0.5")
 
 
-def handle_global_config_update(global_config: global_config_lib.GlobalConfig) -> None:
+def handle_global_config_update(
+    global_config: global_config_lib.GlobalConfig, global_config_path: str
+) -> None:
     """Handle changes in globalConfig file."""
     version = global_config.schema_version or "0.0.0"
     logger.info(f"Current globalConfig schema version is {version}")
@@ -147,7 +153,7 @@ def handle_global_config_update(global_config: global_config_lib.GlobalConfig) -
 
     if _version_tuple(version) < _version_tuple("0.0.1"):
         _handle_biased_terms_update(global_config)
-        global_config.dump(global_config.original_path)
+        global_config.dump(global_config_path)
         logger.info("Updated globalConfig schema to version 0.0.1")
 
     if _version_tuple(version) < _version_tuple("0.0.2"):
@@ -213,44 +219,44 @@ def handle_global_config_update(global_config: global_config_lib.GlobalConfig) -
                     )
                     del service_options["onLoad"]
         global_config.update_schema_version("0.0.2")
-        global_config.dump(global_config.original_path)
+        global_config.dump(global_config_path)
         logger.info("Updated globalConfig schema to version 0.0.2")
 
     if _version_tuple(version) < _version_tuple("0.0.3"):
         _handle_dropping_api_version_update(global_config)
-        global_config.dump(global_config.original_path)
+        global_config.dump(global_config_path)
         logger.info("Updated globalConfig schema to version 0.0.3")
 
     if _version_tuple(version) < _version_tuple("0.0.4"):
-        _handle_alert_action_updates(global_config)
-        global_config.dump(global_config.original_path)
+        _handle_alert_action_updates(global_config, global_config_path)
+        global_config.dump(global_config_path)
         logger.info("Updated globalConfig schema to version 0.0.4")
 
     if _version_tuple(version) < _version_tuple("0.0.5"):
-        _handle_xml_dashboard_update(global_config)
-        global_config.dump(global_config.original_path)
+        _handle_xml_dashboard_update(global_config, global_config_path)
+        global_config.dump(global_config_path)
         logger.info("Updated globalConfig schema to version 0.0.5")
 
     if _version_tuple(version) < _version_tuple("0.0.6"):
         global_config.update_schema_version("0.0.6")
-        _dump_with_migrated_tabs(global_config, global_config.original_path)
+        _dump_with_migrated_tabs(global_config, global_config_path)
         logger.info("Updated globalConfig schema to version 0.0.6")
 
     if _version_tuple(version) < _version_tuple("0.0.7"):
         global_config.update_schema_version("0.0.7")
         _dump_with_migrated_entities(
-            global_config, global_config.original_path, [IntervalEntity]
+            global_config, global_config_path, [IntervalEntity]
         )
         logger.info("Updated globalConfig schema to version 0.0.7")
 
     if _version_tuple(version) < _version_tuple("0.0.8"):
         _stop_build_on_placeholder_usage(global_config)
-        global_config.dump(global_config.original_path)
+        global_config.dump(global_config_path)
         logger.info("Updated globalConfig schema to version 0.0.8")
 
     if _version_tuple(version) < _version_tuple("0.0.9"):
         _dump_enable_from_global_config(global_config)
-        global_config.dump(global_config.original_path)
+        global_config.dump(global_config_path)
         logger.info("Updated globalConfig schema to version 0.0.9")
 
 

--- a/tests/testdata/test_addons/package_conf_only_TA/globalConfig.json
+++ b/tests/testdata/test_addons/package_conf_only_TA/globalConfig.json
@@ -2,7 +2,7 @@
     "meta": {
         "name": "Splunk_TA_UCCExample",
         "restRoot": "splunk_ta_uccexample",
-        "version": "5.56.0+09ad75911",
+        "version": "5.60.0+34ad0cb7a",
         "displayName": "Splunk UCC test Add-on",
         "schemaVersion": "0.0.9"
     }

--- a/tests/testdata/test_addons/package_files_conflict_test/globalConfig.json
+++ b/tests/testdata/test_addons/package_files_conflict_test/globalConfig.json
@@ -199,7 +199,7 @@
     "meta": {
         "name": "test_addon",
         "restRoot": "test_addon",
-        "version": "5.57.0+f11804ebf",
+        "version": "5.60.0+34ad0cb7a",
         "displayName": "This is my add-on",
         "schemaVersion": "0.0.9"
     }

--- a/tests/testdata/test_addons/package_global_config_everything/globalConfig.json
+++ b/tests/testdata/test_addons/package_global_config_everything/globalConfig.json
@@ -2090,7 +2090,7 @@
     "meta": {
         "name": "Splunk_TA_UCCExample",
         "restRoot": "splunk_ta_uccexample",
-        "version": "5.58.1+10197a346",
+        "version": "5.60.0+34ad0cb7a",
         "displayName": "Splunk UCC test Add-on",
         "schemaVersion": "0.0.9",
         "supportedThemes": [

--- a/tests/testdata/test_addons/package_global_config_everything_uccignore/globalConfig.json
+++ b/tests/testdata/test_addons/package_global_config_everything_uccignore/globalConfig.json
@@ -1246,7 +1246,7 @@
     "meta": {
         "name": "Splunk_TA_UCCExample",
         "restRoot": "splunk_ta_uccexample",
-        "version": "5.57.0+f11804ebf",
+        "version": "5.60.0+34ad0cb7a",
         "displayName": "Splunk UCC test Add-on",
         "schemaVersion": "0.0.9"
     }

--- a/tests/testdata/test_addons/package_global_config_multi_input/globalConfig.json
+++ b/tests/testdata/test_addons/package_global_config_multi_input/globalConfig.json
@@ -769,7 +769,7 @@
     "meta": {
         "name": "Splunk_TA_UCCExample",
         "restRoot": "splunk_ta_uccexample",
-        "version": "5.57.0+f11804ebf",
+        "version": "5.60.0+34ad0cb7a",
         "displayName": "Splunk UCC test Add-on",
         "schemaVersion": "0.0.9"
     }

--- a/tests/testdata/test_addons/package_global_config_no_configuration/globalConfig.json
+++ b/tests/testdata/test_addons/package_global_config_no_configuration/globalConfig.json
@@ -169,7 +169,7 @@
     "meta": {
         "name": "Splunk_TA_UCCExample",
         "restRoot": "splunk_ta_uccexample",
-        "version": "5.55.0+1bb56cc1",
+        "version": "1.1.1",
         "displayName": "Splunk UCC test Add-on",
         "schemaVersion": "0.0.9"
     }

--- a/tests/testdata/test_addons/package_global_config_only_one_tab/globalConfig.json
+++ b/tests/testdata/test_addons/package_global_config_only_one_tab/globalConfig.json
@@ -36,7 +36,7 @@
     "meta": {
         "name": "Splunk_TA_UCCExample",
         "restRoot": "splunk_ta_uccexample",
-        "version": "5.57.0+f11804ebf",
+        "version": "5.60.0+34ad0cb7a",
         "displayName": "Splunk UCC test Add-on",
         "schemaVersion": "0.0.9"
     }

--- a/tests/unit/test_dashboard.py
+++ b/tests/unit/test_dashboard.py
@@ -46,6 +46,7 @@ def test_generate_only_default_dashboard(global_config_all_json, tmp_path):
 
     dashboard.generate_dashboard(
         global_config_all_json,
+        helpers.get_testdata_file_path("valid_config.json"),
         "Splunk_TA_UCCExample",
         str(definition_jsons_file_path),
     )
@@ -68,12 +69,17 @@ def setup(tmp_path):
     os.makedirs(tmp_ta_path)
     custom_dash_path = os.path.join(tmp_ta_path, "custom_dashboard.json")
     definition_jsons_file_path = tmp_path / "custom"
-    yield global_config, custom_dash_path, definition_jsons_file_path
+    yield global_config, global_config_path, custom_dash_path, definition_jsons_file_path
     shutil.rmtree(tmp_ta_path)
 
 
 def test_generate_dashboard_default_and_custom_components(setup, tmp_path):
-    global_config, custom_dash_path, definition_jsons_file_path = setup
+    (
+        global_config,
+        global_config_path,
+        custom_dash_path,
+        definition_jsons_file_path,
+    ) = setup
 
     with open(custom_dash_path, "w") as file:
         file.write(json.dumps(custom_definition))
@@ -82,6 +88,7 @@ def test_generate_dashboard_default_and_custom_components(setup, tmp_path):
         path_abs.return_value = custom_dash_path
         dashboard.generate_dashboard(
             global_config,
+            global_config_path,
             "Splunk_TA_UCCExample",
             str(definition_jsons_file_path),
         )
@@ -101,7 +108,7 @@ def test_generate_dashboard_default_and_custom_components(setup, tmp_path):
 
 
 def test_generate_dashboard_only_custom_components(setup, tmp_path):
-    _, custom_dash_path, definition_jsons_file_path = setup
+    _, _, custom_dash_path, definition_jsons_file_path = setup
 
     global_config_path = helpers.get_testdata_file_path(
         "valid_config_only_custom_dashboard.json"
@@ -115,6 +122,7 @@ def test_generate_dashboard_only_custom_components(setup, tmp_path):
         path_abs.return_value = custom_dash_path
         dashboard.generate_dashboard(
             global_config,
+            global_config_path,
             "Splunk_TA_UCCExample",
             str(definition_jsons_file_path),
         )
@@ -134,10 +142,15 @@ def test_generate_dashboard_only_custom_components(setup, tmp_path):
 
 
 def test_generate_dashboard_with_custom_components_no_file(setup, tmp_path, caplog):
-    global_config, custom_dash_path, definition_jsons_file_path = setup
+    (
+        global_config,
+        global_config_path,
+        custom_dash_path,
+        definition_jsons_file_path,
+    ) = setup
     custom_dashboard_path = os.path.abspath(
         os.path.join(
-            global_config.original_path,
+            global_config_path,
             os.pardir,
             "custom_dashboard.json",
         )
@@ -146,6 +159,7 @@ def test_generate_dashboard_with_custom_components_no_file(setup, tmp_path, capl
     with pytest.raises(SystemExit):
         dashboard.generate_dashboard(
             global_config,
+            global_config_path,
             "Splunk_TA_UCCExample",
             str(definition_jsons_file_path),
         )
@@ -155,7 +169,12 @@ def test_generate_dashboard_with_custom_components_no_file(setup, tmp_path, capl
 def test_generate_dashboard_with_custom_components_invalid_xml_file(
     setup, tmp_path, caplog
 ):
-    global_config, custom_dash_path, definition_jsons_file_path = setup
+    (
+        global_config,
+        global_config_path,
+        custom_dash_path,
+        definition_jsons_file_path,
+    ) = setup
     with open(custom_dash_path, "w") as file:
         file.write("")
 
@@ -165,6 +184,7 @@ def test_generate_dashboard_with_custom_components_invalid_xml_file(
             path_abs.return_value = custom_dash_path
             dashboard.generate_dashboard(
                 global_config,
+                global_config_path,
                 "Splunk_TA_UCCExample",
                 str(definition_jsons_file_path),
             )
@@ -172,7 +192,12 @@ def test_generate_dashboard_with_custom_components_invalid_xml_file(
 
 
 def test_generate_dashboard_with_custom_components_no_content(setup, tmp_path, caplog):
-    global_config, custom_dash_path, definition_jsons_file_path = setup
+    (
+        global_config,
+        global_config_path,
+        custom_dash_path,
+        definition_jsons_file_path,
+    ) = setup
 
     with open(custom_dash_path, "w") as file:
         file.write("{}")
@@ -182,6 +207,7 @@ def test_generate_dashboard_with_custom_components_no_content(setup, tmp_path, c
             path_abs.return_value = custom_dash_path
             dashboard.generate_dashboard(
                 global_config,
+                global_config_path,
                 "Splunk_TA_UCCExample",
                 str(definition_jsons_file_path),
             )
@@ -218,7 +244,12 @@ def test_generate_dashboard_with_custom_components_no_content(setup, tmp_path, c
 def test_custom_license_usage_search(
     setup, tmp_path, caplog, custom_settings, expected_result
 ):
-    global_config, custom_dash_path, definition_jsons_file_path = setup
+    (
+        global_config,
+        global_config_path,
+        custom_dash_path,
+        definition_jsons_file_path,
+    ) = setup
 
     settings = {
         "settings": {
@@ -238,6 +269,7 @@ def test_custom_license_usage_search(
         path_abs.return_value = custom_dash_path
         dashboard.generate_dashboard(
             global_config,
+            global_config_path,
             "Splunk_TA_UCCExample",
             str(definition_jsons_file_path),
         )

--- a/tests/unit/test_global_config.py
+++ b/tests/unit/test_global_config.py
@@ -25,7 +25,6 @@ def test_global_config_parse(filename):
     assert global_config.namespace == "splunk_ta_uccexample"
     assert global_config.product == "Splunk_TA_UCCExample"
     assert global_config.display_name == "Splunk UCC test Add-on"
-    assert global_config.original_path == global_config_path
     assert global_config.schema_version == "0.0.3"
     assert global_config.version == "1.0.0"
     assert global_config.has_pages() is True

--- a/tests/unit/test_global_config_update.py
+++ b/tests/unit/test_global_config_update.py
@@ -84,7 +84,7 @@ def test_handle_alert_action_updates(tmp_path, caplog):
     helpers.copy_testdata_gc_to_tmp_file(tmp_file_gc, "valid_config_all_alerts.json")
     global_config = global_config_lib.GlobalConfig.from_file(str(tmp_file_gc))
 
-    _handle_alert_action_updates(global_config)
+    _handle_alert_action_updates(global_config, tmp_file_gc)
 
     expected_schema_version = "0.0.4"
     assert expected_schema_version == global_config.schema_version
@@ -112,7 +112,7 @@ def test_migrate_old_dashboard(tmp_path, caplog):
     helpers.copy_testdata_gc_to_tmp_file(tmp_file_gc, "valid_config_old_dashboard.json")
 
     global_config = global_config_lib.GlobalConfig.from_file(str(tmp_file_gc))
-    _handle_xml_dashboard_update(global_config)
+    _handle_xml_dashboard_update(global_config, tmp_file_gc)
 
     expected_schema_version = "0.0.5"
     expected_panel = json.loads('{"panels": [{"name": "default"}]}')
@@ -133,7 +133,7 @@ def test_tab_migration(tmp_path):
     assert "loggingTab" not in tmp_file_gc.read_text()
 
     global_config = global_config_lib.GlobalConfig.from_file(str(tmp_file_gc))
-    _dump_with_migrated_tabs(global_config, global_config.original_path)
+    _dump_with_migrated_tabs(global_config, tmp_file_gc)
 
     assert "loggingTab" in tmp_file_gc.read_text()
 
@@ -154,9 +154,7 @@ def test_entity_migration(tmp_path):
     assert '"type": "interval"' not in tmp_file_gc.read_text()
 
     global_config = global_config_lib.GlobalConfig.from_file(str(tmp_file_gc))
-    _dump_with_migrated_entities(
-        global_config, global_config.original_path, [IntervalEntity]
-    )
+    _dump_with_migrated_entities(global_config, tmp_file_gc, [IntervalEntity])
 
     assert '"type": "interval"' in tmp_file_gc.read_text()
 
@@ -258,6 +256,6 @@ def test_handle_global_config_update_when_valid_config(tmp_path):
     global_config = global_config_lib.GlobalConfig.from_file(str(tmp_file_gc))
     expected_schema_version = "0.0.9"
 
-    handle_global_config_update(global_config)
+    handle_global_config_update(global_config, tmp_file_gc)
 
     assert global_config.schema_version == expected_schema_version


### PR DESCRIPTION
**Issue number:** N/A

### PR Type

**What kind of change does this PR introduce?**
* [ ] Feature
* [ ] Bug Fix
* [x] Refactoring (no functional or API changes)
* [ ] Documentation Update
* [ ] Maintenance (dependency updates, CI, etc.)

## Summary

### Changes

Further simplification of `GlobalConfig` class, this PR removes `original_path` parameter from the `GlobalConfig`'s constructor.

This would allow us to simply integrate `from_app_conf_and_app_manifest` to allow all TAs to have `globalConfig`.

### User experience

N/A

## Checklist

If an item doesn't apply to your changes, leave it unchecked.

### Review

* [x] self-review - I have performed a self-review of this change according to the [development guidelines](https://splunk.github.io/addonfactory-ucc-generator/contributing/#development-guidelines)
* [ ] Changes are documented. The documentation is understandable, examples work [(more info)](https://splunk.github.io/addonfactory-ucc-generator/contributing/#documentation-guidelines)
* [x] PR title and description follows the [contributing principles](https://splunk.github.io/addonfactory-ucc-generator/contributing/#pull-requests)
* [ ] meeting - I have scheduled a meeting or recorded a demo to explain these changes (if there is a video, put a link below and in the ticket)

### Tests

See [the testing doc](https://splunk.github.io/addonfactory-ucc-generator/contributing/#build-and-test).

* [x] Unit - tests have been added/modified to cover the changes
* [ ] Smoke - tests have been added/modified to cover the changes
* [ ] UI - tests have been added/modified to cover the changes
* [x] coverage - I have checked the code coverage of my changes [(see more)](https://splunk.github.io/addonfactory-ucc-generator/contributing/#checking-the-code-coverage)

**Demo/meeting:**

*Reviewers are encouraged to request meetings or demos if any part of the change is unclear*
