### PR TITLE
feat: new arg to publish command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -148,6 +148,7 @@ It does not support:
 
 It accepts the following parameters:
 
+* `--stage` - [optional] flag to choose staging splunkbase to publish the app.
 * `--app-id` - [required] Splunkbase numerical app id listed in the URL of the app details page.
 * `--package-path` - [required] path to the package file (.tar.gz) to be published (must be a valid UCC package).
 * `--splunk-versions` - [required] comma-separated list of supported Splunk versions (e.g. "9.1,9.2").

--- a/splunk_add_on_ucc_framework/commands/publish.py
+++ b/splunk_add_on_ucc_framework/commands/publish.py
@@ -122,7 +122,10 @@ def check_package_validation(
     try:
         with urllib.request.urlopen(request, context=context) as response:
             response_data = json.loads(response.read().decode("utf-8"))
-            logger.info("Validation status: {}".format(response_data.get("message")))
+            if (response_data.get("result") == "pass"):
+                logger.info("Validation status: {}".format(response_data.get("message")))
+            else:
+                raise Exception(response_data.get("message"))
     except urllib.error.HTTPError as e:
         error_msg = e.read().decode()
         logger.error(f"Failed to retrieve package validation status. {error_msg}")

--- a/splunk_add_on_ucc_framework/commands/publish.py
+++ b/splunk_add_on_ucc_framework/commands/publish.py
@@ -62,6 +62,7 @@ def encode_multipart_formdata(
 
 
 def upload_package(
+    base_url: str,
     app_id: int,
     package_path: str,
     splunk_versions: str,
@@ -70,7 +71,7 @@ def upload_package(
     username: str,
     password: str,
 ) -> str:
-    upload_url = f"https://splunkbase.splunk.com/api/v1/app/{app_id}/new_release/"
+    upload_url = f"{base_url}/app/{app_id}/new_release/"
 
     fields = {
         "filename": os.path.basename(package_path),
@@ -109,9 +110,9 @@ def upload_package(
 
 
 def check_package_validation(
-    package_upload_id: str, username: str, password: str
+    base_url: str, package_upload_id: str, username: str, password: str
 ) -> None:
-    url = f"https://splunkbase.splunk.com/api/v1/package/{package_upload_id}/"
+    url = f"{base_url}/package/{package_upload_id}/"
     auth_header = base64.b64encode(f"{username}:{password}".encode()).decode("utf-8")
     context = ssl.create_default_context(cafile=certifi.where())
 
@@ -129,6 +130,7 @@ def check_package_validation(
 
 
 def publish_package(
+    use_stage: bool,
     app_id: int,
     package_path: str,
     splunk_versions: str,
@@ -137,7 +139,12 @@ def publish_package(
     username: str,
     password: str,
 ) -> None:
+    if use_stage:
+        API_BASEURL = "https://classic.stage.splunkbase.splunk.com/api/v1"
+    else:
+        API_BASEURL = "https://splunkbase.splunk.com/api/v1"
     package_upload_id = upload_package(
+        API_BASEURL,
         app_id,
         package_path,
         splunk_versions,
@@ -147,4 +154,4 @@ def publish_package(
         password,
     )
     if package_upload_id:
-        check_package_validation(package_upload_id, username, password)
+        check_package_validation(API_BASEURL, package_upload_id, username, password)

--- a/splunk_add_on_ucc_framework/commands/publish.py
+++ b/splunk_add_on_ucc_framework/commands/publish.py
@@ -122,8 +122,10 @@ def check_package_validation(
     try:
         with urllib.request.urlopen(request, context=context) as response:
             response_data = json.loads(response.read().decode("utf-8"))
-            if (response_data.get("result") == "pass"):
-                logger.info("Validation status: {}".format(response_data.get("message")))
+            if response_data.get("result") == "pass":
+                logger.info(
+                    "Validation status: {}".format(response_data.get("message"))
+                )
             else:
                 raise Exception(response_data.get("message"))
     except urllib.error.HTTPError as e:

--- a/splunk_add_on_ucc_framework/main.py
+++ b/splunk_add_on_ucc_framework/main.py
@@ -261,6 +261,12 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         "publish", description="Publish package to the Splunkbase"
     )
     publish_parser.add_argument(
+        "--stage",
+        dest="stage",
+        help="Whether to release the app on staging or production splunkbase.",
+        action="store_true",
+    )
+    publish_parser.add_argument(
         "--app-id",
         type=int,
         help="Splunkbase numerical app id listed in the URL of the app details page.",
@@ -334,6 +340,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         )
     if args.command == "publish":
         publish.publish_package(
+            use_stage=args.stage,
             app_id=args.app_id,
             package_path=args.package_path,
             splunk_versions=args.splunk_versions,

--- a/tests/unit/commands/test_publish.py
+++ b/tests/unit/commands/test_publish.py
@@ -23,6 +23,7 @@ class TestPackageUpload:
         mock_urlopen.return_value.__exit__ = MagicMock(return_value=None)
 
         pkg_id = upload_package(
+            base_url="https://dummy_url",
             app_id=1001,
             package_path="tests/test_package.tgz",
             splunk_versions="9.5",
@@ -48,7 +49,7 @@ class TestPackageUpload:
         mock_urlopen.return_value.__exit__ = MagicMock(return_value=None)
 
         pkg_id = upload_package(
-            1001, "tests/test_package.tgz", "9.5", "6.x", True, "user", "pass"
+            "https://dummy_url", 1001, "tests/test_package.tgz", "9.5", "6.x", True, "user", "pass"
         )
         assert pkg_id == ""
         mock_file.assert_called_once_with("tests/test_package.tgz", "rb")
@@ -75,7 +76,7 @@ class TestPackageUpload:
 
         with pytest.raises(urllib.error.HTTPError):
             upload_package(
-                1001, "tests/test_package.tgz", "9.5", "6.x", True, "user", "pass"
+                "https://dummy_url", 1001, "tests/test_package.tgz", "9.5", "6.x", True, "user", "pass"
             )
             mock_file.assert_called_once_with("tests/test_package.tgz", "rb")
             mock_logger.error.assert_called_with(
@@ -95,7 +96,7 @@ class TestPackageValidation:
         mock_urlopen.return_value.__enter__ = MagicMock(return_value=mock_response)
         mock_urlopen.return_value.__exit__ = MagicMock(return_value=None)
 
-        check_package_validation("pkg123", "user", "pass")  # should not raise
+        check_package_validation("https://dummy_url", "pkg123", "user", "pass")  # should not raise
         mock_logger.info.assert_called_with("Validation status: Validation passed")
 
     @patch("splunk_add_on_ucc_framework.commands.publish.logger")
@@ -115,7 +116,7 @@ class TestPackageValidation:
         mock_urlopen.return_value.__exit__ = MagicMock(return_value=None)
 
         with pytest.raises(urllib.error.HTTPError):
-            check_package_validation("pkg123", "user", "pass")
+            check_package_validation("https://dummy_url", "pkg123", "user", "pass")
             mock_logger.error.assert_called_with(
                 f"Failed to retrieve package validation status. {mock_error.read().decode()}"
             )

--- a/tests/unit/commands/test_publish.py
+++ b/tests/unit/commands/test_publish.py
@@ -49,7 +49,14 @@ class TestPackageUpload:
         mock_urlopen.return_value.__exit__ = MagicMock(return_value=None)
 
         pkg_id = upload_package(
-            "https://dummy_url", 1001, "tests/test_package.tgz", "9.5", "6.x", True, "user", "pass"
+            "https://dummy_url",
+            1001,
+            "tests/test_package.tgz",
+            "9.5",
+            "6.x",
+            True,
+            "user",
+            "pass",
         )
         assert pkg_id == ""
         mock_file.assert_called_once_with("tests/test_package.tgz", "rb")
@@ -76,7 +83,14 @@ class TestPackageUpload:
 
         with pytest.raises(urllib.error.HTTPError):
             upload_package(
-                "https://dummy_url", 1001, "tests/test_package.tgz", "9.5", "6.x", True, "user", "pass"
+                "https://dummy_url",
+                1001,
+                "tests/test_package.tgz",
+                "9.5",
+                "6.x",
+                True,
+                "user",
+                "pass",
             )
             mock_file.assert_called_once_with("tests/test_package.tgz", "rb")
             mock_logger.error.assert_called_with(
@@ -96,7 +110,9 @@ class TestPackageValidation:
         mock_urlopen.return_value.__enter__ = MagicMock(return_value=mock_response)
         mock_urlopen.return_value.__exit__ = MagicMock(return_value=None)
 
-        check_package_validation("https://dummy_url", "pkg123", "user", "pass")  # should not raise
+        check_package_validation(
+            "https://dummy_url", "pkg123", "user", "pass"
+        )  # should not raise
         mock_logger.info.assert_called_with("Validation status: Validation passed")
 
     @patch("splunk_add_on_ucc_framework.commands.publish.logger")

--- a/tests/unit/commands/test_publish.py
+++ b/tests/unit/commands/test_publish.py
@@ -90,7 +90,7 @@ class TestPackageValidation:
     def test_check_package_validation_success(self, mock_urlopen, mock_logger):
         mock_response = MagicMock()
         mock_response.read.return_value = json.dumps(
-            {"message": "Validation passed"}
+            {"message": "Validation passed", "result": "pass"}
         ).encode("utf-8")
         mock_urlopen.return_value = mock_response
         mock_urlopen.return_value.__enter__ = MagicMock(return_value=mock_response)

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -525,6 +525,7 @@ def test_package_command(mock_package, args, expected_parameters):
         (
             [
                 "publish",
+                "--stage",
                 "--app-id",
                 "123",
                 "--package-path",
@@ -539,6 +540,7 @@ def test_package_command(mock_package, args, expected_parameters):
                 "pass",
             ],
             {
+                "use_stage": True,
                 "app_id": 123,
                 "package_path": "dist/app.tar.gz",
                 "splunk_versions": "9.5",
@@ -566,6 +568,7 @@ def test_package_command(mock_package, args, expected_parameters):
                 "--make-visible",
             ],
             {
+                "use_stage": False,
                 "app_id": 456,
                 "package_path": "/tmp/app.tar.gz",
                 "splunk_versions": "9.1,9.2",


### PR DESCRIPTION
**Issue number:**

### PR Type

**What kind of change does this PR introduce?**
* [x] Feature
* [ ] Bug Fix
* [ ] Refactoring (no functional or API changes)
* [ ] Documentation Update
* [ ] Maintenance (dependency updates, CI, etc.)

## Summary
Added new argument `--stage` to `ucc-gen publish` command to enable users to use staging splunkbase to publish the package.

### Changes
- No major changes. Just a new argument to existing command

### User experience
- No change

## Checklist

If an item doesn't apply to your changes, leave it unchecked.

### Review

* [x] self-review - I have performed a self-review of this change according to the [development guidelines](https://splunk.github.io/addonfactory-ucc-generator/contributing/#development-guidelines)
* [x] Changes are documented. The documentation is understandable, examples work [(more info)](https://splunk.github.io/addonfactory-ucc-generator/contributing/#documentation-guidelines)
* [x] PR title and description follows the [contributing principles](https://splunk.github.io/addonfactory-ucc-generator/contributing/#pull-requests)
* [ ] meeting - I have scheduled a meeting or recorded a demo to explain these changes (if there is a video, put a link below and in the ticket)

### Tests

See [the testing doc](https://splunk.github.io/addonfactory-ucc-generator/contributing/#build-and-test).

* [x] Unit - tests have been added/modified to cover the changes
* [ ] Smoke - tests have been added/modified to cover the changes
* [ ] UI - tests have been added/modified to cover the changes
* [ ] coverage - I have checked the code coverage of my changes [(see more)](https://splunk.github.io/addonfactory-ucc-generator/contributing/#checking-the-code-coverage)

**Demo/meeting:**

*Reviewers are encouraged to request meetings or demos if any part of the change is unclear*
