### PR TITLE
fix: do not generate openapi.json for .conf-only add-ons

### DIFF
--- a/splunk_add_on_ucc_framework/commands/build.py
+++ b/splunk_add_on_ucc_framework/commands/build.py
@@ -682,7 +682,7 @@ def generate(
         # clean-up sys.path manipulation
         sys.path.pop(0)
 
-    if global_config:
+    if global_config.has_configuration() or global_config.has_inputs():
         logger.info("Generating OpenAPI file")
         open_api_object = ucc_to_oas.transform(global_config, app_manifest)
 

--- a/tests/smoke/test_ucc_build.py
+++ b/tests/smoke/test_ucc_build.py
@@ -484,35 +484,15 @@ def test_ucc_generate_with_configuration_files_only():
         )
         # the globalConfig would now always exist
         assert path.exists(global_config_path)
-        # clean-up for tests
-        os.remove(global_config_path)
 
-
-def test_ucc_generate_openapi_with_configuration_files_only():
-    with tempfile.TemporaryDirectory() as temp_dir:
-        package_folder = path.join(
-            path.dirname(path.realpath(__file__)),
-            "..",
-            "testdata",
-            "test_addons",
-            "package_no_global_config",
-            "package",
-        )
-        build.generate(source=package_folder, output_directory=temp_dir)
-
-        actual_file_path = path.join(
+        openapi_file_path = path.join(
             temp_dir, "Splunk_TA_UCCExample", "appserver", "static", "openapi.json"
         )
-        # the openapi.json would now exist as globalConfig.json would always exist
-        assert path.exists(actual_file_path)
+        # the openapi.json should not be generated for .conf-only add-ons
+        assert not path.exists(openapi_file_path)
+
         # clean-up for tests
-        os.remove(
-            path.join(
-                package_folder,
-                path.pardir,
-                "globalConfig.json",
-            )
-        )
+        os.remove(global_config_path)
 
 
 def test_ucc_build_verbose_mode(caplog):


### PR DESCRIPTION
**Issue number:** N/A

### PR Type

**What kind of change does this PR introduce?**
* [ ] Feature
* [x] Bug Fix
* [ ] Refactoring (no functional or API changes)
* [ ] Documentation Update
* [ ] Maintenance (dependency updates, CI, etc.)

## Summary

### Changes

No `openapi.json` is generated for add-ons without configuration or inputs page.

### User experience

No `openapi.json` is generated for add-ons without configuration or inputs page.

## Checklist

If an item doesn't apply to your changes, leave it unchecked.

### Review

* [x] self-review - I have performed a self-review of this change according to the [development guidelines](https://splunk.github.io/addonfactory-ucc-generator/contributing/#development-guidelines)
* [ ] Changes are documented. The documentation is understandable, examples work [(more info)](https://splunk.github.io/addonfactory-ucc-generator/contributing/#documentation-guidelines)
* [x] PR title and description follows the [contributing principles](https://splunk.github.io/addonfactory-ucc-generator/contributing/#pull-requests)
* [ ] meeting - I have scheduled a meeting or recorded a demo to explain these changes (if there is a video, put a link below and in the ticket)

### Tests

See [the testing doc](https://splunk.github.io/addonfactory-ucc-generator/contributing/#build-and-test).

* [ ] Unit - tests have been added/modified to cover the changes
* [x] Smoke - tests have been added/modified to cover the changes
* [ ] UI - tests have been added/modified to cover the changes
* [ ] coverage - I have checked the code coverage of my changes [(see more)](https://splunk.github.io/addonfactory-ucc-generator/contributing/#checking-the-code-coverage)

**Demo/meeting:**

*Reviewers are encouraged to request meetings or demos if any part of the change is unclear*
