### PR TITLE
fix: add empty parameter in .conf file

### DIFF
--- a/splunk_add_on_ucc_framework/utils.py
+++ b/splunk_add_on_ucc_framework/utils.py
@@ -184,7 +184,7 @@ def merge_conf_file(
 
     sparser = conf_parser.TABConfigParser()
     sparser.read(src_file)
-    src_dict = sparser.item_dict()
+    src_dict = sparser.item_dict(preserve_comments=True)
     parser = conf_parser.TABConfigParser()
     parser.read(dst_file)
     dst_dict = parser.item_dict()
@@ -205,7 +205,8 @@ def merge_conf_file(
                 parser.add_section(stanza)
 
             for k, v in key_values.items():
-                if v:
+                # if the value of parameter is empty then it would be added in .conf file
+                if v or v == "":
                     parser.set(stanza, k, v)
                 else:
                     parser.remove_option(stanza, k)
@@ -213,6 +214,9 @@ def merge_conf_file(
         # overwrite the whole file
         parser.read(src_file)
 
+    # if any comments are present at the top of .conf file then write it to destination file.
+    if sparser.top_comments is not []:
+        parser.top_comments = sparser.top_comments
     with open(dst_file, "w") as df:
         parser.write(df)
 

--- a/tests/testdata/expected_addons/expected_output_global_config_everything/Splunk_TA_UCCExample/default/restmap.conf
+++ b/tests/testdata/expected_addons/expected_output_global_config_everything/Splunk_TA_UCCExample/default/restmap.conf
@@ -1,3 +1,7 @@
+# License header 1
+# License header 2
+# License header 3
+# License header 4
 [admin:splunk_ta_uccexample]
 match = /
 members = splunk_ta_uccexample_account, splunk_ta_uccexample_custom_amd_row_tab, splunk_ta_uccexample_custom_row_tab, splunk_ta_uccexample_example_input_four, splunk_ta_uccexample_example_input_one, splunk_ta_uccexample_example_input_three, splunk_ta_uccexample_example_input_two, splunk_ta_uccexample_oauth, splunk_ta_uccexample_service_hidden_for_cloud, splunk_ta_uccexample_service_hidden_for_enterprise, splunk_ta_uccexample_service_inside_menu_four, splunk_ta_uccexample_service_inside_menu_one, splunk_ta_uccexample_service_inside_menu_three, splunk_ta_uccexample_service_inside_menu_two, splunk_ta_uccexample_service_with_conf_param, splunk_ta_uccexample_settings, splunk_ta_uccexample_tab_hidden_for_cloud, splunk_ta_uccexample_tab_hidden_for_enterprise
@@ -131,10 +135,11 @@ handlerpersistentmode = true
 [admin:non_ui_rest_handlers]
 match = /splunk_ta_uccexample
 members = dependent_dropdown
+; This is example comment 
 
 [admin_external:dependent_dropdown]
 handlertype = python
-python.version = python3
+python.version = python3 # inline comment example
 handlerfile = dependent_dropdown.py
 handleractions = list
 handlerpersistentmode = true

--- a/tests/testdata/test_addons/package_global_config_everything/package/default/restmap.conf
+++ b/tests/testdata/test_addons/package_global_config_everything/package/default/restmap.conf
@@ -1,10 +1,15 @@
+# License header 1
+# License header 2
+# License header 3
+# License header 4
 [admin:non_ui_rest_handlers]
 match = /splunk_ta_uccexample
 members = dependent_dropdown
+; This is example comment 
 
 [admin_external:dependent_dropdown]
 handlertype = python
-python.version = python3
+python.version = python3# inline comment example
 handlerfile = dependent_dropdown.py
 handleractions = list
 handlerpersistentmode = true

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -12,6 +12,10 @@ Loader = getattr(yaml, "CSafeLoader", yaml.SafeLoader)
 yaml_load = functools.partial(yaml.load, Loader=Loader)
 
 
+def write_conf_file(path: Path, content: str) -> int:
+    return path.write_text(content)
+
+
 def compare_xml_content(content: str, expected_content: str) -> str:
     diff = xmldiff.main.diff_texts(content, expected_content)
     return " ".join([str(item) for item in diff])


### PR DESCRIPTION
**Issue number:** *ADDON-82577*

### PR Type

**What kind of change does this PR introduce?**
* [ ] Feature
* [X] Bug Fix
* [ ] Refactoring (no functional or API changes)
* [ ] Documentation Update
* [ ] Maintenance (dependency updates, CI, etc.)

## Summary

### Changes

Empty parameter and comments should also be included in `.conf` file while merging source and generated files.

### User experience

From now on, user can have the `.conf` file with comment (if defined in source code) and empty parameter in output directory.

## Checklist

If an item doesn't apply to your changes, leave it unchecked.

### Review

* [X] self-review - I have performed a self-review of this change according to the [development guidelines](https://splunk.github.io/addonfactory-ucc-generator/contributing/#development-guidelines)
* [ ] Changes are documented. The documentation is understandable, examples work [(more info)](https://splunk.github.io/addonfactory-ucc-generator/contributing/#documentation-guidelines)
* [X] PR title and description follows the [contributing principles](https://splunk.github.io/addonfactory-ucc-generator/contributing/#pull-requests)
* [ ] meeting - I have scheduled a meeting or recorded a demo to explain these changes (if there is a video, put a link below and in the ticket)

### Tests

See [the testing doc](https://splunk.github.io/addonfactory-ucc-generator/contributing/#build-and-test).

* [x] Unit - tests have been added/modified to cover the changes
* [X] Smoke - tests have been added/modified to cover the changes
* [ ] UI - tests have been added/modified to cover the changes
* [x] coverage - I have checked the code coverage of my changes [(see more)](https://splunk.github.io/addonfactory-ucc-generator/contributing/#checking-the-code-coverage)

**Demo/meeting:**

*Reviewers are encouraged to request meetings or demos if any part of the change is unclear*
