### PR TITLE
chore: migrate from FOSSA to SRS configuration

### DIFF
--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -48,3 +48,4 @@ header:
     - "splunk_add_on_ucc_framework/commands/imports.py"
     - "scripts/rum-script.html"
     - "mypy.ini"
+    - "srs.yaml"

--- a/srs.yaml
+++ b/srs.yaml
@@ -1,0 +1,21 @@
+# SRS configuration file
+# Generated from .fossa.yml
+#
+
+scan:
+  scanners:
+  - vuln
+  - license
+  skip-files:
+  - splunk_add_on_ucc_framework/commands/init_template/{{cookiecutter.addon_name}}/package/lib/pyproject.toml
+  - splunk_add_on_ucc_framework/commands/init_template/{{cookiecutter.addon_name}}/package/lib/setup.cfg
+  - splunk_add_on_ucc_framework/commands/init_template/{{cookiecutter.addon_name}}/package/lib/setup.py
+  - tests/testdata/expected_addons/expected_addon_after_init/demo_addon_for_splunk/package/lib/pyproject.toml
+  - tests/testdata/expected_addons/expected_addon_after_init/demo_addon_for_splunk/package/lib/setup.cfg
+  - tests/testdata/expected_addons/expected_addon_after_init/demo_addon_for_splunk/package/lib/setup.py
+  - tests/testdata/test_addons/package_global_config_configuration/package/lib/pyproject.toml
+  - tests/testdata/test_addons/package_global_config_configuration/package/lib/setup.cfg
+  - tests/testdata/test_addons/package_global_config_configuration/package/lib/setup.py
+  - tests/testdata/test_addons/package_global_config_everything/package/lib/pyproject.toml
+  - tests/testdata/test_addons/package_global_config_everything/package/lib/setup.cfg
+  - tests/testdata/test_addons/package_global_config_everything/package/lib/setup.py


### PR DESCRIPTION
## Summary
- Add `srs.yaml` configuration file generated from `.fossa.yml` settings
- Map FOSSA `paths.exclude` to SRS `skip-dirs` and FOSSA `targets.exclude` to SRS `skip-files`
- Update `.licenserc.yaml` to exclude `srs.yaml` from license header checks

## Test plan
- [ ] Verify `srs.yaml` contains correct scanner configuration (vuln + license)
- [ ] Verify skip-files list matches the original FOSSA exclusions
- [ ] Verify `.licenserc.yaml` correctly excludes `srs.yaml`

This change migrates open source dependency scanning from FOSSA to Splunk's internal SRS system.

Closes #1994

🤖 Generated with [Claude Code](https://claude.com/claude-code)