### PR TITLE
fix(proxy): allow hostnames/IPs in proxy Host validator (#2051)

### DIFF
--- a/splunk_add_on_ucc_framework/schema/schema.json
+++ b/splunk_add_on_ucc_framework/schema/schema.json
@@ -3897,8 +3897,8 @@
               },
               {
                 "type": "regex",
-                "errorMsg": "Proxy Host should not have special characters",
-                "pattern": "^[a-zA-Z]\\w*$"
+                "errorMsg": "Proxy Host must be a valid hostname or IP address",
+                "pattern": "^[A-Za-z0-9]([A-Za-z0-9._:-]*[A-Za-z0-9])?$"
               }
             ],
             "field": "proxy_url"

--- a/splunk_add_on_ucc_framework/tabs/proxy_tab.py
+++ b/splunk_add_on_ucc_framework/tabs/proxy_tab.py
@@ -56,8 +56,8 @@ DEFAULT_HOST = {
         },
         {
             "type": "regex",
-            "errorMsg": "Proxy Host should not have special characters",
-            "pattern": "^[a-zA-Z]\\w*$",
+            "errorMsg": "Proxy Host must be a valid hostname or IP address",
+            "pattern": "^[A-Za-z0-9]([A-Za-z0-9._:-]*[A-Za-z0-9])?$",
         },
     ],
     "field": "proxy_url",

--- a/tests/unit/tabs/test_proxy_tab.py
+++ b/tests/unit/tabs/test_proxy_tab.py
@@ -22,8 +22,8 @@ def expected_generation():
                     },
                     {
                         "type": "regex",
-                        "errorMsg": "Proxy Host should not have special characters",
-                        "pattern": "^[a-zA-Z]\\w*$",
+                        "errorMsg": "Proxy Host must be a valid hostname or IP address",
+                        "pattern": "^[A-Za-z0-9]([A-Za-z0-9._:-]*[A-Za-z0-9])?$",
                     },
                 ],
                 "field": "proxy_url",


### PR DESCRIPTION
Fixes #2051

## Problem
The built-in `proxyTab` validates the proxy **Host** (`proxy_url`) field with `^[a-zA-Z]\w*$`. That only allows a letter followed by word-characters, so it rejects every realistic proxy host — FQDNs (`proxy.example.com`), hyphenated names (`my-proxy`), IPv4 (`10.0.0.1`), IPv6. Only identifier-like values like `myproxy` pass, which makes proxy configuration unusable in normal deployments (both in Splunk Web and via the generated REST handler).

## Change
Use a regex that accepts hostnames, IPv4, and IPv6 while still rejecting clearly-invalid input (scheme, whitespace, `/`, `@`):

```
^[A-Za-z0-9]([A-Za-z0-9._:-]*[A-Za-z0-9])?$
```

Updated in:
- `splunk_add_on_ucc_framework/tabs/proxy_tab.py` (`DEFAULT_HOST`)
- `splunk_add_on_ucc_framework/schema/schema.json` (proxy tab default)
- `tests/unit/tabs/test_proxy_tab.py` (expected value)

`errorMsg` updated to "Proxy Host must be a valid hostname or IP address".

## Notes
- Account **name** validators (also `^[a-zA-Z]\w*$`) are intentionally left unchanged — those fields are meant to be identifier-like.
- Snapshot fixtures under `tests/testdata/**/globalConfig.json` that embed the old proxy pattern may need regeneration via the project's tooling; glad to update them or adjust the pattern to maintainer preference.

## Repro (before)
Configuration → Proxy → Host = `proxy.example.com` → rejected with *"Proxy Host should not have special characters."*
