### PR TITLE
fix: upgrade react-router-dom to v7.18.0 (CVE-2026-53666, CVE-2026-53669)

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -58,7 +58,7 @@
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-is": "^16.13.1",
-    "react-router-dom": "6.30.5",
+    "react-router-dom": "7.18.0",
     "styled-components": "^5.3.11",
     "uuid": "^14.0.0",
     "vite": "^7.3.1",

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -2321,11 +2321,6 @@
     redux-thunk "^2.4.2"
     reselect "^4.1.8"
 
-"@remix-run/router@1.23.3":
-  version "1.23.3"
-  resolved "https://registry.npmjs.org/@remix-run/router/-/router-1.23.3.tgz#957c098d4393d301a8aa7dccf3ef28ea5430e36a"
-  integrity sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==
-
 "@rolldown/pluginutils@1.0.0-beta.27":
   version "1.0.0-beta.27"
   resolved "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz#47d2bf4cef6d470b22f5831b420f8964e0bf755f"
@@ -5404,7 +5399,7 @@ cookie-storage@^5.0.3:
   resolved "https://registry.npmjs.org/cookie-storage/-/cookie-storage-5.0.3.tgz#f599063ede0ee51ec87e0d91153d202954f4eb89"
   integrity sha512-QJ51JmyfLuOzFAems6GTB6NvFu5GCmjXqfQfguC6+6ii0R+PAmMaNJmIjllCLEo3nHwM7q1gYYZSGPGt5s+gHg==
 
-cookie@^1.0.2:
+cookie@^1.0.1, cookie@^1.0.2:
   version "1.1.1"
   resolved "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz#3bb9bdfc82369db9c2f69c93c9c3ceb310c88b3c"
   integrity sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==
@@ -10673,20 +10668,20 @@ react-resize-detector@^12.3.0:
   dependencies:
     es-toolkit "^1.39.6"
 
-react-router-dom@6.30.5:
-  version "6.30.5"
-  resolved "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.5.tgz#394a991230860f8eba36451f15efc9a38328cb79"
-  integrity sha512-Howo+e5+VnIBTSLNlD/ld92CBekQffjXa2zPQH2mghkghR3JptAeO/m+xXcwACml0+XuKw3ezscmCH4jdkPMoA==
+react-router-dom@7.18.0:
+  version "7.18.0"
+  resolved "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.0.tgz#71a657374610e00cebf2783804d7812facfdb1b5"
+  integrity sha512-Fi0yY6kgtKae/Th2xibdWK0KSdYZ4B53Gyf6wRtomOKWgpNm7H7+DyfDhncdz9FKbpS+1jmDhg3F4WoGJ+yFOA==
   dependencies:
-    "@remix-run/router" "1.23.3"
-    react-router "6.30.5"
+    react-router "7.18.0"
 
-react-router@6.30.5:
-  version "6.30.5"
-  resolved "https://registry.npmjs.org/react-router/-/react-router-6.30.5.tgz#5c55bef1bfbcf011eaa6c7074ddf1b775ef2b088"
-  integrity sha512-MyMPiI3vOGXnQhlPZ/am6V3+9doI1jzcAw/3Ufrzav9/x5DnM2KykOPzKtKLHaLYPG4o+orFIgjxKqM6DBnjcw==
+react-router@7.18.0:
+  version "7.18.0"
+  resolved "https://registry.npmjs.org/react-router/-/react-router-7.18.0.tgz#e7d94b54745277aabe3cf93fac938cbebc9c1c5e"
+  integrity sha512-pTTGt8J+ji1NOmYnjzT+bAJy/1zD+Jp4ziO6cL7T3ZLvXKtusO7BpFqlRXitqpcPVqllsIXFHRMt+2/k3Xn6HQ==
   dependencies:
-    "@remix-run/router" "1.23.3"
+    cookie "^1.0.1"
+    set-cookie-parser "^2.6.0"
 
 react@18.3.1:
   version "18.3.1"
@@ -11189,7 +11184,7 @@ set-blocking@^2.0.0:
   resolved "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==
 
-set-cookie-parser@^2.4.1:
+set-cookie-parser@^2.4.1, set-cookie-parser@^2.6.0:
   version "2.7.2"
   resolved "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz#ccd08673a9ae5d2e44ea2a2de25089e67c7edf68"
   integrity sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==


### PR DESCRIPTION
## Summary

Upgrades `react-router-dom` 6.30.5 → 7.18.0, which transitively updates `react-router` to 7.18.0 and resolves both remaining medium CVEs.

| CVE | Package | Fixed in |
|-----|---------|----------|
| CVE-2026-53666 | react-router@6.30.5 | 7.18.0 ✅ |
| CVE-2026-53669 | react-router@6.30.5 | 7.18.0 ✅ |

## Why no code changes are needed

UCC only uses react-router's stable library-mode APIs — all identical between v6 and v7:

| API | Used in |
|-----|---------|
| `BrowserRouter` | 11 test/page files |
| `useNavigate` | `InputPage.tsx` |
| `useLocation` | `InputPage.tsx`, `useQuery.ts` |
| `useSearchParams` | `CustomTable.tsx` |

No data-router APIs (loaders, actions, `createBrowserRouter`) are used, so none of the v7 framework-mode breaking changes apply.

## Test plan

- [x] `yarn install` — clean, no conflicts (React >=18 and Node >=20 peer deps both satisfied)
- [x] `yarn test` — 487/487 tests pass, 54/54 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)