### PR TITLE
chore(deps): update dependency react-router-dom to v6.30.4 [security] (VULN-88210)

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -58,7 +58,7 @@
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-is": "^16.13.1",
-    "react-router-dom": "6.30.3",
+    "react-router-dom": "6.30.4",
     "styled-components": "^5.3.11",
     "uuid": "^14.0.0",
     "vite": "^7.3.1",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -2321,10 +2321,10 @@
     redux-thunk "^2.4.2"
     reselect "^4.1.8"
 
-"@remix-run/router@1.23.2":
-  version "1.23.2"
-  resolved "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz#156c4b481c0bee22a19f7924728a67120de06971"
-  integrity sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==
+"@remix-run/router@1.23.3":
+  version "1.23.3"
+  resolved "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz#957c098d4393d301a8aa7dccf3ef28ea5430e36a"
+  integrity sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==
 
 "@rolldown/pluginutils@1.0.0-beta.27":
   version "1.0.0-beta.27"
@@ -10673,20 +10673,20 @@ react-resize-detector@^12.3.0:
   dependencies:
     es-toolkit "^1.39.6"
 
-react-router-dom@6.30.3:
-  version "6.30.3"
-  resolved "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz#42ae6dc4c7158bfb0b935f162b9621b29dddf740"
-  integrity sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==
+react-router-dom@6.30.4:
+  version "6.30.4"
+  resolved "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.4.tgz#f7167bf3da6c7d9132130ea985dd06def25e84d5"
+  integrity sha512-q4HvNl+mmDdkS0g+MqiBZNteQJCuimWoOyHMy4T/RQLAn9Z29+E91QXRaxOujeMl2HTzRSS0KFPd7lxX3PjV0Q==
   dependencies:
-    "@remix-run/router" "1.23.2"
-    react-router "6.30.3"
+    "@remix-run/router" "1.23.3"
+    react-router "6.30.4"
 
-react-router@6.30.3:
-  version "6.30.3"
-  resolved "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz#994b3ccdbe0e81fe84d4f998100f62584dfbf1cf"
-  integrity sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==
+react-router@6.30.4:
+  version "6.30.4"
+  resolved "https://registry.npmjs.org/react-router/-/react-router-6.30.4.tgz#638f35176527bd243d96d81d35d33b757bad46c2"
+  integrity sha512-SVUsDe+DybHM/WmYKIVYhZh1o5Dcuf16yM6WjG02Q9XVFMZIJyHYhwrr6bFBXZkVP6z69kNkMyBCujt8FaFLJA==
   dependencies:
-    "@remix-run/router" "1.23.2"
+    "@remix-run/router" "1.23.3"
 
 react@18.3.1:
   version "18.3.1"


### PR DESCRIPTION
## Summary
- Bumps `react-router-dom` from `6.30.3` → `6.30.4` in `ui/package.json` (and matching transitive `react-router` in `ui/yarn.lock`).
- Addresses [VULN-88210](https://splunk.atlassian.net/browse/VULN-88210) / CVE-2026-40181: open redirect in `react-router`'s `redirect` function where path values starting with `//` are reinterpreted as protocol-relative URLs and can redirect to an external domain. Patched upstream in `6.30.4`.
- Note: this codebase uses `<BrowserRouter>` (Declarative Mode), so the vulnerability is not directly exploitable here, but the dep still needs to be on a patched version to clear the ticket.

## Test plan
- [x] `yarn install` — resolves cleanly, lockfile updated
- [x] `yarn tsc --noEmit` — no type errors
- [x] `yarn test` — 486/486 passing across 54 test files
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)