### PR TITLE
fix: include built UI files in the wheel package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,10 @@ version = "6.0.0"
 description = "Splunk Add-on SDK formerly UCC is a build and code generation framework"
 license = "Apache-2.0"
 authors = ["Splunk <addonfactory@splunk.com>"]
-include = ["NOTICE", "splunk_add_on_ucc_framework/package/appserver/**/*"]
+include = [
+    { path = "NOTICE", format = ["sdist", "wheel"] },
+    { path = "splunk_add_on_ucc_framework/package/appserver/**/*", format = ["sdist", "wheel"] }
+]
 readme = "README.md"
 homepage = "https://github.com/splunk/addonfactory-ucc-generator"
 repository = "https://github.com/splunk/addonfactory-ucc-generator"


### PR DESCRIPTION
**Issue number:** ADDON-83800

### PR Type

**What kind of change does this PR introduce?**
* [ ] Feature
* [x] Bug Fix
* [ ] Refactoring (no functional or API changes)
* [ ] Documentation Update
* [ ] Maintenance (dependency updates, CI, etc.)

## Summary

### Changes

Poetry changed the format of `pyproject.toml`, related to included files.

Our existing configuration resulted in inclusion of files only in the `sdist` package, not in the `wheel`.

This resulted in no UI files in the UCC wheel package.

### User experience

It makes UCC usable.

## Checklist

If an item doesn't apply to your changes, leave it unchecked.

### Review

* [x] self-review - I have performed a self-review of this change according to the [development guidelines](https://splunk.github.io/addonfactory-ucc-generator/contributing/#development-guidelines)
* [ ] Changes are documented. The documentation is understandable, examples work [(more info)](https://splunk.github.io/addonfactory-ucc-generator/contributing/#documentation-guidelines)
* [x] PR title and description follows the [contributing principles](https://splunk.github.io/addonfactory-ucc-generator/contributing/#pull-requests)
* [ ] meeting - I have scheduled a meeting or recorded a demo to explain these changes (if there is a video, put a link below and in the ticket)

### Tests

See [the testing doc](https://splunk.github.io/addonfactory-ucc-generator/contributing/#build-and-test).

* [x] Unit - tests have been added/modified to cover the changes
* [ ] Smoke - tests have been added/modified to cover the changes
* [ ] UI - tests have been added/modified to cover the changes
* [ ] coverage - I have checked the code coverage of my changes [(see more)](https://splunk.github.io/addonfactory-ucc-generator/contributing/#checking-the-code-coverage)

**Demo/meeting:**

*Reviewers are encouraged to request meetings or demos if any part of the change is unclear*
