### PR TITLE
  fix: replace runtime JS cache busting with build-time timestamp

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -553,6 +553,21 @@ files = [
 ]
 
 [[package]]
+name = "freezegun"
+version = "1.5.5"
+description = "Let your Python tests travel through time"
+optional = false
+python-versions = ">=3.8"
+groups = ["dev"]
+files = [
+    {file = "freezegun-1.5.5-py3-none-any.whl", hash = "sha256:cd557f4a75cf074e84bc374249b9dd491eaeacd61376b9eb3c423282211619d2"},
+    {file = "freezegun-1.5.5.tar.gz", hash = "sha256:ac7742a6cc6c25a2c35e9292dfd554b897b517d2dec26891a2e8debf205cb94a"},
+]
+
+[package.dependencies]
+python-dateutil = ">=2.7"
+
+[[package]]
 name = "future"
 version = "1.0.0"
 description = "Clean single-source support for Python 3 and 2"
@@ -2350,4 +2365,4 @@ validate = ["splunk-appinspect"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<3.14"
-content-hash = "bee928b01ec791457447c3283b56dfd022bef87ad0491a15a912bb2fdfb36f41"
+content-hash = "8b77b97da48b46b568dbf198c1f3ebc7075043c4660f7d87629b56446b8d82ea"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ pytest-cov = "^6.0.0"
 covdefaults = "^2.3.0"
 xmldiff = "^2.7.0"
 pytest-split-tests = "^1.1.0"
+freezegun = "^1.5.5"
 
 [tool.poetry.scripts]
 ucc-gen="splunk_add_on_ucc_framework.main:main"

--- a/splunk_add_on_ucc_framework/commands/build.py
+++ b/splunk_add_on_ucc_framework/commands/build.py
@@ -70,12 +70,15 @@ logger = logging.getLogger("ucc_gen")
 internal_root_dir = os.path.dirname(os.path.dirname(__file__))
 
 
-def _render_base_html(ta_name: str, source: str, outputdir: str) -> None:
+def _render_base_html(
+    ta_name: str, build_time: str, source: str, outputdir: str
+) -> None:
     """
     Render the managed base.html template with the actual add-on name.
 
     Args:
         ta_name: Add-on name.
+        build_time: Add-on's build time.
         source: source package directory.
         outputdir: output directory.
     """
@@ -106,6 +109,7 @@ def _render_base_html(ta_name: str, source: str, outputdir: str) -> None:
     rendered_content = template_env.get_template("base.html").render(
         app_name=ta_name,
         include_custom_favicon=include_custom_favicon,
+        app_build_number=build_time,
     )
 
     with open(base_html_path, "w") as f:
@@ -138,6 +142,7 @@ def _modify_and_replace_token_for_oauth_templates(
             s = s.replace("__APP_NAME__", ta_name)
             s = s.replace("__TA_NAME__", ta_name.lower())
             s = s.replace("__TA_VERSION__", global_config.version)
+            s = s.replace("__APP_BUILD_NUMBER__", global_config.build_time)
             f.write(s)
 
         redirect_js_dest = (
@@ -694,7 +699,7 @@ def generate(
             global_config,
             output_directory,
         )
-        _render_base_html(ta_name, source, output_directory)
+        _render_base_html(ta_name, global_config.build_time, source, output_directory)
 
     default_meta_conf_path = os.path.join(
         output_directory, ta_name, "metadata", meta_conf_lib.DEFAULT_META_FILE_NAME

--- a/splunk_add_on_ucc_framework/generators/conf_files/create_app_conf.py
+++ b/splunk_add_on_ucc_framework/generators/conf_files/create_app_conf.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from time import time
 import os
 from typing import Optional
 
@@ -53,7 +52,7 @@ class AppConf(FileGenerator):
 
         self.addon_version = global_config.version
         self.is_visible = self._resolve_is_visible(global_config, input_dir)
-        self.build = str(int(time()))
+        self.build = global_config.build_time
 
     @staticmethod
     def _get_source_app_conf_is_visible(input_dir: str) -> Optional[str]:

--- a/splunk_add_on_ucc_framework/global_config.py
+++ b/splunk_add_on_ucc_framework/global_config.py
@@ -15,6 +15,7 @@
 #
 import functools
 import json
+import time
 from typing import Optional, Any
 from dataclasses import dataclass, field, fields
 from urllib.parse import urlparse
@@ -76,6 +77,7 @@ class GlobalConfig:
         self._is_global_config_yaml = is_yaml
         rest_handlers = self._content.get("options", {}).get("restHandlers", [])
         self.user_defined_handlers = UserDefinedRestHandlers(rest_handlers)
+        self._build_time = str(int(time.time()))
 
     @classmethod
     def from_file(cls, global_config_path: str) -> "GlobalConfig":
@@ -294,6 +296,10 @@ class GlobalConfig:
 
     def add_ucc_version(self, version: str) -> None:
         self.content.setdefault("meta", {})["_uccVersion"] = version
+
+    @property
+    def build_time(self) -> str:
+        return self._build_time
 
     def has_pages(self) -> bool:
         return bool(self.pages)

--- a/splunk_add_on_ucc_framework/package/appserver/templates/base.html
+++ b/splunk_add_on_ucc_framework/package/appserver/templates/base.html
@@ -32,8 +32,6 @@
 
     <body>
         <script>
-            var _b = window.$C && window.$C.BUILD_NUMBER ? '/@' + window.$C.BUILD_NUMBER : '';
-            var _p = _b && window.$C.BUILD_PUSH_NUMBER ? '.' + window.$C.BUILD_PUSH_NUMBER : '';
             function _loadScript(src, type) {
                 return new Promise(function (resolve, reject) {
                     var s = document.createElement('script');
@@ -44,11 +42,11 @@
                     document.head.appendChild(s);
                 });
             }
-            _loadScript('../../static' + _b + _p + '/js/i18n.js')
+            _loadScript('../../static/@{{ app_build_number }}/js/i18n.js')
                 .then(function () { return _loadScript('../../i18ncatalog?autoload=1'); })
                 .then(function () {
                     return _loadScript(
-                        '../../static' + _b + _p + '/app/{{ app_name }}/js/build/entry_page.js',
+                        '../../static/@{{ app_build_number }}/app/{{ app_name }}/js/build/entry_page.js',
                         'module'
                     );
                 });

--- a/splunk_add_on_ucc_framework/package/appserver/templates/redirect.html
+++ b/splunk_add_on_ucc_framework/package/appserver/templates/redirect.html
@@ -26,8 +26,6 @@
 
     <body>
         <script>
-            var _b = window.$C && window.$C.BUILD_NUMBER ? '/@' + window.$C.BUILD_NUMBER : '';
-            var _p = _b && window.$C.BUILD_PUSH_NUMBER ? '.' + window.$C.BUILD_PUSH_NUMBER : '';
             function _loadScript(src, type) {
                 return new Promise(function (resolve, reject) {
                     var s = document.createElement('script');
@@ -38,11 +36,11 @@
                     document.head.appendChild(s);
                 });
             }
-            _loadScript('../../static' + _b + _p + '/js/i18n.js')
+            _loadScript('../../static/@__APP_BUILD_NUMBER__/js/i18n.js')
                 .then(function () { return _loadScript('../../i18ncatalog?autoload=1'); })
                 .then(function () {
                     return _loadScript(
-                        '../../static' + _b + _p + '/app/__APP_NAME__/js/build/__TA_NAME___redirect_page.__TA_VERSION__.js',
+                        '../../static/@__APP_BUILD_NUMBER__/app/__APP_NAME__/js/build/__TA_NAME___redirect_page.__TA_VERSION__.js',
                         'module'
                     );
                 });

--- a/tests/smoke/test_ucc_build.py
+++ b/tests/smoke/test_ucc_build.py
@@ -6,6 +6,7 @@ import logging
 import json
 import pytest
 from os import path
+import freezegun
 from pathlib import Path
 from typing import Any
 import subprocess
@@ -118,6 +119,7 @@ def test_ucc_generate_with_config_param():
         check_ucc_versions(temp)
 
 
+@freezegun.freeze_time("2026-06-10 00:00:00")
 def test_ucc_generate_with_everything(caplog):
     with tempfile.TemporaryDirectory() as temp_dir:
         package_folder = path.join(
@@ -281,6 +283,7 @@ def test_ucc_generate_with_multiple_inputs_tabs():
     build.generate(source=package_folder)
 
 
+@freezegun.freeze_time("2026-06-10 00:00:00")
 def test_ucc_generate_with_configuration():
     with tempfile.TemporaryDirectory() as temp_dir:
         package_folder = path.join(

--- a/tests/testdata/expected_addons/expected_output_global_config_configuration/Splunk_TA_UCCExample/appserver/templates/base.html
+++ b/tests/testdata/expected_addons/expected_output_global_config_configuration/Splunk_TA_UCCExample/appserver/templates/base.html
@@ -26,8 +26,6 @@
 
     <body>
         <script>
-            var _b = window.$C && window.$C.BUILD_NUMBER ? '/@' + window.$C.BUILD_NUMBER : '';
-            var _p = _b && window.$C.BUILD_PUSH_NUMBER ? '.' + window.$C.BUILD_PUSH_NUMBER : '';
             function _loadScript(src, type) {
                 return new Promise(function (resolve, reject) {
                     var s = document.createElement('script');
@@ -38,11 +36,11 @@
                     document.head.appendChild(s);
                 });
             }
-            _loadScript('../../static' + _b + _p + '/js/i18n.js')
+            _loadScript('../../static/@1781049600/js/i18n.js')
                 .then(function () { return _loadScript('../../i18ncatalog?autoload=1'); })
                 .then(function () {
                     return _loadScript(
-                        '../../static' + _b + _p + '/app/Splunk_TA_UCCExample/js/build/entry_page.js',
+                        '../../static/@1781049600/app/Splunk_TA_UCCExample/js/build/entry_page.js',
                         'module'
                     );
                 });

--- a/tests/testdata/expected_addons/expected_output_global_config_configuration/Splunk_TA_UCCExample/appserver/templates/splunk_ta_uccexample_redirect.html
+++ b/tests/testdata/expected_addons/expected_output_global_config_configuration/Splunk_TA_UCCExample/appserver/templates/splunk_ta_uccexample_redirect.html
@@ -26,8 +26,6 @@
 
     <body>
         <script>
-            var _b = window.$C && window.$C.BUILD_NUMBER ? '/@' + window.$C.BUILD_NUMBER : '';
-            var _p = _b && window.$C.BUILD_PUSH_NUMBER ? '.' + window.$C.BUILD_PUSH_NUMBER : '';
             function _loadScript(src, type) {
                 return new Promise(function (resolve, reject) {
                     var s = document.createElement('script');
@@ -38,11 +36,11 @@
                     document.head.appendChild(s);
                 });
             }
-            _loadScript('../../static' + _b + _p + '/js/i18n.js')
+            _loadScript('../../static/@1781049600/js/i18n.js')
                 .then(function () { return _loadScript('../../i18ncatalog?autoload=1'); })
                 .then(function () {
                     return _loadScript(
-                        '../../static' + _b + _p + '/app/Splunk_TA_UCCExample/js/build/splunk_ta_uccexample_redirect_page.1.0.0.js',
+                        '../../static/@1781049600/app/Splunk_TA_UCCExample/js/build/splunk_ta_uccexample_redirect_page.1.0.0.js',
                         'module'
                     );
                 });

--- a/tests/testdata/expected_addons/expected_output_global_config_everything/Splunk_TA_UCCExample/appserver/templates/base.html
+++ b/tests/testdata/expected_addons/expected_output_global_config_everything/Splunk_TA_UCCExample/appserver/templates/base.html
@@ -26,8 +26,6 @@
 
     <body>
         <script>
-            var _b = window.$C && window.$C.BUILD_NUMBER ? '/@' + window.$C.BUILD_NUMBER : '';
-            var _p = _b && window.$C.BUILD_PUSH_NUMBER ? '.' + window.$C.BUILD_PUSH_NUMBER : '';
             function _loadScript(src, type) {
                 return new Promise(function (resolve, reject) {
                     var s = document.createElement('script');
@@ -38,11 +36,11 @@
                     document.head.appendChild(s);
                 });
             }
-            _loadScript('../../static' + _b + _p + '/js/i18n.js')
+            _loadScript('../../static/@1781049600/js/i18n.js')
                 .then(function () { return _loadScript('../../i18ncatalog?autoload=1'); })
                 .then(function () {
                     return _loadScript(
-                        '../../static' + _b + _p + '/app/Splunk_TA_UCCExample/js/build/entry_page.js',
+                        '../../static/@1781049600/app/Splunk_TA_UCCExample/js/build/entry_page.js',
                         'module'
                     );
                 });

--- a/tests/testdata/expected_addons/expected_output_global_config_everything/Splunk_TA_UCCExample/appserver/templates/splunk_ta_uccexample_redirect.html
+++ b/tests/testdata/expected_addons/expected_output_global_config_everything/Splunk_TA_UCCExample/appserver/templates/splunk_ta_uccexample_redirect.html
@@ -26,8 +26,6 @@
 
     <body>
         <script>
-            var _b = window.$C && window.$C.BUILD_NUMBER ? '/@' + window.$C.BUILD_NUMBER : '';
-            var _p = _b && window.$C.BUILD_PUSH_NUMBER ? '.' + window.$C.BUILD_PUSH_NUMBER : '';
             function _loadScript(src, type) {
                 return new Promise(function (resolve, reject) {
                     var s = document.createElement('script');
@@ -38,11 +36,11 @@
                     document.head.appendChild(s);
                 });
             }
-            _loadScript('../../static' + _b + _p + '/js/i18n.js')
+            _loadScript('../../static/@1781049600/js/i18n.js')
                 .then(function () { return _loadScript('../../i18ncatalog?autoload=1'); })
                 .then(function () {
                     return _loadScript(
-                        '../../static' + _b + _p + '/app/Splunk_TA_UCCExample/js/build/splunk_ta_uccexample_redirect_page.5.5.8R5fd76615.js',
+                        '../../static/@1781049600/app/Splunk_TA_UCCExample/js/build/splunk_ta_uccexample_redirect_page.5.5.8R5fd76615.js',
                         'module'
                     );
                 });

--- a/tests/testdata/test_addons/package_conf_only_TA/globalConfig.json
+++ b/tests/testdata/test_addons/package_conf_only_TA/globalConfig.json
@@ -2,7 +2,7 @@
     "meta": {
         "name": "Splunk_TA_UCCExample",
         "restRoot": "splunk_ta_uccexample",
-        "version": "6.2.0+38a26eac5",
+        "version": "6.5.0+367e327ba",
         "displayName": "Splunk UCC test Add-on",
         "schemaVersion": "0.0.10"
     }

--- a/tests/testdata/test_addons/package_files_conflict_test/globalConfig.json
+++ b/tests/testdata/test_addons/package_files_conflict_test/globalConfig.json
@@ -199,7 +199,7 @@
     "meta": {
         "name": "test_addon",
         "restRoot": "test_addon",
-        "version": "6.2.0+38a26eac5",
+        "version": "6.5.0+367e327ba",
         "displayName": "This is my add-on",
         "schemaVersion": "0.0.10"
     }

--- a/tests/testdata/test_addons/package_global_config_configuration/globalConfig.json
+++ b/tests/testdata/test_addons/package_global_config_configuration/globalConfig.json
@@ -454,7 +454,7 @@
     "meta": {
         "name": "Splunk_TA_UCCExample",
         "restRoot": "splunk_ta_uccexample",
-        "version": "6.2.0+38a26eac5",
+        "version": "1.1.1",
         "displayName": "Splunk UCC test Add-on",
         "schemaVersion": "0.0.10"
     }

--- a/tests/testdata/test_addons/package_global_config_everything/globalConfig.json
+++ b/tests/testdata/test_addons/package_global_config_everything/globalConfig.json
@@ -2383,7 +2383,7 @@
     "meta": {
         "name": "Splunk_TA_UCCExample",
         "restRoot": "splunk_ta_uccexample",
-        "version": "6.2.0+38a26eac5",
+        "version": "6.5.0+367e327ba",
         "displayName": "Splunk UCC test Add-on",
         "schemaVersion": "0.0.10",
         "supportedThemes": [

--- a/tests/testdata/test_addons/package_global_config_everything_uccignore/globalConfig.json
+++ b/tests/testdata/test_addons/package_global_config_everything_uccignore/globalConfig.json
@@ -1236,7 +1236,7 @@
     "meta": {
         "name": "Splunk_TA_UCCExample",
         "restRoot": "splunk_ta_uccexample",
-        "version": "6.2.0+38a26eac5",
+        "version": "6.5.0+367e327ba",
         "displayName": "Splunk UCC test Add-on",
         "schemaVersion": "0.0.10"
     }

--- a/tests/testdata/test_addons/package_global_config_multi_input/globalConfig.json
+++ b/tests/testdata/test_addons/package_global_config_multi_input/globalConfig.json
@@ -763,7 +763,7 @@
     "meta": {
         "name": "Splunk_TA_UCCExample",
         "restRoot": "splunk_ta_uccexample",
-        "version": "6.2.0+38a26eac5",
+        "version": "6.5.0+367e327ba",
         "displayName": "Splunk UCC test Add-on",
         "schemaVersion": "0.0.10"
     }

--- a/tests/testdata/test_addons/package_global_config_only_one_tab/globalConfig.json
+++ b/tests/testdata/test_addons/package_global_config_only_one_tab/globalConfig.json
@@ -36,7 +36,7 @@
     "meta": {
         "name": "Splunk_TA_UCCExample",
         "restRoot": "splunk_ta_uccexample",
-        "version": "6.2.0+38a26eac5",
+        "version": "6.5.0+367e327ba",
         "displayName": "Splunk UCC test Add-on",
         "schemaVersion": "0.0.10"
     }

--- a/tests/unit/commands/test_build.py
+++ b/tests/unit/commands/test_build.py
@@ -155,7 +155,7 @@ def test_render_base_html_preserves_app_name_case(tmp_path):
     base_html_path.parent.mkdir(parents=True)
     base_html_path.write_text("placeholder")
 
-    _render_base_html(ta_name, str(source), str(tmp_path))
+    _render_base_html(ta_name, "123456789", str(source), str(tmp_path))
 
     rendered = base_html_path.read_text()
     assert "Splunk_TA_UCCExample/js/build/entry_page.js" in rendered
@@ -167,7 +167,7 @@ def test_render_base_html_preserves_app_name_case(tmp_path):
 def test_render_base_html_skips_when_template_is_missing(tmp_path):
     ta_name = "Splunk_TA_UCCExample"
 
-    _render_base_html(ta_name, str(tmp_path), str(tmp_path))
+    _render_base_html(ta_name, "123456789", str(tmp_path), str(tmp_path))
 
     assert not (tmp_path / ta_name / "appserver" / "templates" / "base.html").exists()
 
@@ -180,7 +180,7 @@ def test_render_base_html_omits_favicon_when_asset_is_missing(tmp_path):
     base_html_path.parent.mkdir(parents=True)
     base_html_path.write_text("placeholder")
 
-    _render_base_html(ta_name, str(source), str(tmp_path))
+    _render_base_html(ta_name, "123456789", str(source), str(tmp_path))
 
     rendered = base_html_path.read_text()
     assert "Splunk_TA_UCCExample/js/build/entry_page.js" in rendered
@@ -195,7 +195,7 @@ def test_render_base_html_overwrites_copied_template(tmp_path):
     base_html_path.parent.mkdir(parents=True)
     base_html_path.write_text("<html><body>totally custom</body></html>\n")
 
-    _render_base_html(ta_name, str(source), str(tmp_path))
+    _render_base_html(ta_name, "123456789", str(source), str(tmp_path))
 
     rendered = base_html_path.read_text()
     assert "totally custom" not in rendered
@@ -223,6 +223,7 @@ def test_modify_and_replace_token_for_oauth_templates_preserves_app_name_case(
         SimpleNamespace(
             version="1.2.3",
             has_oauth=lambda: True,
+            build_time="123456789",
         ),
     )
 

--- a/tests/unit/test_package_files_update.py
+++ b/tests/unit/test_package_files_update.py
@@ -49,9 +49,8 @@ def test_package_files_update_replaces_legacy_base_template(tmp_path, caplog):
     handle_package_files_update(str(tmp_path))
 
     assert '<script src="../../config?autoload=1"' in template_path.read_text()
-    assert "window.$C.BUILD_NUMBER" in template_path.read_text()
     assert (
-        "'../../static' + _b + _p + '/app/{{ app_name }}/js/build/entry_page.js'"
+        "'../../static/@{{ app_build_number }}/app/{{ app_name }}/js/build/entry_page.js'"
         in template_path.read_text()
     )
     assert "{% if include_custom_favicon %}" in template_path.read_text()
@@ -76,9 +75,8 @@ def test_package_files_update_replaces_legacy_redirect_template(tmp_path, caplog
     handle_package_files_update(str(tmp_path))
 
     assert '<script src="../../config?autoload=1"' in template_path.read_text()
-    assert "window.$C.BUILD_NUMBER" in template_path.read_text()
     assert (
-        "'../../static' + _b + _p + '/app/__APP_NAME__/js/build/__TA_NAME___redirect_page.__TA_VERSION__.js'"
+        "'../../static/@__APP_BUILD_NUMBER__/app/__APP_NAME__/js/build/__TA_NAME___redirect_page.__TA_VERSION__.js'"
         in template_path.read_text()
     )
     assert "cherrypy.request.path_info" not in template_path.read_text()
@@ -116,15 +114,8 @@ def test_base_template_cache_busting_script():
         "splunk_add_on_ucc_framework/package/appserver/templates/base.html"
     ).read_text()
 
-    # BUILD_NUMBER is used for the cache buster path segment
-    assert "window.$C.BUILD_NUMBER" in template
-    # BUILD_PUSH_NUMBER is only appended when BUILD_NUMBER is present
-    assert "_b && window.$C.BUILD_PUSH_NUMBER" in template
-    # fallback to no cache buster when $C is unavailable
-    assert "? '/@' + window.$C.BUILD_NUMBER : ''" in template
-    assert "? '.' + window.$C.BUILD_PUSH_NUMBER : ''" in template
     # i18n.js URL is built using the cache buster
-    assert "_loadScript('../../static' + _b + _p + '/js/i18n.js')" in template
+    assert "_loadScript('../../static/@{{ app_build_number }}/js/i18n.js')" in template
     # i18ncatalog loads after i18n.js
     assert (
         ".then(function () { return _loadScript('../../i18ncatalog?autoload=1'); })"
@@ -132,7 +123,7 @@ def test_base_template_cache_busting_script():
     )
     # entry_page.js loads last, as a module
     assert (
-        "'../../static' + _b + _p + '/app/{{ app_name }}/js/build/entry_page.js'"
+        "'../../static/@{{ app_build_number }}/app/{{ app_name }}/js/build/entry_page.js'"
         in template
     )
     assert "'module'" in template


### PR DESCRIPTION
**Issue number:** N/A

### PR Type

**What kind of change does this PR introduce?**
* [ ] Feature
* [x] Bug Fix
* [ ] Refactoring (no functional or API changes)
* [ ] Documentation Update
* [ ] Maintenance (dependency updates, CI, etc.)

## Summary

### Changes

Previously, base.html and redirect.html computed static asset paths at
runtime using window.$C.BUILD_NUMBER, which silently fell back to no
cache busting when $C was unavailable. Now the build timestamp is
captured once in GlobalConfig and baked into the generated HTML at
build time, making cache busting deterministic and independent of the
Splunk runtime context.

- Add GlobalConfig.build_time property (Unix timestamp captured at init)
- Pass build_time through _render_base_html and token replacement for redirect
- Use same timestamp in app.conf build field (replaces local time() call)
- Add freezegun to pin timestamps in smoke tests that compare expected output

### User experience

Users should see correct content when building and installing add-ons using UCC.

## Checklist

If an item doesn't apply to your changes, leave it unchecked.

### Review

* [x] self-review - I have performed a self-review of this change according to the [development guidelines](https://splunk.github.io/addonfactory-ucc-generator/contributing/#development-guidelines)
* [ ] Changes are documented. The documentation is understandable, examples work [(more info)](https://splunk.github.io/addonfactory-ucc-generator/contributing/#documentation-guidelines)
* [x] PR title and description follows the [contributing principles](https://splunk.github.io/addonfactory-ucc-generator/contributing/#pull-requests)
* [ ] meeting - I have scheduled a meeting or recorded a demo to explain these changes (if there is a video, put a link below and in the ticket)

### Tests

See [the testing doc](https://splunk.github.io/addonfactory-ucc-generator/contributing/#build-and-test).

* [x] Unit - tests have been added/modified to cover the changes
* [x] Smoke - tests have been added/modified to cover the changes
* [ ] UI - tests have been added/modified to cover the changes
* [ ] coverage - I have checked the code coverage of my changes [(see more)](https://splunk.github.io/addonfactory-ucc-generator/contributing/#checking-the-code-coverage)

**Demo/meeting:**

*Reviewers are encouraged to request meetings or demos if any part of the change is unclear*
