### PR TITLE
ci: fix TAs Regression false-failures (build-log gate + drop cisco-asa)

### DIFF
--- a/.github/workflows/ta-tests.yml
+++ b/.github/workflows/ta-tests.yml
@@ -71,6 +71,11 @@ jobs:
           if [[ "${{ github.event_name }}" == "workflow_dispatch" && -n "${{ github.event.inputs.target_repo }}" ]]; then
             echo "repos=[\"${{ github.event.inputs.target_repo }}\"]" >> $GITHUB_OUTPUT
           else
+            # splunk/splunk-add-on-for-cisco-asa is temporarily disabled: its
+            # additional_packaging.py rmdir()s default/data/spl2 after deleting a
+            # hardcoded file list, which fails because cisco_asa_schema_1_1.json
+            # (added in the TA's 6.0.1 release) isn't in that list. Re-enable
+            # once the TA switches to shutil.rmtree or updates the list.
             echo "repos<<EOF" >> $GITHUB_OUTPUT
             echo '[
               "splunk/splunk-add-on-for-amazon-web-services",
@@ -81,7 +86,6 @@ jobs:
               "splunk/splunk-add-on-for-salesforce",
               "splunk/splunk-add-on-for-servicenow",
               "splunk/splunk-add-on-for-mysql",
-              "splunk/splunk-add-on-for-cisco-asa",
               "splunk/splunk-add-on-for-unix-and-linux"
             ]' >> $GITHUB_OUTPUT
             echo "EOF" >> $GITHUB_OUTPUT

--- a/.github/workflows/ta-tests.yml
+++ b/.github/workflows/ta-tests.yml
@@ -227,12 +227,12 @@ jobs:
           ./.ucc_venv/bin/python3 -m pip install ./$UCC_WHL
           
           ./.ucc_venv/bin/ucc-gen build 2>&1 | tee build_output.log
-          if tail -n 1 build_output.log | grep -q "^INFO: File creation summary: created: "; then
+          if grep -q "^INFO: File creation summary: created: " build_output.log; then
             echo "✓ Build completed successfully with expected output"
             cat build_output.log
           else
             echo "✗ Build did not complete with expected output"
-            echo "Last line of output should start with 'INFO: File creation summary: created: '"
+            echo "Output should contain a line starting with 'INFO: File creation summary: created: '"
             echo "Full output:"
             cat build_output.log
             exit 1


### PR DESCRIPTION
**Issue number:**

### PR Type

**What kind of change does this PR introduce?**
* [ ] Feature
* [x] Bug Fix
* [ ] Refactoring (no functional or API changes)
* [ ] Documentation Update
* [x] Maintenance (dependency updates, CI, etc.)

## Summary

### Changes

Two unrelated `test-addons` matrix entries in `.github/workflows/ta-tests.yml` have been failing on every run for weeks. Both failures are pre-existing and unrelated to the matrix being run on a given PR; with `continue-on-error: true` they're swallowed by the umbrella job but show up red on every PR.

**1. AWS TA — false-positive build-log gate.** The `Run ucc-gen build in Target Add-on` step only inspects the *last* line of `build_output.log` for the `INFO: File creation summary: created: ...` message. The AWS TA's `additional_packaging.py` prints an extra line after the summary (`Patched botocore CSM UDP code in ...`), so the gate fails even though `ucc-gen build` itself succeeded. Fix: grep the whole log for the summary line.

**2. cisco-asa TA — stale cleanup logic in the TA repo.** The cisco-asa TA's `additional_packaging.py` `rmdir()`s `default/data/spl2` after deleting a hardcoded list of files. `cisco_asa_schema_1_1.json` was added to that directory in the TA's 6.0.1 release (2026-05-06) without being added to the cleanup list, so `rmdir` raises `OSError: [Errno 39] Directory not empty`. This is a bug in the cisco-asa repo, not in UCC. As a workaround, temporarily drop `splunk/splunk-add-on-for-cisco-asa` from the regression matrix until the TA's cleanup logic is fixed (a comment in the workflow points at the root cause and the fix condition).

### User experience

Before: every TAs Regression run on this repo shows two persistently red matrix entries (AWS and cisco-asa), masking any genuine regressions.

After: AWS regression passes; cisco-asa is omitted from the matrix with a comment explaining why and when to put it back. Real regressions are now visible.

## Checklist

If an item doesn't apply to your changes, leave it unchecked.

### Review

* [x] self-review - I have performed a self-review of this change according to the [development guidelines](https://splunk.github.io/addonfactory-ucc-generator/contributing/#development-guidelines)
* [ ] Changes are documented. The documentation is understandable, examples work [(more info)](https://splunk.github.io/addonfactory-ucc-generator/contributing/#documentation-guidelines)
* [x] PR title and description follows the [contributing principles](https://splunk.github.io/addonfactory-ucc-generator/contributing/#pull-requests)
* [ ] meeting - I have scheduled a meeting or recorded a demo to explain these changes (if there is a video, put a link below and in the ticket)

### Tests

See [the testing doc](https://splunk.github.io/addonfactory-ucc-generator/contributing/#build-and-test).

* [ ] Unit - tests have been added/modified to cover the changes
* [ ] Smoke - tests have been added/modified to cover the changes
* [ ] UI - tests have been added/modified to cover the changes
* [ ] coverage - I have checked the code coverage of my changes [(see more)](https://splunk.github.io/addonfactory-ucc-generator/contributing/#checking-the-code-coverage)

**Demo/meeting:**

*Reviewers are encouraged to request meetings or demos if any part of the change is unclear*