### PR TITLE
feat(textarea): mask data when encrypted

### DIFF
--- a/ui/src/components/TextAreaComponent/TextAreaComponent.tsx
+++ b/ui/src/components/TextAreaComponent/TextAreaComponent.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import TextArea, { TextAreaChangeHandler, TextAreaPropsBase } from '@splunk/react-ui/TextArea';
+import styled from 'styled-components';
 
 import { excludeControlWrapperProps } from '../ControlWrapper/utils';
 
@@ -9,7 +10,14 @@ export interface TextAreaComponentProps extends Omit<Partial<TextAreaPropsBase>,
     handleChange: (field: string, value: string) => void;
     field: string;
     controlOptions?: { rowsMax?: number; rowsMin?: number };
+    encrypted?: boolean;
 }
+
+const MaskedTextArea = styled(TextArea)`
+    textarea {
+        -webkit-text-security: disc;
+    }
+`;
 
 function TextAreaComponent({
     id,
@@ -17,6 +25,7 @@ function TextAreaComponent({
     handleChange,
     field,
     controlOptions,
+    encrypted,
     ...restProps
 }: TextAreaComponentProps) {
     const onChange: TextAreaChangeHandler = (_e, data) => {
@@ -24,17 +33,20 @@ function TextAreaComponent({
     };
 
     const restSuiProps = excludeControlWrapperProps(restProps);
-    return (
-        <TextArea
-            {...restSuiProps}
-            inputId={id}
-            className={field}
-            value={value?.toString() || ''}
-            onChange={onChange}
-            rowsMax={controlOptions?.rowsMax ? controlOptions?.rowsMax : 12}
-            rowsMin={controlOptions?.rowsMin ? controlOptions?.rowsMin : 8}
-        />
-    );
+
+    const sharedProps = {
+        ...restSuiProps,
+        inputId: id,
+        className: field,
+        value: value?.toString() || '',
+        onChange,
+        rowsMax: controlOptions?.rowsMax ?? 12,
+        rowsMin: controlOptions?.rowsMin ?? 8,
+    };
+
+    const TextAreaComp = encrypted ? MaskedTextArea : TextArea;
+
+    return <TextAreaComp {...sharedProps} />;
 }
 
 export default TextAreaComponent;

--- a/ui/src/components/TextAreaComponent/stories/TextAreaComponent.stories.tsx
+++ b/ui/src/components/TextAreaComponent/stories/TextAreaComponent.stories.tsx
@@ -37,5 +37,30 @@ export const Base: Story = {
         error: false,
         controlOptions: { rowsMax: 10, rowsMin: 2 },
         disabled: false,
+        encrypted: false,
+    },
+};
+
+export const UnEncrypted: Story = {
+    args: {
+        handleChange: fn(),
+        value: 'visbile text',
+        field: 'field',
+        error: false,
+        controlOptions: { rowsMax: 10, rowsMin: 2 },
+        disabled: false,
+        encrypted: false,
+    },
+};
+
+export const Encrypted: Story = {
+    args: {
+        handleChange: fn(),
+        value: 'not visbile text',
+        field: 'field',
+        error: false,
+        controlOptions: { rowsMax: 10, rowsMin: 2 },
+        disabled: false,
+        encrypted: true,
     },
 };

--- a/ui/src/components/TextAreaComponent/stories/TextAreaComponent.stories.tsx
+++ b/ui/src/components/TextAreaComponent/stories/TextAreaComponent.stories.tsx
@@ -44,7 +44,8 @@ export const Base: Story = {
 export const UnEncrypted: Story = {
     args: {
         handleChange: fn(),
-        value: 'visbile text',
+        value: `visbile text 
+multiple lanes`,
         field: 'field',
         error: false,
         controlOptions: { rowsMax: 10, rowsMin: 2 },
@@ -56,7 +57,8 @@ export const UnEncrypted: Story = {
 export const Encrypted: Story = {
     args: {
         handleChange: fn(),
-        value: 'not visbile text',
+        value: `none visbile text 
+multiple lanes`,
         field: 'field',
         error: false,
         controlOptions: { rowsMax: 10, rowsMin: 2 },

--- a/ui/src/components/TextAreaComponent/stories/__images__/TextAreaComponent-encrypted-chromium.png
+++ b/ui/src/components/TextAreaComponent/stories/__images__/TextAreaComponent-encrypted-chromium.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a0714d122b0742d448d27010ee5c78ff2823f224c2bb3712e7fc3f938b76298d
+size 5629

--- a/ui/src/components/TextAreaComponent/stories/__images__/TextAreaComponent-un-encrypted-chromium.png
+++ b/ui/src/components/TextAreaComponent/stories/__images__/TextAreaComponent-un-encrypted-chromium.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:7cbdaf7bc9a9fca2d38ee0c3a425d40a9672c836f6a6093050a4cf10763f94c6
+size 7957

--- a/ui/src/components/TextComponent/TextComponent.tsx
+++ b/ui/src/components/TextComponent/TextComponent.tsx
@@ -16,7 +16,6 @@ export interface TextComponentProps {
 
 class TextComponent extends Component<TextComponentProps> {
     handleChange = (e: unknown, { value }: { value: string | number }) => {
-        console.log('TextComponent handleChange', value);
         this.props.handleChange(this.props.field, value);
     };
 

--- a/ui/src/components/TextComponent/TextComponent.tsx
+++ b/ui/src/components/TextComponent/TextComponent.tsx
@@ -16,6 +16,7 @@ export interface TextComponentProps {
 
 class TextComponent extends Component<TextComponentProps> {
     handleChange = (e: unknown, { value }: { value: string | number }) => {
+        console.log('TextComponent handleChange', value);
         this.props.handleChange(this.props.field, value);
     };
 


### PR DESCRIPTION
**Issue number:**
https://splunk.atlassian.net/browse/ADDON-81688

### PR Type

**What kind of change does this PR introduce?**
* [ ] Feature
* [x] Bug Fix
* [ ] Refactoring (no functional or API changes)
* [ ] Documentation Update
* [ ] Maintenance (dependency updates, CI, etc.)

## Summary

### Changes

Masks text area data when encrypted.

### User experience

Data in text area are masked into many ***** when using it for encrypted fields.

Unfortunately works well only for 
Chrome	✅ Yes
Safari	✅ Yes
Opera	✅ Yes
Edge (Chromium)

Does not work for
Firefox	❌ No
Internet Explorer	❌ No
Old Edge (EdgeHTML)	❌ No

## Checklist

If an item doesn't apply to your changes, leave it unchecked.

### Review

* [x] self-review - I have performed a self-review of this change according to the [development guidelines](https://splunk.github.io/addonfactory-ucc-generator/contributing/#development-guidelines)
* [ ] Changes are documented. The documentation is understandable, examples work [(more info)](https://splunk.github.io/addonfactory-ucc-generator/contributing/#documentation-guidelines)
* [x] PR title and description follows the [contributing principles](https://splunk.github.io/addonfactory-ucc-generator/contributing/#pull-requests)
* [ ] meeting - I have scheduled a meeting or recorded a demo to explain these changes (if there is a video, put a link below and in the ticket)

### Tests

See [the testing doc](https://splunk.github.io/addonfactory-ucc-generator/contributing/#build-and-test).

* [ ] Unit - tests have been added/modified to cover the changes
* [ ] Smoke - tests have been added/modified to cover the changes
* [ ] UI - tests have been added/modified to cover the changes
* [ ] coverage - I have checked the code coverage of my changes [(see more)](https://splunk.github.io/addonfactory-ucc-generator/contributing/#checking-the-code-coverage)
* [x] storybook screenshots tests - tests have been created to cover all visual changes in code

**Demo/meeting:**
Encrypted = true:
![Screenshot 2025-06-24 at 22 31 26](https://github.com/user-attachments/assets/c0be0ad5-696c-4776-92b0-4c53e0f16760)

Encrypted = false:
![Screenshot 2025-06-24 at 22 31 45](https://github.com/user-attachments/assets/781beeee-016f-4bfa-9b08-5cd93578866c)


*Reviewers are encouraged to request meetings or demos if any part of the change is unclear*
