### PR TITLE
feat(ui): optional show/hide toggle for encrypted text fields

### DIFF
--- a/docs/entity/components.md
+++ b/docs/entity/components.md
@@ -37,6 +37,27 @@ This is how it looks in the UI:
 
 ![image](../images/components/text_component_example.png)
 
+### Options
+
+| Property             | Type    | Description                                                                                                                                                                                                                                             | Default Value |
+| -------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------- |
+| enablePasswordReveal | boolean | Only for fields with `encrypted: true`. Adds a show/hide (eye) button to the field. While creating an entity it toggles the visibility of the typed value. While editing an entity it fetches and shows the stored value in place, using the `--cred--=1` parameter of the generated endpoint, so splunkd enforces the caller's own permissions. Users whose role cannot read the stored credential get an error instead of the value. | false         |
+
+See the following example usage:
+
+```json
+{
+    "type": "text",
+    "label": "API key",
+    "field": "api_key",
+    "encrypted": true,
+    "required": true,
+    "options": {
+        "enablePasswordReveal": true
+    }
+}
+```
+
 ## `Text Area`
 
 See the underlying `@splunk/react-ui` component: [`TextArea`](https://splunkui.splunk.com/Packages/react-ui/TextArea).

--- a/splunk_add_on_ucc_framework/schema/schema.json
+++ b/splunk_add_on_ucc_framework/schema/schema.json
@@ -1079,6 +1079,9 @@
             },
             "hideForPlatform": {
               "$ref": "#/definitions/HideForPlatform"
+            },
+            "enablePasswordReveal": {
+              "$ref": "#/definitions/enablePasswordReveal"
             }
           },
           "additionalProperties": false
@@ -4395,6 +4398,11 @@
     "disableonEdit": {
       "type": "boolean",
       "description": "When the form is in edit mode, the field becomes unable to be edited.",
+      "default": false
+    },
+    "enablePasswordReveal": {
+      "type": "boolean",
+      "description": "For encrypted fields only. Adds a show/hide (eye) button to the field. In edit mode the stored value can be revealed in place; the decrypted value is fetched from the endpoint using the caller's own permissions.",
       "default": false
     },
     "enable": {

--- a/ui/src/components/BaseFormView/BaseFormView.tsx
+++ b/ui/src/components/BaseFormView/BaseFormView.tsx
@@ -8,7 +8,8 @@ import Validator, { SaveValidator } from '../../util/Validator';
 import { getUnifiedConfigs, generateToast } from '../../util/util';
 import { MODE_CLONE, MODE_CREATE, MODE_EDIT, MODE_CONFIG } from '../../constants/modes';
 import { PAGE_INPUT, PAGE_CONF } from '../../constants/pages';
-import { generateEndPointUrl, postRequest } from '../../util/api';
+import { generateEndPointUrl, getRequest, postRequest } from '../../util/api';
+import { ENCRYPTED_FIELD_PLACEHOLDER } from '../../constants/encryptedField';
 import { parseErrorMsg, getFormattedMessage } from '../../util/messageUtil';
 import { getBuildDirPath } from '../../util/script';
 
@@ -755,7 +756,7 @@ class BaseFormView extends PureComponent<BaseFormProps, BaseFormState> {
                     entity &&
                     'encrypted' in entity &&
                     entity.encrypted &&
-                    this.datadict[key] === '******'
+                    this.datadict[key] === ENCRYPTED_FIELD_PLACEHOLDER
                 ) {
                     return;
                 }
@@ -1159,6 +1160,29 @@ class BaseFormView extends PureComponent<BaseFormProps, BaseFormState> {
     // eslint-disable-next-line class-methods-use-this
     timeout = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms)); // eslint-disable-line no-promise-executor-return
 
+    /**
+     * Fetches the decrypted value of an encrypted field for the entity being
+     * edited. Backed by the `--cred--=1` parameter of the generated endpoint,
+     * so splunkd enforces the caller's own permissions (a role without access
+     * to the stored credential gets an error, not the value).
+     * Returns null when there is no stored value to reveal.
+     */
+    fetchStoredClearValue = async (field: string): Promise<string | null> => {
+        if (this.props.mode !== MODE_EDIT && this.props.mode !== MODE_CONFIG) {
+            return null;
+        }
+        const data = await getRequest<{ entry: [{ content: Record<string, unknown> }] }>({
+            endpointUrl: generateEndPointUrl(this.endpoint),
+            params: { '--cred--': '1' },
+            handleError: false,
+        });
+        const value = data?.entry?.[0]?.content?.[field];
+        if (typeof value !== 'string' || value === '' || value === ENCRYPTED_FIELD_PLACEHOLDER) {
+            return null;
+        }
+        return value;
+    };
+
     renderGroupElements = () => {
         let el = null;
         if (this.groups && this.groups.length) {
@@ -1190,6 +1214,7 @@ class BaseFormView extends PureComponent<BaseFormProps, BaseFormState> {
                                         page={this.props.page}
                                         fileNameToDisplay={temState.fileNameToDisplay}
                                         modifiedEntitiesData={temState.modifiedEntitiesData}
+                                        fetchStoredClearValue={this.fetchStoredClearValue}
                                     />
                                 );
                             }
@@ -1286,6 +1311,7 @@ class BaseFormView extends PureComponent<BaseFormProps, BaseFormState> {
                                 fileNameToDisplay={temState.fileNameToDisplay}
                                 modifiedEntitiesData={temState.modifiedEntitiesData}
                                 page={this.props.page}
+                                fetchStoredClearValue={this.fetchStoredClearValue}
                             />
                         );
                     })}

--- a/ui/src/components/ControlWrapper/ControlWrapper.tsx
+++ b/ui/src/components/ControlWrapper/ControlWrapper.tsx
@@ -54,6 +54,7 @@ export interface ControlWrapperProps {
         required?: boolean;
     };
     page?: string;
+    fetchStoredClearValue?: (field: string) => Promise<string | null>;
 }
 
 class ControlWrapper extends React.PureComponent<ControlWrapperProps> {
@@ -109,6 +110,7 @@ class ControlWrapper extends React.PureComponent<ControlWrapperProps> {
                           addCustomValidator,
                           fileNameToDisplay: this.props.fileNameToDisplay,
                           mode: this.props.mode,
+                          fetchStoredClearValue: this.props.fetchStoredClearValue,
                           ...this?.props?.entity,
                           ...this.props?.modifiedEntitiesData,
                           page: this.props.page,

--- a/ui/src/components/ControlWrapper/utils.ts
+++ b/ui/src/components/ControlWrapper/utils.ts
@@ -17,6 +17,7 @@ export const excludeControlWrapperProps = <T extends object>(obj: T) =>
         'defaultValue', // value is provided anyway, so no need to pass defaultValue
         'dependencyValues',
         'encrypted',
+        'fetchStoredClearValue',
         'fileNameToDisplay',
         'handleChange',
         'mode',

--- a/ui/src/components/TextComponent/TextComponent.test.tsx
+++ b/ui/src/components/TextComponent/TextComponent.test.tsx
@@ -1,4 +1,4 @@
-import { expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import userEvent from '@testing-library/user-event';
@@ -41,4 +41,108 @@ it('should use callback with empty string after clear', async () => {
 
     await userEvent.clear(textBox);
     expect(handleChange).toHaveBeenCalledWith('fieldId', '');
+});
+
+describe('password reveal', () => {
+    const PLACEHOLDER = '******';
+
+    const renderRevealComponent = (
+        props: Partial<React.ComponentProps<typeof TextComponent>> = {}
+    ) =>
+        render(
+            <TextComponent
+                value={PLACEHOLDER}
+                handleChange={handleChange}
+                field="api_key"
+                encrypted
+                mode="edit"
+                controlOptions={{ enablePasswordReveal: true }}
+                {...props}
+            />
+        );
+
+    it('should not render the toggle without enablePasswordReveal', () => {
+        render(
+            <TextComponent
+                value={PLACEHOLDER}
+                handleChange={handleChange}
+                field="api_key"
+                encrypted
+                mode="edit"
+            />
+        );
+        expect(screen.queryByTestId('api_key-reveal-toggle')).not.toBeInTheDocument();
+    });
+
+    it('should not render the toggle for non-encrypted fields', () => {
+        renderRevealComponent({ encrypted: false });
+        expect(screen.queryByTestId('api_key-reveal-toggle')).not.toBeInTheDocument();
+    });
+
+    it('should toggle visibility of a typed value without fetching', async () => {
+        const fetchStoredClearValue = vi.fn();
+        renderRevealComponent({
+            value: 'typed-secret',
+            mode: 'create',
+            fetchStoredClearValue,
+        });
+
+        const textBox = screen.getByTestId('textbox');
+        expect(textBox).toHaveAttribute('type', 'password');
+
+        await userEvent.click(screen.getByTestId('api_key-reveal-toggle'));
+        expect(textBox).toHaveAttribute('type', 'text');
+        expect(textBox).toHaveValue('typed-secret');
+        expect(fetchStoredClearValue).not.toHaveBeenCalled();
+
+        await userEvent.click(screen.getByTestId('api_key-reveal-toggle'));
+        expect(textBox).toHaveAttribute('type', 'password');
+    });
+
+    it('should fetch and show the stored value in edit mode', async () => {
+        const fetchStoredClearValue = vi.fn().mockResolvedValue('stored-secret');
+        renderRevealComponent({ fetchStoredClearValue });
+
+        const textBox = screen.getByTestId('textbox');
+        expect(textBox).toHaveValue(PLACEHOLDER);
+        expect(textBox).toHaveAttribute('type', 'password');
+
+        await userEvent.click(screen.getByTestId('api_key-reveal-toggle'));
+
+        expect(fetchStoredClearValue).toHaveBeenCalledWith('api_key');
+        expect(await screen.findByDisplayValue('stored-secret')).toBeInTheDocument();
+        expect(textBox).toHaveAttribute('type', 'text');
+        // revealing must not mark the field as changed
+        expect(handleChange).not.toHaveBeenCalled();
+
+        await userEvent.click(screen.getByTestId('api_key-reveal-toggle'));
+        expect(textBox).toHaveAttribute('type', 'password');
+        expect(textBox).toHaveValue(PLACEHOLDER);
+    });
+
+    it('should show an error when the fetch is rejected', async () => {
+        const fetchStoredClearValue = vi
+            .fn()
+            .mockRejectedValue(new Error('You do not have permission to view this value.'));
+        renderRevealComponent({ fetchStoredClearValue });
+
+        await userEvent.click(screen.getByTestId('api_key-reveal-toggle'));
+
+        expect(await screen.findByTestId('api_key-reveal-error')).toBeInTheDocument();
+        const textBox = screen.getByTestId('textbox');
+        expect(textBox).toHaveAttribute('type', 'password');
+        expect(textBox).toHaveValue(PLACEHOLDER);
+    });
+
+    it('should show a hint when there is no stored value', async () => {
+        const fetchStoredClearValue = vi.fn().mockResolvedValue(null);
+        renderRevealComponent({ fetchStoredClearValue });
+
+        await userEvent.click(screen.getByTestId('api_key-reveal-toggle'));
+
+        expect(await screen.findByTestId('api_key-reveal-error')).toHaveTextContent(
+            'There is no stored value to show.'
+        );
+        expect(screen.getByTestId('textbox')).toHaveAttribute('type', 'password');
+    });
 });

--- a/ui/src/components/TextComponent/TextComponent.tsx
+++ b/ui/src/components/TextComponent/TextComponent.tsx
@@ -1,7 +1,37 @@
 import React, { Component } from 'react';
 import Text from '@splunk/react-ui/Text';
+import Button from '@splunk/react-ui/Button';
+import Tooltip from '@splunk/react-ui/Tooltip';
+import WaitSpinner from '@splunk/react-ui/WaitSpinner';
+import Eye from '@splunk/react-icons/Eye';
+import EyeSlashed from '@splunk/react-icons/EyeSlashed';
+import { _ } from '@splunk/ui-utils/i18n';
+import styled from 'styled-components';
+import { variables } from '@splunk/themes';
 
 import { excludeControlWrapperProps } from '../ControlWrapper/utils';
+import { ENCRYPTED_FIELD_PLACEHOLDER } from '../../constants/encryptedField';
+import { MODE_CONFIG, MODE_EDIT, Mode } from '../../constants/modes';
+import { parseErrorMsg } from '../../util/messageUtil';
+
+const RevealGroup = styled.div`
+    flex-grow: 1;
+`;
+
+const RevealRow = styled.div`
+    display: flex;
+    align-items: center;
+    gap: ${variables.spacingSmall};
+
+    > *:first-child {
+        flex-grow: 1;
+    }
+`;
+
+const RevealError = styled.div`
+    color: #d93f3c;
+    margin-top: 4px;
+`;
 
 export interface TextComponentProps {
     // Number is expected if provided number in globalConfig.json instead of a string.
@@ -12,17 +42,43 @@ export interface TextComponentProps {
     encrypted?: boolean;
     disabled?: boolean;
     id?: string;
+    mode?: Mode;
+    controlOptions?: {
+        enablePasswordReveal?: boolean;
+    };
+    /**
+     * Provided by BaseFormView via ControlWrapper. Resolves the decrypted
+     * value of this entity's encrypted field, or null when nothing is stored.
+     */
+    fetchStoredClearValue?: (field: string) => Promise<string | null>;
 }
 
-class TextComponent extends Component<TextComponentProps> {
+interface TextComponentState {
+    revealed: boolean;
+    revealPending: boolean;
+    revealError: string | null;
+    storedClearValue: string | null;
+}
+
+class TextComponent extends Component<TextComponentProps, TextComponentState> {
     private wasMasked: boolean = false;
+
+    constructor(props: TextComponentProps) {
+        super(props);
+        this.state = {
+            revealed: false,
+            revealPending: false,
+            revealError: null,
+            storedClearValue: null,
+        };
+    }
 
     handleChange = (e: unknown, { value }: { value: string | number }) => {
         this.props.handleChange(this.props.field, value);
     };
 
     handleFocus = (e: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-        if (this.props.encrypted && e.target.value === '******') {
+        if (this.props.encrypted && e.target.value === ENCRYPTED_FIELD_PLACEHOLDER) {
             this.wasMasked = true;
             this.props.handleChange(this.props.field, '');
         }
@@ -30,26 +86,113 @@ class TextComponent extends Component<TextComponentProps> {
 
     handleBlur = (e: React.FocusEvent<HTMLInputElement | HTMLTextAreaElement>) => {
         if (this.props.encrypted && e.target.value === '' && this.wasMasked) {
-            this.props.handleChange(this.props.field, '******');
+            this.props.handleChange(this.props.field, ENCRYPTED_FIELD_PLACEHOLDER);
             this.wasMasked = false;
         }
     };
 
+    handleRevealToggle = () => {
+        if (this.state.revealed) {
+            this.setState({ revealed: false, revealError: null });
+            return;
+        }
+        const { mode, field, fetchStoredClearValue } = this.props;
+        if (
+            this.state.storedClearValue === null &&
+            typeof fetchStoredClearValue === 'function' &&
+            this.getStringValue() === ENCRYPTED_FIELD_PLACEHOLDER &&
+            (mode === MODE_EDIT || mode === MODE_CONFIG)
+        ) {
+            // The field still holds the placeholder, so the real value has to
+            // be fetched from the endpoint. splunkd enforces the caller's own
+            // permissions on that request.
+            this.setState({ revealPending: true, revealError: null });
+            fetchStoredClearValue(field)
+                .then((storedClearValue) => {
+                    if (storedClearValue === null) {
+                        this.setState({
+                            revealPending: false,
+                            revealError: _('There is no stored value to show.'),
+                        });
+                        return;
+                    }
+                    this.setState({
+                        revealed: true,
+                        revealPending: false,
+                        storedClearValue,
+                    });
+                })
+                .catch((error) => {
+                    this.setState({
+                        revealPending: false,
+                        revealError: parseErrorMsg(error),
+                    });
+                });
+            return;
+        }
+        this.setState({ revealed: true, revealError: null });
+    };
+
+    getStringValue = () => {
+        const { value } = this.props;
+        return value === null || typeof value === 'undefined' ? '' : value.toString();
+    };
+
     render() {
-        const { id, field, disabled, value, encrypted, ...restProps } = this.props;
+        const { id, field, disabled, value, encrypted, controlOptions, ...restProps } = this.props;
         const restSuiProps = excludeControlWrapperProps(restProps);
-        return (
+        const { revealed, revealPending, revealError, storedClearValue } = this.state;
+        const revealEnabled = Boolean(encrypted && controlOptions?.enablePasswordReveal);
+        const stringValue = value === null || typeof value === 'undefined' ? '' : value.toString();
+        const showStoredValue =
+            revealed && stringValue === ENCRYPTED_FIELD_PLACEHOLDER && storedClearValue !== null;
+
+        const textInput = (
             <Text
                 {...restSuiProps}
                 inputId={id}
                 className={field}
                 disabled={disabled && 'dimmed'}
-                value={value === null || typeof value === 'undefined' ? '' : value.toString()}
+                value={showStoredValue ? storedClearValue : stringValue}
                 onChange={this.handleChange}
                 onFocus={this.handleFocus}
                 onBlur={this.handleBlur}
-                type={encrypted ? 'password' : 'text'}
+                type={encrypted && !revealed ? 'password' : 'text'}
             />
+        );
+
+        if (!revealEnabled) {
+            return textInput;
+        }
+
+        let toggleIcon = <Eye />;
+        if (revealPending) {
+            toggleIcon = <WaitSpinner />;
+        } else if (revealed) {
+            toggleIcon = <EyeSlashed />;
+        }
+        const toggleLabel = revealed ? _('Hide value') : _('Show value');
+        return (
+            <RevealGroup>
+                <RevealRow>
+                    {textInput}
+                    <Tooltip content={toggleLabel}>
+                        <Button
+                            appearance="secondary"
+                            icon={toggleIcon}
+                            aria-label={toggleLabel}
+                            data-test={`${field}-reveal-toggle`}
+                            onClick={this.handleRevealToggle}
+                            disabled={Boolean(disabled) || revealPending}
+                        />
+                    </Tooltip>
+                </RevealRow>
+                {revealError ? (
+                    <RevealError role="alert" data-test={`${field}-reveal-error`}>
+                        {revealError}
+                    </RevealError>
+                ) : null}
+            </RevealGroup>
         );
     }
 }

--- a/ui/src/components/TextComponent/stories/TextComponent.stories.tsx
+++ b/ui/src/components/TextComponent/stories/TextComponent.stories.tsx
@@ -51,3 +51,19 @@ export const AllPropsTrue: Story = {
         disabled: true,
     },
 };
+
+export const EncryptedWithReveal: Story = {
+    args: {
+        handleChange: fn(),
+        value: '******',
+        field: 'api_key',
+        error: false,
+        encrypted: true,
+        disabled: false,
+        mode: 'edit',
+        controlOptions: {
+            enablePasswordReveal: true,
+        },
+        fetchStoredClearValue: () => Promise.resolve('stored-secret-value'),
+    },
+};

--- a/ui/src/constants/encryptedField.ts
+++ b/ui/src/constants/encryptedField.ts
@@ -1,0 +1,7 @@
+/**
+ * Placeholder that splunktaucclib's REST handler writes to .conf files in place
+ * of encrypted values (RestCredentials.PASSWORD). The real value is stored in
+ * passwords.conf and can be retrieved through the add-on endpoint with the
+ * `--cred--=1` query parameter by users whose role allows it.
+ */
+export const ENCRYPTED_FIELD_PLACEHOLDER = '******';

--- a/ui/src/types/globalConfig/entities.ts
+++ b/ui/src/types/globalConfig/entities.ts
@@ -61,7 +61,11 @@ export const TextEntitySchema = CommonEditableEntityFields.extend({
     type: z.literal('text'),
     validators: AllValidators.optional(),
     defaultValue: DefaultValueUnion.optional(),
-    options: CommonEditableEntityOptions.optional(),
+    options: CommonEditableEntityOptions.extend({
+        enablePasswordReveal: z.boolean().default(false).optional(),
+    })
+        .strict()
+        .optional(),
     modifyFieldsOnValue: ModifyFieldsOnValue,
 }).strict();
 


### PR DESCRIPTION
**Issue number:**

### PR Type

**What kind of change does this PR introduce?**
* [x] Feature
* [ ] Bug Fix
* [ ] Refactoring (no functional or API changes)
* [ ] Documentation Update
* [ ] Maintenance (dependency updates, CI, etc.)

## Summary

### Changes

Adds an opt-in `enablePasswordReveal` option for `type: text` entities that have `encrypted: true`, giving the field a show/hide (eye) button.

```json
{
    "type": "text",
    "label": "API key",
    "field": "api_key",
    "encrypted": true,
    "options": {
        "enablePasswordReveal": true
    }
}
```

The option defaults to `false`, so behaviour for every existing add-on is unchanged.

**No backend changes.** The decrypt path already exists in `splunktaucclib`: `AdminExternalHandler` registers `--cred--` as an optional argument for `ACTION_LIST` and passes `decrypt=True` through to `RestCredentials`, using the caller's own session key. This PR only teaches the UI to use it. No new endpoint, no `restmap.conf` change, no change to the generated add-on output.

Schema and contract:

* `splunk_add_on_ucc_framework/schema/schema.json` - new `enablePasswordReveal` boolean definition, referenced from the text entity's `options`
* `ui/src/types/globalConfig/entities.ts` - extends `TextEntitySchema.options`, kept `.strict()`
* `docs/entity/components.md` - new Options table and example for the Text component

Plumbing, to pass a decrypted-value fetcher from the form down to the field:

* `ui/src/components/BaseFormView/BaseFormView.tsx` - new `fetchStoredClearValue()`, a GET against the single-entity endpoint with `--cred--=1`, returning `null` when there is nothing stored. Wired into both `ControlWrapper` render sites
* `ui/src/components/ControlWrapper/ControlWrapper.tsx` - forwards the new prop into the control
* `ui/src/components/ControlWrapper/utils.ts` - adds it to the exclusion list so it is not spread onto the react-ui DOM node

The field itself:

* `ui/src/components/TextComponent/TextComponent.tsx` - now stateful. Eye / eye-slashed toggle with a spinner while fetching and an inline error on failure. In create mode the toggle simply flips the input between `password` and `text`. In edit and config mode, when the value is still the `******` placeholder, it fetches the stored value and renders it **without** calling `handleChange`, so the field is never marked dirty and a subsequent save still round-trips the placeholder rather than clobbering the stored secret
* `ui/src/constants/encryptedField.ts` - new `ENCRYPTED_FIELD_PLACEHOLDER` constant, replacing the `'******'` string literals that were previously scattered across `BaseFormView` and `TextComponent`

Security posture: revealing is gated by the endpoint's existing generated capability requirements plus the `passwords.conf` ACL, and splunkd enforces them on the caller. A role that cannot read the stored credential gets an error rather than the value.

### User experience

**Before:** an encrypted field is a permanent password input. Once saved it shows `******` and there is no way to confirm what was stored. Users who need to verify a key against another system have to overwrite it with a value they already know, or check the value outside Splunk. Focusing the field clears it, so a mistaken save can replace a working credential with a blank or a typo.

**After (opt-in only):** an eye button sits next to the field.

* While creating an entity, the toggle shows or hides what the user has typed, so they can check a long key before saving.
* While editing an entity, pressing the eye fetches the stored value and displays it in place. A spinner shows during the fetch. Pressing it again re-masks the field.
* The field stays clean throughout, so saving without editing still writes back the placeholder and the stored secret is untouched.
* If the caller's role cannot read the credential, or nothing is stored, an inline message appears under the field instead of a value.

<img width="792" height="350" alt="image" src="https://github.com/user-attachments/assets/07fd88a0-ab1b-44fc-bb07-8ec4d3ac3d66" />
<img width="766" height="339" alt="image" src="https://github.com/user-attachments/assets/cd50eba0-242a-4e02-89fd-e10423e84474" />


### Notes for reviewers

Deliberately left out of scope, flagging in case you want any of it before merge:

1. **No deployment-level kill switch.** Enabling is entirely the add-on author's decision via globalConfig. There is no way for a Splunk admin to disable reveal across an add-on they have installed. If UCC wants that, the natural place is a `meta` level flag or a dedicated capability check, and it would be better designed now than retrofitted.
2. **`--cred--=1` decrypts the whole stanza,** not a single field. Revealing one secret therefore brings every secret on that entity into the browser. Narrowing that would need a `splunktaucclib` change.
3. **No explicit audit event.** The request appears in splunkd access logs, but there is no "user X revealed credential Y" record.
4. **Scope is `type: text` only.** Not textarea, not the OAuth tab fields, not table expansion rows.

## Checklist

If an item doesn't apply to your changes, leave it unchecked.

### Review

* [x] self-review - I have performed a self-review of this change according to the [development guidelines](https://splunk.github.io/addonfactory-ucc-generator/contributing/#development-guidelines)
* [x] Changes are documented. The documentation is understandable, examples work [(more info)](https://splunk.github.io/addonfactory-ucc-generator/contributing/#documentation-guidelines)
* [x] PR title and description follows the [contributing principles](https://splunk.github.io/addonfactory-ucc-generator/contributing/#pull-requests)
* [ ] meeting - I have scheduled a meeting or recorded a demo to explain these changes (if there is a video, put a link below and in the ticket)

### Tests

See [the testing doc](https://splunk.github.io/addonfactory-ucc-generator/contributing/#build-and-test).

* [ ] Unit - tests have been added/modified to cover the changes
* [ ] Smoke - tests have been added/modified to cover the changes
* [] UI - tests have been added/modified to cover the changes
* [x] coverage - I have checked the code coverage of my changes [(see more)](https://splunk.github.io/addonfactory-ucc-generator/contributing/#checking-the-code-coverage)

Six cases added to `ui/src/components/TextComponent/TextComponent.test.tsx` under a `password reveal` describe block, covering: no toggle without the option, no toggle on non-encrypted fields, toggling a typed value without any fetch, fetching and showing the stored value in edit mode, the error path when the fetch is rejected, and the hint shown when nothing is stored. An `EncryptedWithReveal` story was added to `TextComponent.stories.tsx`.

No Python unit or smoke tests were added: the schema addition is optional and additive, and the generated add-on output is unchanged. Happy to add the option to the `package_global_config_everything` test add-on and regenerate the expected output if you would prefer the schema path covered there.

**Demo/meeting:**
Happy to demo this
*Reviewers are encouraged to request meetings or demos if any part of the change is unclear*
