### PR TITLE
chore: use spaces instead of tabs for HTML templates

### DIFF
--- a/splunk_add_on_ucc_framework/templates/html_templates/alert_html_skeleton.template
+++ b/splunk_add_on_ucc_framework/templates/html_templates/alert_html_skeleton.template
@@ -1,9 +1,9 @@
 <form class="form-horizontal form-complex">
 {% if mod_alert.get("parameters") %}
-	{% for param in mod_alert.parameters %}
-		{% with mod_alert=mod_alert, param=param %}
-			{% include param.format_type + ".html" %}
-		{% endwith %}
-	{% endfor %}
+    {% for param in mod_alert.parameters %}
+        {% with mod_alert=mod_alert, param=param %}
+            {% include param.format_type + ".html" %}
+        {% endwith %}
+    {% endfor %}
 {% endif %}
 </form>

--- a/splunk_add_on_ucc_framework/templates/html_templates/checkbox.html
+++ b/splunk_add_on_ucc_framework/templates/html_templates/checkbox.html
@@ -2,10 +2,10 @@
 {% from "helper.html" import show_help with context %}
 <div class="control-group">
     <div class="controls">
-		<label class="checkbox" for="{{ mod_alert.short_name }}_{{ param.name }}">
-			<input type="checkbox" name="action.{{ mod_alert.short_name }}.param.{{ param.name }}" id="{{ mod_alert.short_name }}_{{ param.name }}" {{ expand_ctrl_props(param) }} />
-			{{ param.label }}
-		</label>
-		{{ show_help(param) }}
+        <label class="checkbox" for="{{ mod_alert.short_name }}_{{ param.name }}">
+            <input type="checkbox" name="action.{{ mod_alert.short_name }}.param.{{ param.name }}" id="{{ mod_alert.short_name }}_{{ param.name }}" {{ expand_ctrl_props(param) }} />
+            {{ param.label }}
+        </label>
+        {{ show_help(param) }}
     </div>
 </div>

--- a/splunk_add_on_ucc_framework/templates/html_templates/dropdownlist_splunk_search.html
+++ b/splunk_add_on_ucc_framework/templates/html_templates/dropdownlist_splunk_search.html
@@ -1,5 +1,6 @@
 {% extends "basecontrol.html" %}
 {% from "helper.html" import expand_ctrl_props with context %}
 {% block control %}
-		<splunk-search-dropdown name="action.{{ mod_alert.short_name }}.param.{{ param.name }}" id="{{ mod_alert.short_name }}_{{ param.name }}" {{ expand_ctrl_props(param) }} />
+        <splunk-search-dropdown name="action.{{ mod_alert.short_name }}.param.{{ param.name }}" id="{{ mod_alert.short_name }}_{{ param.name }}"
+{{ expand_ctrl_props(param) }} />
 {% endblock %}

--- a/splunk_add_on_ucc_framework/templates/html_templates/radio.html
+++ b/splunk_add_on_ucc_framework/templates/html_templates/radio.html
@@ -1,16 +1,16 @@
 {% from "helper.html" import expand_ctrl_props with context %}
 {% from "helper.html" import show_help with context %}
 <div class="control-group">
-	<label class="control-label">{{ param.label }}</label>
-		<div class="controls">
-			{% for option, value in param.possible_values.items() %}
-				<label class="radio" for="{{ mod_alert.short_name }}_{{ param.name }}_{{ value }}">
-					<input type="radio"
-					name="action.{{ mod_alert.short_name }}.param.{{ param.name }}" id="{{ mod_alert.short_name }}_{{ param.name }}_{{ value }}" value="{{ value }}"
-				    {{ expand_ctrl_props(param) }} />
-					{{ option }}
-				</label>
-			{% endfor %}
-			{{ show_help(param) }}
-		</div>
+    <label class="control-label">{{ param.label }}</label>
+        <div class="controls">
+            {% for option, value in param.possible_values.items() %}
+                <label class="radio" for="{{ mod_alert.short_name }}_{{ param.name }}_{{ value }}">
+                    <input type="radio"
+                    name="action.{{ mod_alert.short_name }}.param.{{ param.name }}" id="{{ mod_alert.short_name }}_{{ param.name }}_{{ value }}" value="{{ value }}"
+                    {{ expand_ctrl_props(param) }} />
+                    {{ option }}
+                </label>
+            {% endfor %}
+            {{ show_help(param) }}
+        </div>
 </div>

--- a/splunk_add_on_ucc_framework/templates/html_templates/text.html
+++ b/splunk_add_on_ucc_framework/templates/html_templates/text.html
@@ -2,5 +2,5 @@
 {% from "helper.html" import expand_ctrl_props with context %}
 {% block control %}
 <input type="text" name="action.{{ mod_alert.short_name }}.param.{{ param.name }}"
-		id="{{ mod_alert.short_name }}_{{ param.name }}" {{ expand_ctrl_props(param) }}/>
+        id="{{ mod_alert.short_name }}_{{ param.name }}" {{ expand_ctrl_props(param) }}/>
 {% endblock %}

--- a/splunk_add_on_ucc_framework/templates/html_templates/textarea.html
+++ b/splunk_add_on_ucc_framework/templates/html_templates/textarea.html
@@ -2,5 +2,5 @@
 {% from "helper.html" import expand_ctrl_props with context %}
 {% block control %}
 <textarea name="action.{{ mod_alert.short_name }}.param.{{ param.name }}"
-		id="{{ mod_alert.short_name }}_{{ param.name }}" {{ expand_ctrl_props(param) }}></textarea>
+        id="{{ mod_alert.short_name }}_{{ param.name }}" {{ expand_ctrl_props(param) }}></textarea>
 {% endblock %}

--- a/tests/testdata/expected_addons/expected_output_global_config_everything/Splunk_TA_UCCExample/default/data/ui/alerts/test_alert.html
+++ b/tests/testdata/expected_addons/expected_output_global_config_everything/Splunk_TA_UCCExample/default/data/ui/alerts/test_alert.html
@@ -3,7 +3,7 @@
     <label class="control-label" for="test_alert_name">Name <span class="required">*</span> </label>
     <div class="controls">
 <input type="text" name="action.test_alert.param.name"
-		id="test_alert_name" />
+        id="test_alert_name" />
             <span class="help-block">
         Please enter your name
     </span>
@@ -13,7 +13,7 @@
     <label class="control-label" for="test_alert_description">Description <span class="required">*</span> </label>
     <div class="controls">
 <textarea name="action.test_alert.param.description"
-		id="test_alert_description" ></textarea>
+        id="test_alert_description" ></textarea>
             <span class="help-block">
         Please enter the description for the alert
     </span>
@@ -21,11 +21,11 @@
 </div>
 <div class="control-group">
     <div class="controls">
-		<label class="checkbox" for="test_alert_all_incidents">
-			<input type="checkbox" name="action.test_alert.param.all_incidents" id="test_alert_all_incidents"  />
-			All Incidents
-		</label>
-		    <span class="help-block">
+        <label class="checkbox" for="test_alert_all_incidents">
+            <input type="checkbox" name="action.test_alert.param.all_incidents" id="test_alert_all_incidents"  />
+            All Incidents
+        </label>
+            <span class="help-block">
         Tick if you want to update all incidents/problems
     </span>
     </div>
@@ -43,29 +43,30 @@
     </div>
 </div>
 <div class="control-group">
-	<label class="control-label">Action:</label>
-		<div class="controls">
-				<label class="radio" for="test_alert_action_update">
-					<input type="radio"
-					name="action.test_alert.param.action" id="test_alert_action_update" value="update"
-				     />
-					Update
-				</label>
-				<label class="radio" for="test_alert_action_delete">
-					<input type="radio"
-					name="action.test_alert.param.action" id="test_alert_action_delete" value="delete"
-				     />
-					Delete
-				</label>
-			    <span class="help-block">
+    <label class="control-label">Action:</label>
+        <div class="controls">
+                <label class="radio" for="test_alert_action_update">
+                    <input type="radio"
+                    name="action.test_alert.param.action" id="test_alert_action_update" value="update"
+                     />
+                    Update
+                </label>
+                <label class="radio" for="test_alert_action_delete">
+                    <input type="radio"
+                    name="action.test_alert.param.action" id="test_alert_action_delete" value="delete"
+                     />
+                    Delete
+                </label>
+                <span class="help-block">
         Select the action you want to perform
     </span>
-		</div>
+        </div>
 </div>
 <div class="control-group">
     <label class="control-label" for="test_alert_account">Select Account <span class="required">*</span> </label>
     <div class="controls">
-		<splunk-search-dropdown name="action.test_alert.param.account" id="test_alert_account"                 value-field="title"
+        <splunk-search-dropdown name="action.test_alert.param.account" id="test_alert_account"
+                value-field="title"
                 label-field="title"
                 search="| rest /servicesNS/nobody/Splunk_TA_UCCExample/splunk_ta_uccexample_account | dedup title"
                 earliest="-4@h"


### PR DESCRIPTION
**Issue number:**

### PR Type

**What kind of change does this PR introduce?**
* [ ] Feature
* [ ] Bug Fix
* [x] Refactoring (no functional or API changes)
* [ ] Documentation Update
* [ ] Maintenance (dependency updates, CI, etc.)

## Summary

### Changes

Used spaces instead of tabs for `HTML templates`.

### User experience

No change in User experience.

## Checklist

If an item doesn't apply to your changes, leave it unchecked.

### Review

* [x] self-review - I have performed a self-review of this change according to the [development guidelines](https://splunk.github.io/addonfactory-ucc-generator/contributing/#development-guidelines)
* [ ] Changes are documented. The documentation is understandable, examples work [(more info)](https://splunk.github.io/addonfactory-ucc-generator/contributing/#documentation-guidelines)
* [x] PR title and description follows the [contributing principles](https://splunk.github.io/addonfactory-ucc-generator/contributing/#pull-requests)
* [ ] meeting - I have scheduled a meeting or recorded a demo to explain these changes (if there is a video, put a link below and in the ticket)

### Tests

See [the testing doc](https://splunk.github.io/addonfactory-ucc-generator/contributing/#build-and-test).

* [ ] Unit - tests have been added/modified to cover the changes
* [x] Smoke - tests have been added/modified to cover the changes
* [ ] UI - tests have been added/modified to cover the changes
* [ ] coverage - I have checked the code coverage of my changes [(see more)](https://splunk.github.io/addonfactory-ucc-generator/contributing/#checking-the-code-coverage)

**Demo/meeting:**

*Reviewers are encouraged to request meetings or demos if any part of the change is unclear*
