### PR TITLE
chore(security): bump mako to 1.3.12 and postcss floor to 8.5.10 (VULN-85404, VULN-86364)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -901,15 +901,15 @@ source = ["Cython (>=3.0.11,<3.1.0)"]
 
 [[package]]
 name = "mako"
-version = "1.3.10"
+version = "1.3.12"
 description = "A super-fast templating language that borrows the best ideas from the existing templating languages."
 optional = true
 python-versions = ">=3.8"
 groups = ["main"]
 markers = "extra == \"validate\""
 files = [
-    {file = "mako-1.3.10-py3-none-any.whl", hash = "sha256:baef24a52fc4fc514a0887ac600f9f1cff3d82c61d4d700a1fa84d597b88db59"},
-    {file = "mako-1.3.10.tar.gz", hash = "sha256:99579a6f39583fa7e5630a28c3c1f440e4e97a414b80372649c0ce338da2ea28"},
+    {file = "mako-1.3.12-py3-none-any.whl", hash = "sha256:8f61569480282dbf557145ce441e4ba888be453c30989f879f0d652e39f53ea9"},
+    {file = "mako-1.3.12.tar.gz", hash = "sha256:9f778e93289bd410bb35daadeb4fc66d95a746f0b75777b942088b7fd7af550a"},
 ]
 
 [package.dependencies]

--- a/ui/package.json
+++ b/ui/package.json
@@ -150,7 +150,7 @@
     "d3-color": "^3.1.0",
     "d3-interpolate": "^3.0.1",
     "glob-parent": "^5.1.2",
-    "postcss": "^8.5.8",
+    "postcss": "^8.5.10",
     "semver": "^7.7.4",
     "strip-ansi": "^6.0.1",
     "string-width": "^4.2.3",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -10238,7 +10238,7 @@ postcss-value-parser@^4.0.2, postcss-value-parser@^4.1.0, postcss-value-parser@^
 
 postcss@^8.4.19, postcss@^8.4.40, postcss@^8.5.10, postcss@^8.5.6:
   version "8.5.16"
-  resolved "https://repo.splunkdev.net:443/artifactory/api/npm/npm/postcss/-/postcss-8.5.16.tgz#1230ce0b5df354c24c0ea45f99ce5f6a88279d28"
+  resolved "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz#1230ce0b5df354c24c0ea45f99ce5f6a88279d28"
   integrity sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==
   dependencies:
     nanoid "^3.3.12"

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -10236,10 +10236,10 @@ postcss-value-parser@^4.0.2, postcss-value-parser@^4.1.0, postcss-value-parser@^
   resolved "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz#723c09920836ba6d3e5af019f92bc0971c02e514"
   integrity sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==
 
-postcss@^8.4.19, postcss@^8.4.40, postcss@^8.5.6, postcss@^8.5.8:
-  version "8.5.15"
-  resolved "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz#d1eaf677a324e9ec02196da2d3fecf4a0b9a735c"
-  integrity sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==
+postcss@^8.4.19, postcss@^8.4.40, postcss@^8.5.10, postcss@^8.5.6:
+  version "8.5.16"
+  resolved "https://repo.splunkdev.net:443/artifactory/api/npm/npm/postcss/-/postcss-8.5.16.tgz#1230ce0b5df354c24c0ea45f99ce5f6a88279d28"
+  integrity sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==
   dependencies:
     nanoid "^3.3.12"
     picocolors "^1.1.1"


### PR DESCRIPTION
**Issue number:** VULN-85404, VULN-86364

### PR Type

**What kind of change does this PR introduce?**
* [ ] Feature
* [ ] Bug Fix
* [ ] Refactoring (no functional or API changes)
* [ ] Documentation Update
* [x] Maintenance (dependency updates, CI, etc.)

## Summary

### Changes

Bumps two vulnerable dependencies:

| Package | Before | After | CVE | Severity | Ticket |
|---|---|---|---|---|---|
| `mako` (Python, transitive via `splunk-appinspect`) | 1.3.10 | 1.3.12 | CVE-2026-44307 | HIGH | VULN-85404 |
| `postcss` (npm resolution floor) | ^8.5.8 | ^8.5.10 | CVE-2026-41305 | MEDIUM | VULN-86364 |

- **CVE-2026-44307** (`mako`): On Windows, a URI using backslash traversal (e.g. `\..\..\secret.txt`) bypasses the directory traversal check in `Template.__init__` and the posixpath-based normalization in `TemplateLookup.get_template()`, allowing reads outside the configured template directory.
- **CVE-2026-41305** (`postcss`): Versions prior to 8.5.10 do not escape `</style>` sequences when stringifying CSS ASTs, enabling XSS when user-submitted CSS is parsed and re-stringified into HTML `<style>` tags. `ui/yarn.lock` already resolves to 8.5.16; this PR raises the resolution floor to make the security minimum explicit.

### Out of scope (deferred)

Two related VULN tickets were investigated but cannot be addressed in this PR due to upstream constraints:

- **VULN-85394** (`lxml` 5.4.0 → 6.1.0, CVE-2026-41066): blocked by upstream pins `lxml >=5.3.0,<6.0.0` (`splunk-appinspect` 4.2.x), `lxml >=5.1.0,<6.0.0` (`pytest-splunk-addon-ui-smartx` 6.0.1). Requires waiting on upstream to widen constraints.
- **VULN-87175** (`click` 8.1.8 → 8.3.3, CVE-2026-7246): blocked by Python floor. `click >=8.2.0` requires Python `>=3.10`; this project targets Python `>=3.9` and CI runs on 3.9. Requires dropping 3.9 support (separate scope).

These two tickets remain In Progress and will be handled separately.

### User experience

No user-facing changes. These are build-time / runtime library upgrades with no API changes.

## Checklist

If an item doesn't apply to your changes, leave it unchecked.

### Review

* [x] self-review - I have performed a self-review of this change according to the [development guidelines](https://splunk.github.io/addonfactory-ucc-generator/contributing/#development-guidelines)
* [ ] Changes are documented. The documentation is understandable, examples work [(more info)](https://splunk.github.io/addonfactory-ucc-generator/contributing/#documentation-guidelines)
* [x] PR title and description follows the [contributing principles](https://splunk.github.io/addonfactory-ucc-generator/contributing/#pull-requests)
* [ ] meeting - I have scheduled a meeting or recorded a demo to explain these changes (if there is a video, put a link below and in the ticket)

### Tests

See [the testing doc](https://splunk.github.io/addonfactory-ucc-generator/contributing/#build-and-test).

* [ ] Unit - tests have been added/modified to cover the changes
* [ ] Smoke - tests have been added/modified to cover the changes
* [ ] UI - tests have been added/modified to cover the changes
* [ ] coverage - I have checked the code coverage of my changes [(see more)](https://splunk.github.io/addonfactory-ucc-generator/contributing/#checking-the-code-coverage)

**Demo/meeting:** N/A — dependency-only change.

*Reviewers are encouraged to request meetings or demos if any part of the change is unclear*