### PR TITLE
test: failing test case for custom tab without entity

### DIFF
--- a/tests/unit/commands/openapi_generator/test_ucc_to_oas.py
+++ b/tests/unit/commands/openapi_generator/test_ucc_to_oas.py
@@ -37,6 +37,18 @@ def test_transform_multiple_account(
     assert json.loads(expected_open_api_json) == openapi_object.json
 
 
+def test_transform_custom_tab_without_entity(
+    global_config_only_custom_tab, app_manifest_correct
+):
+    openapi_object = ucc_to_oas.transform(
+        global_config_only_custom_tab, app_manifest_correct
+    )
+    expected_open_api_json = get_testdata_file(
+        "openapi.json.custom_tab_without_entity.generated"
+    )
+    assert json.loads(expected_open_api_json) == openapi_object.json
+
+
 def test_transform_one_auth_type(
     global_config_single_authentication, app_manifest_correct
 ):

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -66,6 +66,13 @@ def global_config_no_configuration() -> global_config_lib.GlobalConfig:
 
 
 @pytest.fixture
+def global_config_only_custom_tab() -> global_config_lib.GlobalConfig:
+    return global_config_lib.GlobalConfig.from_file(
+        helpers.get_testdata_file_path("valid_config_custom_tab_without_entity.json")
+    )
+
+
+@pytest.fixture
 def global_config_all_yaml() -> global_config_lib.GlobalConfig:
     global_config_path = helpers.get_testdata_file_path("valid_config.yaml")
     global_config = global_config_lib.GlobalConfig.from_file(global_config_path)

--- a/tests/unit/testdata/openapi.json.custom_tab_without_entity
+++ b/tests/unit/testdata/openapi.json.custom_tab_without_entity
@@ -1,0 +1,45 @@
+{
+    "openapi": "3.0.0",
+    "info": {
+        "title": "Splunk_TA_UCCExample",
+        "version": "1.0.0",
+        "description": "Splunk UCC test Add-on",
+        "contact": {
+            "name": "Splunk",
+            "email": "addonfactory@splunk.com"
+        },
+        "license": {
+            "name": "Apache-2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0"
+        }
+    },
+    "servers": [
+        {
+            "url": "https://{domain}:{port}/servicesNS/-/Splunk_TA_UCCExample",
+            "variables": {
+                "domain": {
+                    "default": "localhost"
+                },
+                "port": {
+                    "default": "8089"
+                }
+            },
+            "description": "Access via management interface"
+        }
+    ],
+    "components": {
+        "schemas": {},
+        "securitySchemes": {
+            "BasicAuth": {
+                "type": "http",
+                "scheme": "basic"
+            }
+        }
+    },
+    "paths": {},
+    "security": [
+        {
+            "BasicAuth": []
+        }
+    ]
+}

--- a/tests/unit/testdata/valid_config_custom_tab_without_entity.json
+++ b/tests/unit/testdata/valid_config_custom_tab_without_entity.json
@@ -1,0 +1,25 @@
+{
+    "pages": {
+        "configuration": {
+            "tabs": [
+                {
+                    "name": "custom_tab",
+                    "title": "Customized Tab",
+                    "customTab": {
+                        "src": "custom_tab",
+                        "type": "external"
+                    }
+                }
+            ],
+            "title": "Configuration",
+            "description": "Set up your add-on"
+        }
+    },
+    "meta": {
+        "name": "Splunk_TA_UCCExample",
+        "restRoot": "splunk_ta_uccexample",
+        "version": "1.0.0",
+        "displayName": "Splunk UCC test Add-on",
+        "schemaVersion": "0.0.3"
+    }
+}


### PR DESCRIPTION
**Issue number:**

### PR Type

**What kind of change does this PR introduce?**
* [ ] Feature
* [ ] Bug Fix
* [ ] Refactoring (no functional or API changes)
* [ ] Documentation Update
* [ ] Maintenance (dependency updates, CI, etc.)

## Summary

### Changes

This PR is being raised just to showcase the error which is caused when `custom_tab` is passed without entity. Will close this when the fix PR #1718 will get merged.

### User experience

No change in User experience.

## Checklist

If an item doesn't apply to your changes, leave it unchecked.

### Review

* [ ] self-review - I have performed a self-review of this change according to the [development guidelines](https://splunk.github.io/addonfactory-ucc-generator/contributing/#development-guidelines)
* [ ] Changes are documented. The documentation is understandable, examples work [(more info)](https://splunk.github.io/addonfactory-ucc-generator/contributing/#documentation-guidelines)
* [x] PR title and description follows the [contributing principles](https://splunk.github.io/addonfactory-ucc-generator/contributing/#pull-requests)
* [ ] meeting - I have scheduled a meeting or recorded a demo to explain these changes (if there is a video, put a link below and in the ticket)

### Tests

See [the testing doc](https://splunk.github.io/addonfactory-ucc-generator/contributing/#build-and-test).

* [x] Unit - tests have been added/modified to cover the changes
* [ ] Smoke - tests have been added/modified to cover the changes
* [ ] UI - tests have been added/modified to cover the changes
* [ ] coverage - I have checked the code coverage of my changes [(see more)](https://splunk.github.io/addonfactory-ucc-generator/contributing/#checking-the-code-coverage)

**Demo/meeting:**

*Reviewers are encouraged to request meetings or demos if any part of the change is unclear*
