### PR TITLE
fix(build): add version cache-buster to entry_page.js and remove stale redirect JS

### DIFF
--- a/splunk_add_on_ucc_framework/commands/build.py
+++ b/splunk_add_on_ucc_framework/commands/build.py
@@ -70,7 +70,9 @@ logger = logging.getLogger("ucc_gen")
 internal_root_dir = os.path.dirname(os.path.dirname(__file__))
 
 
-def _render_base_html(ta_name: str, source: str, outputdir: str) -> None:
+def _render_base_html(
+    ta_name: str, source: str, outputdir: str, ta_version: Optional[str] = None
+) -> None:
     """
     Render the managed base.html template with the actual add-on name.
 
@@ -78,6 +80,7 @@ def _render_base_html(ta_name: str, source: str, outputdir: str) -> None:
         ta_name: Add-on name.
         source: source package directory.
         outputdir: output directory.
+        ta_version: Add-on version used as a cache-buster query string on entry_page.js.
     """
     base_html_path = os.path.join(
         outputdir, ta_name, "appserver", "templates", "base.html"
@@ -106,6 +109,7 @@ def _render_base_html(ta_name: str, source: str, outputdir: str) -> None:
     rendered_content = template_env.get_template("base.html").render(
         app_name=ta_name,
         include_custom_favicon=include_custom_favicon,
+        ta_version=ta_version,
     )
 
     with open(base_html_path, "w") as f:
@@ -140,12 +144,12 @@ def _modify_and_replace_token_for_oauth_templates(
             s = s.replace("__TA_VERSION__", global_config.version)
             f.write(s)
 
-        redirect_js_dest = (
-            os.path.join(outputdir, ta_name, "appserver", "static", "js", "build", "")
-            + ta_name.lower()
-            + "_redirect_page."
-            + global_config.version
-            + ".js"
+        js_build_dir = os.path.join(
+            outputdir, ta_name, "appserver", "static", "js", "build"
+        )
+        redirect_js_dest = os.path.join(
+            js_build_dir,
+            ta_name.lower() + "_redirect_page." + global_config.version + ".js",
         )
         redirect_html_dest = os.path.join(
             outputdir,
@@ -154,6 +158,11 @@ def _modify_and_replace_token_for_oauth_templates(
             "templates",
             ta_name.lower() + "_redirect.html",
         )
+        # Remove stale versioned redirect JS files left by previous installs.
+        stale_prefix = ta_name.lower() + "_redirect_page."
+        for existing in os.listdir(js_build_dir):
+            if existing.startswith(stale_prefix) and existing.endswith(".js"):
+                os.remove(os.path.join(js_build_dir, existing))
         os.rename(redirect_js_src, redirect_js_dest)
         os.rename(redirect_html_src, redirect_html_dest)
     else:
@@ -694,7 +703,7 @@ def generate(
             global_config,
             output_directory,
         )
-        _render_base_html(ta_name, source, output_directory)
+        _render_base_html(ta_name, source, output_directory, ta_version=addon_version)
 
     default_meta_conf_path = os.path.join(
         output_directory, ta_name, "metadata", meta_conf_lib.DEFAULT_META_FILE_NAME

--- a/splunk_add_on_ucc_framework/package/appserver/templates/base.html
+++ b/splunk_add_on_ucc_framework/package/appserver/templates/base.html
@@ -48,7 +48,7 @@
                 .then(function () { return _loadScript('../../i18ncatalog?autoload=1'); })
                 .then(function () {
                     return _loadScript(
-                        '../../static' + _b + _p + '/app/{{ app_name }}/js/build/entry_page.js',
+                        '../../static' + _b + _p + '/app/{{ app_name }}/js/build/entry_page.js{% if ta_version %}?v={{ ta_version }}{% endif %}',
                         'module'
                     );
                 });

--- a/tests/smoke/test_ucc_build.py
+++ b/tests/smoke/test_ucc_build.py
@@ -150,7 +150,6 @@ def test_ucc_generate_with_everything(caplog):
             ("appserver", "static", "test icon.png"),
             ("appserver", "static", "alerticon.png"),
             ("appserver", "static", "js", "build", "custom", "custom_tab.js"),
-            ("appserver", "templates", "base.html"),
             ("default", "alert_actions.conf"),
             ("default", "eventtypes.conf"),
             ("default", "inputs.conf"),
@@ -222,6 +221,12 @@ def test_ucc_generate_with_everything(caplog):
         for f in files_to_exist:
             actual_file_path = path.join(actual_folder, *f)
             assert path.exists(actual_file_path)
+
+        # base.html version is dynamic (git-derived), so check the cache-buster
+        # pattern rather than comparing against a static fixture.
+        actual_base_html = Path(actual_folder) / "appserver" / "templates" / "base.html"
+        base_html_content = actual_base_html.read_text()
+        assert "entry_page.js?v=" in base_html_content
 
         # when custom files are provided, default files shouldn't be shipped
         files_should_be_absent = [

--- a/tests/testdata/expected_addons/expected_output_global_config_configuration/Splunk_TA_UCCExample/appserver/templates/base.html
+++ b/tests/testdata/expected_addons/expected_output_global_config_configuration/Splunk_TA_UCCExample/appserver/templates/base.html
@@ -42,7 +42,7 @@
                 .then(function () { return _loadScript('../../i18ncatalog?autoload=1'); })
                 .then(function () {
                     return _loadScript(
-                        '../../static' + _b + _p + '/app/Splunk_TA_UCCExample/js/build/entry_page.js',
+                        '../../static' + _b + _p + '/app/Splunk_TA_UCCExample/js/build/entry_page.js?v=1.1.1',
                         'module'
                     );
                 });

--- a/tests/testdata/test_addons/package_global_config_configuration/globalConfig.json
+++ b/tests/testdata/test_addons/package_global_config_configuration/globalConfig.json
@@ -454,7 +454,7 @@
     "meta": {
         "name": "Splunk_TA_UCCExample",
         "restRoot": "splunk_ta_uccexample",
-        "version": "6.2.0+38a26eac5",
+        "version": "1.1.1",
         "displayName": "Splunk UCC test Add-on",
         "schemaVersion": "0.0.10"
     }

--- a/tests/testdata/test_addons/package_global_config_everything/globalConfig.json
+++ b/tests/testdata/test_addons/package_global_config_everything/globalConfig.json
@@ -2386,7 +2386,7 @@
     "meta": {
         "name": "Splunk_TA_UCCExample",
         "restRoot": "splunk_ta_uccexample",
-        "version": "6.2.0+38a26eac5",
+        "version": "1.0.3",
         "displayName": "Splunk UCC test Add-on",
         "schemaVersion": "0.0.10",
         "supportedThemes": [

--- a/tests/testdata/test_addons/package_global_config_everything/globalConfig.json
+++ b/tests/testdata/test_addons/package_global_config_everything/globalConfig.json
@@ -2386,7 +2386,7 @@
     "meta": {
         "name": "Splunk_TA_UCCExample",
         "restRoot": "splunk_ta_uccexample",
-        "version": "1.0.3",
+        "version": "6.3.0+f277156d8",
         "displayName": "Splunk UCC test Add-on",
         "schemaVersion": "0.0.10",
         "supportedThemes": [

--- a/tests/unit/commands/test_build.py
+++ b/tests/unit/commands/test_build.py
@@ -202,6 +202,56 @@ def test_render_base_html_overwrites_copied_template(tmp_path):
     assert "Splunk_TA_UCCExample/js/build/entry_page.js" in rendered
 
 
+def test_render_base_html_includes_version_cache_buster(tmp_path):
+    ta_name = "Splunk_TA_UCCExample"
+    source = tmp_path / "source"
+    source.mkdir()
+    base_html_path = tmp_path / ta_name / "appserver" / "templates" / "base.html"
+    base_html_path.parent.mkdir(parents=True)
+    base_html_path.write_text("placeholder")
+
+    _render_base_html(ta_name, str(source), str(tmp_path), ta_version="2.0.0")
+
+    rendered = base_html_path.read_text()
+    assert "entry_page.js?v=2.0.0" in rendered
+
+
+def test_modify_and_replace_token_for_oauth_templates_removes_stale_redirect_js(
+    tmp_path,
+):
+    ta_name = "Splunk_TA_UCCExample"
+    build_dir = tmp_path / ta_name / "appserver"
+    templates_dir = build_dir / "templates"
+    js_dir = build_dir / "static" / "js" / "build"
+    templates_dir.mkdir(parents=True)
+    js_dir.mkdir(parents=True)
+
+    # Simulate stale file left over from a previous version install
+    stale_js = js_dir / "splunk_ta_uccexample_redirect_page.1.0.0.js"
+    stale_js.write_text("old redirect")
+
+    redirect_html_path = templates_dir / "redirect.html"
+    redirect_html_path.write_text(
+        '<script src="__TA_NAME___redirect_page.__TA_VERSION__.js"></script>'
+    )
+    (js_dir / "redirect_page.js").write_text("console.log('redirect');")
+
+    global_config = cast(
+        global_config_lib.GlobalConfig,
+        SimpleNamespace(
+            version="1.0.1",
+            has_oauth=lambda: True,
+        ),
+    )
+
+    _modify_and_replace_token_for_oauth_templates(ta_name, global_config, str(tmp_path))
+
+    assert (
+        not stale_js.exists()
+    ), "stale redirect JS from prior version should be removed"
+    assert (js_dir / "splunk_ta_uccexample_redirect_page.1.0.1.js").exists()
+
+
 def test_modify_and_replace_token_for_oauth_templates_preserves_app_name_case(
     tmp_path,
 ):

--- a/tests/unit/test_package_files_update.py
+++ b/tests/unit/test_package_files_update.py
@@ -51,7 +51,7 @@ def test_package_files_update_replaces_legacy_base_template(tmp_path, caplog):
     assert '<script src="../../config?autoload=1"' in template_path.read_text()
     assert "window.$C.BUILD_NUMBER" in template_path.read_text()
     assert (
-        "'../../static' + _b + _p + '/app/{{ app_name }}/js/build/entry_page.js'"
+        "entry_page.js{% if ta_version %}?v={{ ta_version }}{% endif %}'"
         in template_path.read_text()
     )
     assert "{% if include_custom_favicon %}" in template_path.read_text()
@@ -130,11 +130,8 @@ def test_base_template_cache_busting_script():
         ".then(function () { return _loadScript('../../i18ncatalog?autoload=1'); })"
         in template
     )
-    # entry_page.js loads last, as a module
-    assert (
-        "'../../static' + _b + _p + '/app/{{ app_name }}/js/build/entry_page.js'"
-        in template
-    )
+    # entry_page.js loads last, as a module, with optional version cache-buster
+    assert "entry_page.js{% if ta_version %}?v={{ ta_version }}{% endif %}'" in template
     assert "'module'" in template
     assert "{% if include_custom_favicon %}" in template
     assert "../../static/app/{{ app_name }}/customfavicon/favicon.ico" in template


### PR DESCRIPTION
## Summary

- Passes `ta_version` to `_render_base_html` and appends `?v=<version>` to the `entry_page.js` script URL, ensuring browsers fetch the latest JS on add-on upgrades.
- Refactors redirect JS destination path construction for readability.
- Before placing the new versioned redirect JS, removes any stale `*_redirect_page.*.js` files left by previous installs so they don't accumulate in `js/build`.

## Testing

- `test_render_base_html_includes_version_cache_buster` — verifies the `?v=` query string appears in the rendered `base.html`.
- `test_modify_and_replace_token_for_oauth_templates_removes_stale_redirect_js` — verifies stale versioned redirect JS is deleted before the new one is placed.