### PR TITLE
feat(validate): expose detailed AppInspect output options

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -135,6 +135,10 @@ You can install the required dependencies using the following command:
 It accepts the following parameters:
 
 * `--addon-path` - [required] Specifies the path to the built add-on that you want to validate.
+* `--output-file` - [optional] Writes detailed AppInspect validation output to a file.
+* `--log-level` - [optional] Sets the AppInspect logging level, for example `DEBUG`, `INFO`, `WARNING`, `ERROR`, or `CRITICAL`.
+* `--log-file` - [optional] Writes AppInspect logs to a file.
+* `--max-messages` - [optional] Limits the number of AppInspect messages per check, or accepts `all` to include every message.
 
 ## `ucc-gen publish`
 

--- a/splunk_add_on_ucc_framework/commands/validate.py
+++ b/splunk_add_on_ucc_framework/commands/validate.py
@@ -15,12 +15,40 @@
 #
 import logging
 import sys
+from typing import Optional
 
 logger = logging.getLogger("ucc_gen")
 
 
+def build_validate_args(
+    file_path: str,
+    output_file: Optional[str] = None,
+    log_level: Optional[str] = None,
+    log_file: Optional[str] = None,
+    max_messages: Optional[str] = None,
+) -> list[str]:
+    args = [file_path, "--included-tags", "cloud"]
+
+    if output_file:
+        args.extend(["--output-file", output_file])
+    if log_level:
+        args.extend(["--log-level", log_level])
+    if log_file:
+        args.extend(["--log-file", log_file])
+    if max_messages:
+        args.extend(["--max-messages", max_messages])
+
+    return args
+
+
 # Tested in the CI during the build process of test add-on.
-def validate(file_path: str) -> None:
+def validate(
+    file_path: str,
+    output_file: Optional[str] = None,
+    log_level: Optional[str] = None,
+    log_file: Optional[str] = None,
+    max_messages: Optional[str] = None,
+) -> None:
     try:
         from splunk_appinspect import main
     except ModuleNotFoundError:
@@ -30,4 +58,12 @@ def validate(file_path: str) -> None:
         )
         sys.exit(1)
     else:
-        main.validate([f"{file_path}", "--included-tags", "cloud"])
+        main.validate(
+            build_validate_args(
+                file_path=file_path,
+                output_file=output_file,
+                log_level=log_level,
+                log_file=log_file,
+                max_messages=max_messages,
+            )
+        )

--- a/splunk_add_on_ucc_framework/main.py
+++ b/splunk_add_on_ucc_framework/main.py
@@ -256,6 +256,34 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         help="Path of the Splunk app.",
         required=True,
     )
+    validate_parser.add_argument(
+        "--output-file",
+        type=str,
+        help="Write detailed AppInspect validation output to a file.",
+        required=False,
+        default=None,
+    )
+    validate_parser.add_argument(
+        "--log-level",
+        type=str,
+        help="Set the AppInspect logging level, for example DEBUG, INFO, WARNING, ERROR, or CRITICAL.",
+        required=False,
+        default=None,
+    )
+    validate_parser.add_argument(
+        "--log-file",
+        type=str,
+        help="Write AppInspect logs to a file.",
+        required=False,
+        default=None,
+    )
+    validate_parser.add_argument(
+        "--max-messages",
+        type=str,
+        help="Limit the number of AppInspect messages per check, or use all.",
+        required=False,
+        default=None,
+    )
 
     publish_parser = subparsers.add_parser(
         "publish", description="Publish package to the Splunkbase"
@@ -315,7 +343,13 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     if args.command == "package":
         package.package(path_to_built_addon=args.path, output_directory=args.output)
     if args.command == "validate":
-        validate.validate(file_path=args.addon_path)
+        validate.validate(
+            file_path=args.addon_path,
+            output_file=args.output_file,
+            log_level=args.log_level,
+            log_file=args.log_file,
+            max_messages=args.max_messages,
+        )
     if args.command == "init":
         init.init(
             addon_name=args.addon_name,

--- a/tests/testdata/test_addons/package_conf_only_TA/globalConfig.json
+++ b/tests/testdata/test_addons/package_conf_only_TA/globalConfig.json
@@ -2,7 +2,7 @@
     "meta": {
         "name": "Splunk_TA_UCCExample",
         "restRoot": "splunk_ta_uccexample",
-        "version": "6.2.0+f57c133b4",
+        "version": "6.2.0+38a26eac5",
         "displayName": "Splunk UCC test Add-on",
         "schemaVersion": "0.0.10"
     }

--- a/tests/testdata/test_addons/package_files_conflict_test/globalConfig.json
+++ b/tests/testdata/test_addons/package_files_conflict_test/globalConfig.json
@@ -199,7 +199,7 @@
     "meta": {
         "name": "test_addon",
         "restRoot": "test_addon",
-        "version": "6.2.0+f57c133b4",
+        "version": "6.2.0+38a26eac5",
         "displayName": "This is my add-on",
         "schemaVersion": "0.0.10"
     }

--- a/tests/testdata/test_addons/package_global_config_configuration/globalConfig.json
+++ b/tests/testdata/test_addons/package_global_config_configuration/globalConfig.json
@@ -454,7 +454,7 @@
     "meta": {
         "name": "Splunk_TA_UCCExample",
         "restRoot": "splunk_ta_uccexample",
-        "version": "6.2.0+f57c133b4",
+        "version": "6.2.0+38a26eac5",
         "displayName": "Splunk UCC test Add-on",
         "schemaVersion": "0.0.10"
     }

--- a/tests/testdata/test_addons/package_global_config_everything/globalConfig.json
+++ b/tests/testdata/test_addons/package_global_config_everything/globalConfig.json
@@ -2386,7 +2386,7 @@
     "meta": {
         "name": "Splunk_TA_UCCExample",
         "restRoot": "splunk_ta_uccexample",
-        "version": "6.2.0+f57c133b4",
+        "version": "6.2.0+38a26eac5",
         "displayName": "Splunk UCC test Add-on",
         "schemaVersion": "0.0.10",
         "supportedThemes": [

--- a/tests/testdata/test_addons/package_global_config_everything_uccignore/globalConfig.json
+++ b/tests/testdata/test_addons/package_global_config_everything_uccignore/globalConfig.json
@@ -1236,7 +1236,7 @@
     "meta": {
         "name": "Splunk_TA_UCCExample",
         "restRoot": "splunk_ta_uccexample",
-        "version": "6.2.0+f57c133b4",
+        "version": "6.2.0+38a26eac5",
         "displayName": "Splunk UCC test Add-on",
         "schemaVersion": "0.0.10"
     }

--- a/tests/testdata/test_addons/package_global_config_multi_input/globalConfig.json
+++ b/tests/testdata/test_addons/package_global_config_multi_input/globalConfig.json
@@ -763,7 +763,7 @@
     "meta": {
         "name": "Splunk_TA_UCCExample",
         "restRoot": "splunk_ta_uccexample",
-        "version": "6.2.0+f57c133b4",
+        "version": "6.2.0+38a26eac5",
         "displayName": "Splunk UCC test Add-on",
         "schemaVersion": "0.0.10"
     }

--- a/tests/testdata/test_addons/package_global_config_only_one_tab/globalConfig.json
+++ b/tests/testdata/test_addons/package_global_config_only_one_tab/globalConfig.json
@@ -36,7 +36,7 @@
     "meta": {
         "name": "Splunk_TA_UCCExample",
         "restRoot": "splunk_ta_uccexample",
-        "version": "6.2.0+f57c133b4",
+        "version": "6.2.0+38a26eac5",
         "displayName": "Splunk UCC test Add-on",
         "schemaVersion": "0.0.10"
     }

--- a/tests/unit/commands/test_validate.py
+++ b/tests/unit/commands/test_validate.py
@@ -1,0 +1,65 @@
+import types
+from unittest import mock
+
+from splunk_add_on_ucc_framework.commands import validate
+
+
+def test_build_validate_args_defaults():
+    args = validate.build_validate_args("output/foo")
+
+    assert args == ["output/foo", "--included-tags", "cloud"]
+
+
+def test_build_validate_args_with_optional_parameters():
+    args = validate.build_validate_args(
+        "output/foo",
+        output_file="/tmp/report.txt",
+        log_level="WARNING",
+        log_file="/tmp/validation.log",
+        max_messages="all",
+    )
+
+    assert args == [
+        "output/foo",
+        "--included-tags",
+        "cloud",
+        "--output-file",
+        "/tmp/report.txt",
+        "--log-level",
+        "WARNING",
+        "--log-file",
+        "/tmp/validation.log",
+        "--max-messages",
+        "all",
+    ]
+
+
+def test_validate_forwards_optional_parameters():
+    mock_appinspect_validate = mock.Mock()
+    fake_main = types.SimpleNamespace(validate=mock_appinspect_validate)
+    fake_module = types.SimpleNamespace(main=fake_main)
+
+    with mock.patch.dict("sys.modules", {"splunk_appinspect": fake_module}):
+        validate.validate(
+            file_path="output/foo",
+            output_file="/tmp/report.txt",
+            log_level="WARNING",
+            log_file="/tmp/validation.log",
+            max_messages="all",
+        )
+
+    mock_appinspect_validate.assert_called_with(
+        [
+            "output/foo",
+            "--included-tags",
+            "cloud",
+            "--output-file",
+            "/tmp/report.txt",
+            "--log-level",
+            "WARNING",
+            "--log-file",
+            "/tmp/validation.log",
+            "--max-messages",
+            "all",
+        ]
+    )

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -523,6 +523,50 @@ def test_package_command(mock_package, args, expected_parameters):
     "args,expected_parameters",
     [
         (
+            ["validate", "--addon-path", "output/foo"],
+            {
+                "file_path": "output/foo",
+                "output_file": None,
+                "log_level": None,
+                "log_file": None,
+                "max_messages": None,
+            },
+        ),
+        (
+            [
+                "validate",
+                "--addon-path",
+                "output/foo",
+                "--output-file",
+                "/tmp/validation_report.txt",
+                "--log-level",
+                "WARNING",
+                "--log-file",
+                "/tmp/validation_log.txt",
+                "--max-messages",
+                "all",
+            ],
+            {
+                "file_path": "output/foo",
+                "output_file": "/tmp/validation_report.txt",
+                "log_level": "WARNING",
+                "log_file": "/tmp/validation_log.txt",
+                "max_messages": "all",
+            },
+        ),
+    ],
+)
+@mock.patch("splunk_add_on_ucc_framework.commands.validate.validate")
+def test_validate_command(mock_validate, args, expected_parameters):
+    main.main(args)
+
+    mock_validate.assert_called_with(**expected_parameters)
+
+
+@pytest.mark.parametrize(
+    "args,expected_parameters",
+    [
+        (
             [
                 "publish",
                 "--app-id",


### PR DESCRIPTION
**Issue number:**
#1976

### PR Type

**What kind of change does this PR introduce?**
* [x] Feature
* [ ] Bug Fix
* [ ] Refactoring (no functional or API changes)
* [x] Documentation Update
* [ ] Maintenance (dependency updates, CI, etc.)

## Summary

### Changes

- add `ucc-gen validate` flags for `--output-file`, `--log-level`, `--log-file`, and `--max-messages`
- forward those options from the CLI parser into the AppInspect invocation instead of hardcoding only the addon path
- add unit tests for both CLI argument parsing and the final AppInspect argv construction
- document the new validate command parameters in `docs/commands.md`

### User experience

Before this change, `ucc-gen validate` only exposed `--addon-path` and printed a high-level AppInspect summary, which made it hard to inspect the detailed warnings or failures needed for follow-up fixes.

After this change, users can write the full validation report to a file, capture AppInspect logs at a chosen log level, and control message suppression with `--max-messages`, making the command usable for debugging and review workflows.

## Checklist

If an item does not apply to your changes, leave it unchecked.

### Review

* [x] self-review - I have performed a self-review of this change according to the [development guidelines](https://splunk.github.io/addonfactory-ucc-generator/contributing/#development-guidelines)
* [x] Changes are documented. The documentation is understandable, examples work [(more info)](https://splunk.github.io/addonfactory-ucc-generator/contributing/#documentation-guidelines)
* [x] PR title and description follows the [contributing principles](https://splunk.github.io/addonfactory-ucc-generator/contributing/#pull-requests)
* [ ] meeting - I have scheduled a meeting or recorded a demo to explain these changes (if there is a video, put a link below and in the ticket)

### Tests

See [the testing doc](https://splunk.github.io/addonfactory-ucc-generator/contributing/#build-and-test).

* [x] Unit - tests have been added/modified to cover the changes
* [ ] Smoke - tests have been added/modified to cover the changes
* [ ] UI - tests have been added/modified to cover the changes
* [ ] coverage - I have checked the code coverage of my changes [(see more)](https://splunk.github.io/addonfactory-ucc-generator/contributing/#checking-the-code-coverage)

**Demo/meeting:**

Manual validation check completed locally against the built `Splunk_TA_UCCExample` fixture to confirm `--output-file`, `--log-level`, `--log-file`, and `--max-messages` are forwarded and affect AppInspect output.

*Reviewers are encouraged to request meetings or demos if any part of the change is unclear*