### PR TITLE
chore: display by default required asterisk sign when oauth fields

### DIFF
--- a/ui/src/components/BaseFormView/BaseFormView.tsx
+++ b/ui/src/components/BaseFormView/BaseFormView.tsx
@@ -323,6 +323,11 @@ class BaseFormView extends PureComponent<BaseFormProps, BaseFormState> {
                                 // eslint-disable-next-line no-param-reassign
                                 field.type = field?.type || 'text';
 
+                                // if field is not defined as required, set it to true as it is default for oauth
+                                // eslint-disable-next-line no-param-reassign
+                                field.required =
+                                    typeof field?.required !== 'undefined' ? field?.required : true;
+
                                 // Handled special case for redirect_url
                                 if (field.field === 'redirect_url') {
                                     tempEntity.value = window.location.href
@@ -334,8 +339,8 @@ class BaseFormView extends PureComponent<BaseFormProps, BaseFormState> {
                                     tempEntity.disabled = true;
                                 }
 
-                                // TODO: why field is pushed isntead of tempEntity
-                                // TODO: why temp entity is created at all
+                                // TODO: why field is pushed instead of tempEntity, it contains more data about field
+                                // while tempEntity got just basic state props.
                                 temEntities.push(field);
                                 authfields?.push(field.field);
                             });

--- a/ui/src/components/BaseFormView/stories/globalConfigs/configPageOauth.ts
+++ b/ui/src/components/BaseFormView/stories/globalConfigs/configPageOauth.ts
@@ -237,3 +237,81 @@ export const getConfigOauthOauth = () => {
     }
     return configCp;
 };
+
+export const getConfigOauthBasicWithAdditionalFieldTypes = () => {
+    const configCp = JSON.parse(JSON.stringify(PAGE_CONFIG_BOTH_OAUTH));
+    if (configCp.pages.configuration.tabs[0].entity[2].options?.auth_type) {
+        configCp.pages.configuration.tabs[0].entity[2].options.auth_type = ['basic'];
+        configCp.pages.configuration.tabs[0].entity[2].options.basic.push(
+            {
+                oauth_field: 'additional_text',
+                label: 'Additional Text Field',
+                field: 'additional_text',
+                type: 'text',
+                help: 'This is an additional text field for basic auth.',
+            },
+            {
+                label: 'Security Token certificate',
+                encrypted: true,
+                help: 'Enter the security certificate token.',
+                field: 'token_cert_2',
+            },
+            {
+                label: 'Text Area Token',
+                help: 'Enter Text Area Token',
+                field: 'text_area_test_basic_oauth',
+                type: 'textarea',
+                options: {
+                    rowsMin: 3,
+                    rowsMax: 5,
+                },
+                required: false,
+            },
+            {
+                label: 'Basic Oauth select',
+                help: 'additiona oauth select',
+                field: 'select_test_basic_oauth',
+                type: 'singleSelect',
+                options: {
+                    items: [
+                        {
+                            label: 'Option 1',
+                            value: 'option1',
+                        },
+                        {
+                            label: 'Option 2',
+                            value: 'option2',
+                        },
+                        {
+                            label: 'Option 3',
+                            value: 'option3',
+                        },
+                    ],
+                },
+            },
+            {
+                label: 'Basic Oauth radio',
+                help: 'Additiona oauth radio',
+                field: 'radio_test_basic_oauth',
+                type: 'radio',
+                options: {
+                    items: [
+                        {
+                            label: 'Left',
+                            value: 'left',
+                        },
+                        {
+                            label: 'Middle',
+                            value: 'middle',
+                        },
+                        {
+                            label: 'Right',
+                            value: 'right',
+                        },
+                    ],
+                },
+            }
+        );
+    }
+    return configCp;
+};

--- a/ui/src/components/ControlWrapper/ControlWrapper.tsx
+++ b/ui/src/components/ControlWrapper/ControlWrapper.tsx
@@ -136,15 +136,10 @@ class ControlWrapper extends React.PureComponent<ControlWrapperProps> {
             </>
         );
 
-        const isRequiredModified =
+        const modifiedRequire =
             typeof this.props?.modifiedEntitiesData?.required === 'boolean'
                 ? this.props?.modifiedEntitiesData?.required
                 : this.props.entity?.required;
-
-        const isFieldRequired =
-            isRequiredModified === undefined // // if oauth_field exists field required by default
-                ? 'oauth_field' in (this.props.entity || {}) // if oauth_field does not exists not required by default
-                : isRequiredModified;
 
         const label = this.props?.modifiedEntitiesData?.label || this?.props?.entity?.label || '';
         return (
@@ -157,7 +152,7 @@ class ControlWrapper extends React.PureComponent<ControlWrapperProps> {
                     // @ts-expect-error property should be data-name, but is mapped in obj ControlGroupWrapper
                     dataName={this?.props?.entity.field}
                     labelWidth={240}
-                    required={isFieldRequired}
+                    required={modifiedRequire}
                     label={label}
                 >
                     {rowView}


### PR DESCRIPTION
**Issue number:**

### PR Type

**What kind of change does this PR introduce?**
* [ ] Feature
* [ ] Bug Fix
* [ ] Refactoring (no functional or API changes)
* [ ] Documentation Update
* [ ] Maintenance (dependency updates, CI, etc.)

## Summary

### Changes

Overwrite required when oauth require not defined. (previously it was based on oauth_field, but it is not mandatory right now, as users can add Entity with different type and no oauth_field).

Not adding it as fix as the feature is not yet released.

Added visual storybook tests.

### User experience

Correctly sees asterisk (*) red sign when field required.
## Checklist

If an item doesn't apply to your changes, leave it unchecked.

### Review

* [x] self-review - I have performed a self-review of this change according to the [development guidelines](https://splunk.github.io/addonfactory-ucc-generator/contributing/#development-guidelines)
* [ ] Changes are documented. The documentation is understandable, examples work [(more info)](https://splunk.github.io/addonfactory-ucc-generator/contributing/#documentation-guidelines)
* [ ] PR title and description follows the [contributing principles](https://splunk.github.io/addonfactory-ucc-generator/contributing/#pull-requests)
* [ ] meeting - I have scheduled a meeting or recorded a demo to explain these changes (if there is a video, put a link below and in the ticket)

### Tests

See [the testing doc](https://splunk.github.io/addonfactory-ucc-generator/contributing/#build-and-test).

* [ ] Unit - tests have been added/modified to cover the changes
* [ ] Smoke - tests have been added/modified to cover the changes
* [ ] UI - tests have been added/modified to cover the changes
* [ ] coverage - I have checked the code coverage of my changes [(see more)](https://splunk.github.io/addonfactory-ucc-generator/contributing/#checking-the-code-coverage)

**Demo/meeting:**

*Reviewers are encouraged to request meetings or demos if any part of the change is unclear*
