### PR TITLE
fix(ui lib): do not copy files from lib while building

### DIFF
--- a/splunk_add_on_ucc_framework/utils.py
+++ b/splunk_add_on_ucc_framework/utils.py
@@ -74,11 +74,6 @@ def recursive_overwrite(src: str, dest: str, ui_source_map: bool = False) -> Non
     """
     # TODO: move to shutil.copytree("src", "dst", dirs_exist_ok=True) when Python 3.8+.
     if isdir(src):
-        # do not copy the static/js/lib directory
-        # it is used for UI node library
-        # if src.endswith("appserver/static/js/lib"):
-        #     return
-
         if not isdir(dest):
             makedirs(dest)
         files = listdir(src)

--- a/tests/smoke/test_ucc_build.py
+++ b/tests/smoke/test_ucc_build.py
@@ -579,11 +579,6 @@ def test_ucc_build_verbose_mode(caplog):
             for full_path, dir, files in os.walk(app_server_lib_path):
                 if files:
                     relative_path = full_path[path_len:]
-
-                    if relative_path == "appserver/static/js/lib":
-                        # skip appserver/static/js/lib as it contains UI lib not used in final build
-                        continue
-
                     for file in files:
                         if file not in excluded_files:
                             relative_file_path = os.path.join(relative_path, file)


### PR DESCRIPTION
**Issue number:**

### PR Type

**What kind of change does this PR introduce?**
* [ ] Feature
* [x] Bug Fix
* [ ] Refactoring (no functional or API changes)
* [ ] Documentation Update
* [ ] Maintenance (dependency updates, CI, etc.)

## Summary

### Changes

UI Library files are copied during ucc-gen build. Which is not necessary process.
While building in 'output/Splunk_TA_Example/appserver/static/js' there is additional lib directory generated.
It is not necessary lib as it is used for publishing the library to npm.

Copying only `/appserver/static/js/build` instead of full directory.

### User experience

N/A, user experience remains the same.

## Checklist

If an item doesn't apply to your changes, leave it unchecked.

### Review

* [x] self-review - I have performed a self-review of this change according to the [development guidelines](https://splunk.github.io/addonfactory-ucc-generator/contributing/#development-guidelines)
* [ ] Changes are documented. The documentation is understandable, examples work [(more info)](https://splunk.github.io/addonfactory-ucc-generator/contributing/#documentation-guidelines)
* [x] PR title and description follows the [contributing principles](https://splunk.github.io/addonfactory-ucc-generator/contributing/#pull-requests)
* [ ] meeting - I have scheduled a meeting or recorded a demo to explain these changes (if there is a video, put a link below and in the ticket)

### Tests

See [the testing doc](https://splunk.github.io/addonfactory-ucc-generator/contributing/#build-and-test).

* [ ] Unit - tests have been added/modified to cover the changes
* [ ] Smoke - tests have been added/modified to cover the changes
* [ ] UI - tests have been added/modified to cover the changes
* [ ] coverage - I have checked the code coverage of my changes [(see more)](https://splunk.github.io/addonfactory-ucc-generator/contributing/#checking-the-code-coverage)

**Demo/meeting:**

*Reviewers are encouraged to request meetings or demos if any part of the change is unclear*
